### PR TITLE
Update Formatting and Fix Oxygen Errors

### DIFF
--- a/1905-10-02.xml
+++ b/1905-10-02.xml
@@ -36,18 +36,12 @@
                     <div type="item" scope="advertisement" xml:id="deg-ad-pos01">
                         <head>Peninsular and Oriental S. N. Company.</head>
                         <p>Summer Rates will be charged from 2 May to 31 October. </p>
-                        <p>For the convenience of families and others, a large portion of each ship’s
-                            accommodation has been reserved for <placeName ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName>, so that Berths can be definitely
-                            engaged at once, as if the voyage were commencing at <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>. Plans can be
-                            seen at the Offices of the Company’s Agents. </p>
-                        <p>The through Steamers for <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName> and <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> are intended to leave <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>
-                            after the arrival of the 11 a.m. train from <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> , every Tuesday for the present
-                            except the MONGOLIA, which is taking passengers to the Anglo-French Naval
-                            Review, and will not wait at <placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName>  on 24/25 July. A steam tender will meet
-                            the train to convey passengers to the ship. </p>
+                        <p>For the convenience of families and others, a large portion of each ship’s accommodation has been reserved for <placeName ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName>, so that Berths can be definitely engaged at once, as if the voyage were commencing at <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>. Plans can be seen at the Offices of the Company’s Agents. </p>
+                        <p>The through Steamers for <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName> and <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> are intended to leave <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> after the arrival of the 11 a.m. train from <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> , every Tuesday for the present except the MONGOLIA, which is taking passengers to the Anglo-French Naval Review, and will not wait at <placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName> on 24/25 July. A steam tender will meet the train to convey passengers to the ship. </p>
                         <table>
                             <row>
-                                <cell><placeName ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName> </cell>
+                                <cell><placeName ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName>
+                                </cell>
                                 <cell>4 July</cell>
                                 <cell>Arcadia </cell>
                                 <cell>1 August</cell>
@@ -67,7 +61,8 @@
                                 <cell>18 July</cell>
                                 <cell>Arabia </cell>
                                 <cell>15 August</cell>
-                                <cell><placeName ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName> </cell>
+                                <cell><placeName ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName>
+                                </cell>
                                 <cell>12 Sept.</cell>
                             </row>
                             <row>
@@ -79,27 +74,27 @@
                                 <cell>19 Sept.</cell>
                             </row>
                         </table>
-                        <p>The Brindisi Express Steamers leave <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> directly the Indian Mails arrive.
-                            Passengers can go on board the evening before. The Fare remains as usual. </p>
+                        <p>The Brindisi Express Steamers leave <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> directly the Indian Mails arrive. Passengers can go on board the evening before. The Fare remains as usual. </p>
                         <p>For all further information apply to the Company's Agents, </p>
                         <p>Messrs. THOS. COOK &amp; SON (<placeName ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName>) Ltd. <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> . </p>
                         <p>GEORGE ROYLE, Esq. <placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName> . </p>
                         <p>Messrs. HABELDEN &amp; Co. <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>. </p>
-                        <p> F. G. DAVIDSON, Superintendent P. &amp; O. S. N. Company in <placeName ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName> <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>. </p>
+                        <p> F. G. DAVIDSON, Superintendent P. &amp; O. S. N. Company in <placeName ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName>
+                            <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>. </p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-opl01">
                         <head>Orient-Pacific Line of Royal Mail Steamers.</head>
                         <p>REDUCED SUMMER FARES FROM MAY TO OCTOBER INCLUSIVE.</p>
                         <p>OUTWARDS to <placeName ref="https://www.wikidata.org/wiki/Q408">Australia</placeName>.</p>
-                        <p>R.M.S. “Orotava" will leave <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName> about July 28 | R.M.S "Ormuz" will leave <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>
-                            about August 11. </p>
-                        <p>HOMEWARDS to <placeName ref="https://www.wikidata.org/wiki/Q2634">Naples</placeName>  <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName>, GIBRALTAR, PLYMOUTH, <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName>, TILBURY</p>
-                        <p>R.M.S. "Oroya" will leave <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> about July 18 | R.M.S. “Ortona" will leave
-                            <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> about August 1</p>
+                        <p>R.M.S. “Orotava" will leave <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName> about July 28 | R.M.S "Ormuz" will leave <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName> about August 11. </p>
+                        <p>HOMEWARDS to <placeName ref="https://www.wikidata.org/wiki/Q2634">Naples</placeName>
+                            <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName>, GIBRALTAR, PLYMOUTH, <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName>, TILBURY</p>
+                        <p>R.M.S. "Oroya" will leave <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> about July 18 | R.M.S. “Ortona" will leave <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> about August 1</p>
                         <table>
                             <row>
                                 <cell rows="4">Reduced Summer Fares</cell>
-                                <cell><placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName>  to <placeName ref="https://www.wikidata.org/wiki/Q2634">Naples</placeName> </cell>
+                                <cell><placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName> to <placeName ref="https://www.wikidata.org/wiki/Q2634">Naples</placeName>
+                                </cell>
                                 <cell>1st Class</cell>
                                 <cell>£ 11</cell>
                                 <cell>2nd Class</cell>
@@ -108,7 +103,7 @@
                                 <cell>£ 4.8</cell>
                             </row>
                             <row>
-                                <cell><placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName>  to <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName></cell>
+                                <cell><placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName> to <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName></cell>
                                 <cell>1st Class</cell>
                                 <cell>£ 12.12</cell>
                                 <cell>2nd Class</cell>
@@ -117,7 +112,7 @@
                                 <cell>£ 5.10</cell>
                             </row>
                             <row>
-                                <cell><placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName>  to Gibraltar</cell>
+                                <cell><placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName> to Gibraltar</cell>
                                 <cell>1st Class</cell>
                                 <cell>£ 18.0</cell>
                                 <cell>2nd Class</cell>
@@ -126,7 +121,7 @@
                                 <cell>£ 5.10</cell>
                             </row>
                             <row>
-                                <cell><placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName>  to Plymouth or Tilbury</cell>
+                                <cell><placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName> to Plymouth or Tilbury</cell>
                                 <cell>1st Class</cell>
                                 <cell>£ 16.16</cell>
                                 <cell>2nd Class</cell>
@@ -136,13 +131,9 @@
                             </row>
                         </table>
                         <p>Egyptian Government Officials allowed a rebate of 15% off the above fares.</p>
-                        <p>Return tickets no longer issued, but passengers paying full fare in one direction
-                            allowed abatement of 1/3 fare back if return voyage be within 4 months of
-                            arrival, or abatement of 20 o/o if return voyage be made within 8 months of
-                            arrival.</p>
-                        <p>Agents. <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> :—Thos. Cook &amp; Son. <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> : —R. J. Moss &amp; Co.—For all
-                            information apply </p>
-                        <p>Wm. STAPLEDON &amp; Sons, <placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName>  &amp; PORT-TEWFIK (<placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>) 31-12-904</p>
+                        <p>Return tickets no longer issued, but passengers paying full fare in one direction allowed abatement of 1/3 fare back if return voyage be within 4 months of arrival, or abatement of 20 o/o if return voyage be made within 8 months of arrival.</p>
+                        <p>Agents. <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> :—Thos. Cook &amp; Son. <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> : —R. J. Moss &amp; Co.—For all information apply </p>
+                        <p>Wm. STAPLEDON &amp; Sons, <placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName> &amp; PORT-TEWFIK (<placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>) 31-12-904</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-blm01">
                         <head>BIBBY LINE MAIL STEAMERS.</head>
@@ -153,37 +144,28 @@
                         <p>HOMEWARDS to <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName> and <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName>. Departures from <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>.</p>
                         <p>S.S. Worcestershire 7,160 tons, leaves about July 26.</p>
                         <p>S.S. Yorkshire 4,196 tons leaves about August 9,</p>
-                        <p>FARES from <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> to <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName> £12.0.0, <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> £17.0.0, Colombo £32.10.0,
-                            Rangoon £37.10.0. </p>
-                        <p>Agents <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> : THOS. COOK &amp; SON. <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName> &amp; <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> : WM. STAPLEDON &amp; SONS,
-                            31-12-905</p>
+                        <p>FARES from <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> to <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName> £12.0.0, <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> £17.0.0, Colombo £32.10.0, Rangoon £37.10.0. </p>
+                        <p>Agents <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> : THOS. COOK &amp; SON. <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName> &amp; <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> : WM. STAPLEDON &amp; SONS, 31-12-905</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-kml01">
                         <head>KHEDIVIAL MAIL LINE.</head>
                         <head type="sub">FAST BRITISH PASSENGER STEAMERS</head>
                         <head type="sub"><placeName ref="https://www.wikidata.org/wiki/Q41">Greece</placeName> - <placeName ref="https://www.wikidata.org/wiki/Q43">Turkey</placeName> LINE.</head>
-                        <p>Express Steamers leave <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> every Wednesday at 4 p.m. for PIRAEUS, SMYRNA,
-                            MITYLENE, and CONSTANTINOPLE, in connection with Orient Express train-de-luxe
-                            for Vienna, <placeName ref="https://www.wikidata.org/wiki/Q90">Paris</placeName>, and <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName>.</p>
-                        <head type="sub">PALESTINE - SYRIA LINE.</head>
-                        <p>Fast steamers leave <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> every Saturday at 6 p.m., and <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> every
-                            Sunday at 6 p.m., for JAFFA (for Jerusalem), CAIFFA (for Nazareth), BEYROUT (for
-                            Damascus), TRIPOLI, ALEXANDRETTA, MESSINA, continuing in alternate weeks to
-                            LARNACA and LIMASSOL (Cyprus).</p>
-                        <head type="sub">RED SEA LINE.</head>
-                        <p>Steamers leave <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName> fortnightly on Wednesday at 6 p.m. for JEDDAH, SUAKIN,
-                            MASSOWAH, HODBIDAH, and ADEN ; and in the intervening weeks for PORT SUDAN and
-                            SUAKIN direct. Calls will be made at TOR (for Mount Sinai) as required.</p>
-                        <p>N.B.—Deck chairs provided for the use of passengers, excellent cuisine and table
-                            wine free.</p>
-                        <p>Steamer plans may be seen and passages booked at the Company’s Agencies at
-                            <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>, <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> , <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>, and <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>, or at THOS. COOK &amp; SON or other
-                            Tourist Agency. 31-12-904</p>
+                        <p>Express Steamers leave <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> every Wednesday at 4 p.m. for PIRAEUS, SMYRNA, MITYLENE, and CONSTANTINOPLE, in connection with Orient Express train-de-luxe for Vienna, <placeName ref="https://www.wikidata.org/wiki/Q90">Paris</placeName>, and <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName>.</p>
+                        <div type="subsection">
+                            <head type="sub">PALESTINE - SYRIA LINE.</head>
+                            <p>Fast steamers leave <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> every Saturday at 6 p.m., and <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> every Sunday at 6 p.m., for JAFFA (for Jerusalem), CAIFFA (for Nazareth), BEYROUT (for Damascus), TRIPOLI, ALEXANDRETTA, MESSINA, continuing in alternate weeks to LARNACA and LIMASSOL (Cyprus).</p>
+                        </div>
+                        <div type="subsection">
+                            <head type="sub">RED SEA LINE.</head>
+                            <p>Steamers leave <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName> fortnightly on Wednesday at 6 p.m. for JEDDAH, SUAKIN, MASSOWAH, HODBIDAH, and ADEN ; and in the intervening weeks for PORT SUDAN and SUAKIN direct. Calls will be made at TOR (for Mount Sinai) as required.</p>
+                            <p>N.B.—Deck chairs provided for the use of passengers, excellent cuisine and table wine free.</p>
+                            <p>Steamer plans may be seen and passages booked at the Company’s Agencies at <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>, <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> , <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>, and <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>, or at THOS. COOK &amp; SON or other Tourist Agency. 31-12-904</p>
+                        </div>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-mss01">
                         <head>The Moss S.S. Company, Ltd.</head>
-                        <p>For <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName> calling at <placeName ref="https://www.wikidata.org/wiki/Q233">Malta</placeName> (Messrs. JAMES MOSS &amp; Co. 31, James St,
-                            <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName>, Managers.)</p>
+                        <p>For <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName> calling at <placeName ref="https://www.wikidata.org/wiki/Q233">Malta</placeName> (Messrs. JAMES MOSS &amp; Co. 31, James St, <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName>, Managers.)</p>
                         <table rows="3" cols="8">
                             <row>
                                 <cell>*Amasis</cell>
@@ -216,18 +198,11 @@
                                 <cell>(Building)</cell>
                             </row>
                         </table>
-                        <p>*Second class accommodation only, unless specially reserved.—Fares : <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>
-                            to <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName>, 1st, £14 Single, £25 Return. 2nd, £9 Single, £15 Return.—To <placeName ref="https://www.wikidata.org/wiki/Q233">Malta</placeName>,
-                            1st, £5 Single, £9 Return, 2nd, £3 Single, £5 Return.—Return tickets available
-                            for six months.</p>
-                        <p>S.S. Seti now on the berth, will sail on or about Monday, July 17, to be followed
-                            by S.S. Menes.</p>
+                        <p>*Second class accommodation only, unless specially reserved.—Fares : <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> to <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName>, 1st, £14 Single, £25 Return. 2nd, £9 Single, £15 Return.—To <placeName ref="https://www.wikidata.org/wiki/Q233">Malta</placeName>, 1st, £5 Single, £9 Return, 2nd, £3 Single, £5 Return.—Return tickets available for six months.</p>
+                        <p>S.S. Seti now on the berth, will sail on or about Monday, July 17, to be followed by S.S. Menes.</p>
                         <p>S.S Tabor for Havre via <placeName ref="https://www.wikidata.org/wiki/Q233">Malta</placeName> to sail about Saturday l5th inst.</p>
-                        <p>Through freight rates on cotton, etc., to Lancashire inland towns, Boston, New
-                            York and other U.S.A. towns, obtained on application. Cargo taken by special
-                            agreement only. </p>
-                        <p>Passenger Tickets also issued inclusive of Railway fare through to and from
-                            <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> . Particulars on application to </p>
+                        <p>Through freight rates on cotton, etc., to Lancashire inland towns, Boston, New York and other U.S.A. towns, obtained on application. Cargo taken by special agreement only. </p>
+                        <p>Passenger Tickets also issued inclusive of Railway fare through to and from <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> . Particulars on application to </p>
                         <p>R. J. MOSS &amp; Co., <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>, Agents. 26-12-905</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-mic01">
@@ -239,11 +214,8 @@
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-tce01">
                         <head>Telephone Company of <placeName ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName>, Limited.</head>
-                        <p><placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> -<placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> TELEPHONE.--Rates as follows P.T. 5 for each 3 minutes, or
-                            fraction of 3 minutes; P.T. 10 for over 3 up to 8 minutes communication.</p>
-                        <p>PUBLIC CALL-OFFICES : <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> , Central Office, Opera Square, and New Bar; Helouan,
-                            Central Office, Maison Purvis ; <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>, St Mark’s Buildings, Egyptian Bar,
-                            I. Castelli &amp; Co.; Ramleh, Central Office. San Stefano Casino 30.4.906</p>
+                        <p><placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> -<placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> TELEPHONE.--Rates as follows P.T. 5 for each 3 minutes, or fraction of 3 minutes; P.T. 10 for over 3 up to 8 minutes communication.</p>
+                        <p>PUBLIC CALL-OFFICES : <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> , Central Office, Opera Square, and New Bar; Helouan, Central Office, Maison Purvis ; <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>, St Mark’s Buildings, Egyptian Bar, I. Castelli &amp; Co.; Ramleh, Central Office. San Stefano Casino 30.4.906</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-phc01">
                         <head>P. HENDERSON &amp; CO’s LINE.</head>
@@ -253,8 +225,7 @@
                         <p>S.S. BURMA 5600 Tons will leave <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> about August 6 for <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName>.</p>
                         <p>S.S. ARRACAN 5800 Tons will leave <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> about 20 for <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName></p>
                         <p>Due in <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> or <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName> 12 days thereafter.</p>
-                        <p>Apply WORMS &amp; Co., <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> and <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>. THOS. COOK &amp; SON, (<placeName ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName>) LD.,
-                            <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>  ;</p>
+                        <p>Apply WORMS &amp; Co., <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> and <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>. THOS. COOK &amp; SON, (<placeName ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName>) LD., <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> ;</p>
                         <p>G. J. GRACE &amp; CO., <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>.</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-tcs01">
@@ -264,21 +235,11 @@
                         <p><placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>, <placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName> , <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>, Luxor, Assuan, Haifa, &amp; Khartum.</p>
                         <p>GENERAL RAILWAY AND STEAMSHIP AGENTS. BANKERS.</p>
                         <p>BAGGAGE AND FORWARDING AGENTS.</p>
-                        <p>Officially appointed &amp; Sole Agents in <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>  to the P.&amp;O. S.N. Co.</p>
-                        <p>RESIDENTS IN <placeName ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName> proceeding to Europe for the summer are requested to apply to
-                            our offices for information respecting their Passages, where steamer plans may
-                            be consulted and Berths secured by all Lines of Steamers to all parts of the
-                            Globe; arrangements can also be made for the collection and forwarding of their
-                            baggage and clearance at port of arrival.</p>
-                        <p>CIRCULAR NOTES issued payable at the current rate of exchange in all the
-                            principal cities of Europe. Cook’s Interpreters in uniform are present at the
-                            principal Railway stations and Landing-places in Europe to assist passengers
-                            holding their travelling tickets.</p>
-                        <p>Large and splendidly appointed steamers belonging to the Co. leave <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>  thrice
-                            weekly, between November and March, for Luxor, Assouan and Wady-Halfa in
-                            connection with trains de luxe to Khartoum. Moderate fares. </p>
-                        <p>FREIGHT SERVICE, Steamers leave <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>  every Saturday and Tuesday for Assouan and
-                            Halfa.</p>
+                        <p>Officially appointed &amp; Sole Agents in <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> to the P.&amp;O. S.N. Co.</p>
+                        <p>RESIDENTS IN <placeName ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName> proceeding to Europe for the summer are requested to apply to our offices for information respecting their Passages, where steamer plans may be consulted and Berths secured by all Lines of Steamers to all parts of the Globe; arrangements can also be made for the collection and forwarding of their baggage and clearance at port of arrival.</p>
+                        <p>CIRCULAR NOTES issued payable at the current rate of exchange in all the principal cities of Europe. Cook’s Interpreters in uniform are present at the principal Railway stations and Landing-places in Europe to assist passengers holding their travelling tickets.</p>
+                        <p>Large and splendidly appointed steamers belonging to the Co. leave <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> thrice weekly, between November and March, for Luxor, Assouan and Wady-Halfa in connection with trains de luxe to Khartoum. Moderate fares. </p>
+                        <p>FREIGHT SERVICE, Steamers leave <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> every Saturday and Tuesday for Assouan and Halfa.</p>
                         <p>Special Steamers and Dahabeahs for private parties.</p>
                         <p>Special arrangements for tour in PALESTINE, SYRIA and the DESERT, Lowest Rates.</p>
                         <p>Best camp equipment in the country! 10 12-904 </p>
@@ -288,10 +249,8 @@
                         <head>British India S. N. Company, Limited.</head>
                         <p>MAIL AND PASSENGER STEAM SHIPS.</p>
                         <p>SAILINGS FROM <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>, <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> and CALCUTTA LINE.</p>
-                        <p>Calling at ADEN, COLOMBO and MADRAS Outward, and <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName> (GENOA and PLYMOUTH
-                            optional) Homeward. </p>
-                        <p>Fortnightly Service in connection with the Co's Indian Mail Lines and monthly
-                            with the East African Mail Line between ADEN, MOMBASSA and Zanzibar. </p>
+                        <p>Calling at ADEN, COLOMBO and MADRAS Outward, and <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName> (GENOA and PLYMOUTH optional) Homeward. </p>
+                        <p>Fortnightly Service in connection with the Co's Indian Mail Lines and monthly with the East African Mail Line between ADEN, MOMBASSA and Zanzibar. </p>
                         <p>OUTWARD.—S.S. Fazilka ... July 22 | HOMEWARD.—S.S. Mombassa ... July 21 </p>
                         <p>Queensland Line of Steamers Between <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> and Brisbane.</p>
                         <p>Calling at Colombo, Batavia, Cooktown, Townsville, and Rockhamptom.</p>
@@ -320,16 +279,11 @@
                                 <cell>£19. 0</cell>
                             </row>
                         </table>
-                        <p>From <placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName>  £2 less Homeward, and £2 more Outward. Second class, two thirds of
-                            1st Class Fares.</p>
-                        <p>Agents at <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>, for the <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName>, Calcutta and Persian Gulf Lines, Messrs.
-                            Worms &amp; Co.</p>
-                        <p>Agents at <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>, for the <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> and Queensland Line, Messrs. Wills &amp; Co.,
-                            Limited.</p>
-                        <p>Messrs. Thos. Cook &amp; Son and the Anglo-American Hotel &amp; Steamer Company,
-                            <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>  &amp; <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>.</p>
-                        <p>For further particulars. Freight and Passage apply to G. BEYTS &amp; Co. Agents,
-                            <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>. 31-12-905</p>
+                        <p>From <placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName> £2 less Homeward, and £2 more Outward. Second class, two thirds of 1st Class Fares.</p>
+                        <p>Agents at <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>, for the <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName>, Calcutta and Persian Gulf Lines, Messrs. Worms &amp; Co.</p>
+                        <p>Agents at <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>, for the <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> and Queensland Line, Messrs. Wills &amp; Co., Limited.</p>
+                        <p>Messrs. Thos. Cook &amp; Son and the Anglo-American Hotel &amp; Steamer Company, <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> &amp; <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>.</p>
+                        <p>For further particulars. Freight and Passage apply to G. BEYTS &amp; Co. Agents, <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>. 31-12-905</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-all01">
                         <head>ANCHOR LINE, LIMITED.</head>
@@ -354,23 +308,14 @@
                                 <cell>July 23</cell>
                             </row>
                         </table>
-                        <p>Saloon Fares: from <placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName> , to Gibraltar £9; <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName> £9: <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName> (all sea
-                            route) £15; <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> (all sea route) £ 12 <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> via <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName> £15.5.0.
-                            Passengers embarking at <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName> £2 more, 10 % reduction for officers of army of
-                            Occupation and Government employés. Through tickets issued to New-York (via
-                            Glasgow). Fares on application. </p>
-                        <p> Agents in <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> , Messrs. Thos. Cook &amp; Son. <placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName> , Messrs. Cory Brothers
-                            &amp; Co., Ltd.</p>
-                        <p>For further partienlan of Freight or Passage apply to G. BEYTS &amp; Co., <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>.
-                            31-12-905</p>
+                        <p>Saloon Fares: from <placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName> , to Gibraltar £9; <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName> £9: <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName> (all sea route) £15; <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> (all sea route) £ 12 <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> via <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName> £15.5.0. Passengers embarking at <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName> £2 more, 10 % reduction for officers of army of Occupation and Government employés. Through tickets issued to New-York (via Glasgow). Fares on application. </p>
+                        <p> Agents in <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> , Messrs. Thos. Cook &amp; Son. <placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName> , Messrs. Cory Brothers &amp; Co., Ltd.</p>
+                        <p>For further partienlan of Freight or Passage apply to G. BEYTS &amp; Co., <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>. 31-12-905</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-dll01">
                         <head>Deutsche Levante-Linie.</head>
-                        <p>Mail and Passenger Steamships. Regular three-weekly Service from <lb/> HAMBURG,
-                            via ANTWERP &amp; <placeName ref="https://www.wikidata.org/wiki/Q233">Malta</placeName>, to <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> and vice-versa, admitting<lb/> goods from
-                            all chief German Railway Stations on direct Bill of Landing to<lb/> <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>
-                            and all chief ports of <placeName ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName>, Syria, etc., at favourable through<lb/> rates of
-                            DEUTSCHE <lb/> VERKEHR (traffic).</p>
+                        <p>Mail and Passenger Steamships. Regular three-weekly Service from <lb/> HAMBURG, via ANTWERP &amp; <placeName ref="https://www.wikidata.org/wiki/Q233">Malta</placeName>, to <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> and vice-versa, admitting<lb/> goods from all chief German Railway Stations on direct Bill of Landing to<lb/>
+                            <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> and all chief ports of <placeName ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName>, Syria, etc., at favourable through<lb/> rates of DEUTSCHE <lb/> VERKEHR (traffic).</p>
                         <p>EXPECTED AT <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>.</p>
                         <p>S.S. Lesbos July 20 from Antwerp.</p>
                         <p>S.S. Androos July 20 from Hamburg bound for Beyrout.</p>
@@ -380,24 +325,19 @@
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-doa01">
                         <head>Deutsche Ost-Afrika Linie.</head>
-                        <p>GERMAN EAST-AFRICAN LINE - REGULAR MAIL-SERVICE FROM <placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName> </p>
+                        <p>GERMAN EAST-AFRICAN LINE - REGULAR MAIL-SERVICE FROM <placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName>
+                        </p>
                         <p>OUTWARDS. To ADEN, ZANZIBAR, DURBAN, CAPETOWN and intermediate Ports.</p>
                         <p>HOMEWARDS. To <placeName ref="https://www.wikidata.org/wiki/Q2634">Naples</placeName> , GENOA, <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName>, LISBON, ROTTERDAM, HAMBURG.</p>
-                        <p>Splendid accommodation for passengars of all classes.—First-class steamers,
-                            fitted with all recent improvements. stewardesses and doctor carried—Low passage
-                            rates.</p>
+                        <p>Splendid accommodation for passengars of all classes.—First-class steamers, fitted with all recent improvements. stewardesses and doctor carried—Low passage rates.</p>
                         <p>For all particulars, apply to FIX &amp; DAVID, <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> , Sharia Mansour Pacha</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-nkh01">
                         <head>NEW KHEDIVIAL HOTEL, <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>.</head>
-                        <p>First-class Hotel. Situated in Rosetta Avenue, the finest quarter in the Town.
-                            Two mintes from Railway Station. Close to Conservatory and the Opera House.
-                            Lift. Electric Light Throughout. Perfect Sanitary Arragnements. Magnificent
-                            Ball, Reception, Reading, and Music Rooms. Bar and Smoking Room.</p>
+                        <p>First-class Hotel. Situated in Rosetta Avenue, the finest quarter in the Town. Two mintes from Railway Station. Close to Conservatory and the Opera House. Lift. Electric Light Throughout. Perfect Sanitary Arragnements. Magnificent Ball, Reception, Reading, and Music Rooms. Bar and Smoking Room.</p>
                         <p> HENRI CHAMOULLEAU, Proprietor.</p>
                         <p>45</p>
-                        <p>FINE TERRACE ON THE AVENUE. - SPLENDID GARDEN. - OMNIBUS MEET ALL TRAINS AND
-                            STEAMERS. 28-26 </p>
+                        <p>FINE TERRACE ON THE AVENUE. - SPLENDID GARDEN. - OMNIBUS MEET ALL TRAINS AND STEAMERS. 28-26 </p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-pss01">
                         <head><placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>-SAVOY HOTEL.</head>
@@ -407,12 +347,9 @@
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-hbc01">
                         <head>HOTEL BRISTOL. <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> .</head>
-                        <p>Full South, Electric Light, opposite Esbekieh Gardens, Large Verandahs, Moderate
-                            Charges,</p>
+                        <p>Full South, Electric Light, opposite Esbekieh Gardens, Large Verandahs, Moderate Charges,</p>
                         <p>CHAS. BAUER, Proprietor.</p>
-                        <p>The Hotel is beautifully fitted up and is in the most central part of <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> .
-                            Terms for pension fare at the rate of ten shillings a day. Special terms for
-                            officers of Army of Occupation. 24,882-31-10-5</p>
+                        <p>The Hotel is beautifully fitted up and is in the most central part of <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> . Terms for pension fare at the rate of ten shillings a day. Special terms for officers of Army of Occupation. 24,882-31-10-5</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-gac01">
                         <head>GUARDIAN ASSURANCE COMPANY, LIMITED,</head>
@@ -430,10 +367,8 @@
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-nfl01">
                         <head>NORTHERN FIRE AND LIFE ASSURANCE Coy.</head>
-                        <p>The undersigned agents are authorised to issue policies on behalf of the above
-                            Company at moderate rates.</p>
-                        <p>IMPERIAL OTTOMAN BANK, <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>. OTTO STERZING, <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> . GEORG. MEINECKE, <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>.
-                            3112905</p>
+                        <p>The undersigned agents are authorised to issue policies on behalf of the above Company at moderate rates.</p>
+                        <p>IMPERIAL OTTOMAN BANK, <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>. OTTO STERZING, <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> . GEORG. MEINECKE, <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>. 3112905</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-sio01">
                         <head>Sun Insurance Office,</head>
@@ -455,7 +390,7 @@
                                 <cell><placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> … Mr. J. B. CAFFARI</cell>
                             </row>
                             <row>
-                                <cell><placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>  … Mr. J. B. CAFFARI</cell>
+                                <cell><placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> … Mr. J. B. CAFFARI</cell>
                                 <cell><placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName> … Mr. GEO. MEINECKE.</cell>
                             </row>
                         </table>
@@ -465,11 +400,11 @@
                         <head>INTERNATIONAL SLEEPING AND RESTAURANT CARS COMPANY.</head>
                         <table rows="2" cols="4">
                             <row role="label">
-                                <cell cols="4"><hi rend="italic">Restaurant Car runs every day between <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>
-                                        &amp; <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> &amp; vice-versa</hi>.</cell>
+                                <cell cols="4"><hi rend="italic">Restaurant Car runs every day between <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> &amp; <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> &amp; vice-versa</hi>.</cell>
                             </row>
                             <row>
-                                <cell>Depart. - <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> </cell>
+                                <cell>Depart. - <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>
+                                </cell>
                                 <cell>6.35 p.m.</cell>
                                 <cell>Arrival - <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName></cell>
                                 <cell>10.0 p.m.</cell>
@@ -477,19 +412,19 @@
                             <row>
                                 <cell>Depart. - <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName></cell>
                                 <cell>6. 0 p.m.</cell>
-                                <cell>Arrival - <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> </cell>
+                                <cell>Arrival - <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>
+                                </cell>
                                 <cell>9.20 p.m.</cell>
                             </row>
                         </table>
-                        <p>By the 10.15 p.m. train between <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>  and <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> and vice-versa a sleeping
-                            car is attached every night. Supplement 30 P.T. </p>
+                        <p>By the 10.15 p.m. train between <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> and <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> and vice-versa a sleeping car is attached every night. Supplement 30 P.T. </p>
                         <table rows="4" cols="4">
                             <row role="label">
-                                <cell cols="4"><hi rend="italic">Daily Restaurant Car Service between <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> ,
-                                        Ismailia, <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> &amp; vice-versa</hi>.</cell>
+                                <cell cols="4"><hi rend="italic">Daily Restaurant Car Service between <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> , Ismailia, <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> &amp; vice-versa</hi>.</cell>
                             </row>
                             <row>
-                                <cell>Depart. - <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> </cell>
+                                <cell>Depart. - <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>
+                                </cell>
                                 <cell>11 a.m. &amp; 6.15 p.m.</cell>
                                 <cell>Depart. - <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName></cell>
                                 <cell>11.55 a.m. &amp; 6.30 p.m.</cell>
@@ -509,48 +444,34 @@
                             <row>
                                 <cell>Arriv. - <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName></cell>
                                 <cell>5. 0 p.m. &amp; 11.10 p.m.</cell>
-                                <cell>Arriv. - <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> </cell>
+                                <cell>Arriv. - <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>
+                                </cell>
                                 <cell>5. 0 p.m. &amp; 11.25 p.m.</cell>
                             </row>
                         </table>
                         <p>Restaurant and Sleeping Cars on Luxor trains:</p>
-                        <p>A Restaurant car and a sleeping car are attached to the 8 p.m. train from <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>
-                            every Monday, Wednesday and Saturday and to the 5.30 p.m. train from Luxor every
-                            Tuesday, Thursday and Sunday.</p>
-                        <p>Railway and Sleeping Car tickets can be obtained any number of days ahead at the
-                            office of the International Sleeping Car Company in <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>  Station. 1st class
-                            <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> -Luxor P.T. 200. Sleeping Car supplement P.T. 75.</p>
+                        <p>A Restaurant car and a sleeping car are attached to the 8 p.m. train from <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> every Monday, Wednesday and Saturday and to the 5.30 p.m. train from Luxor every Tuesday, Thursday and Sunday.</p>
+                        <p>Railway and Sleeping Car tickets can be obtained any number of days ahead at the office of the International Sleeping Car Company in <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> Station. 1st class <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> -Luxor P.T. 200. Sleeping Car supplement P.T. 75.</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-ccc01">
-                        <p>The Cigarettes Manufactured by</p>
+                        <head type="sub">The Cigarettes Manufactured by</head>
                         <head>The Cleopatra Cigarette Co.</head>
                         <p>G. NUNGOYICH</p>
-                        <p>are on sale at the Company's establishment by Grand Contental Hotel, <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> , and
-                            at Walker &amp; Meimarschi's, <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>.</p>
+                        <p>are on sale at the Company's establishment by Grand Contental Hotel, <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> , and at Walker &amp; Meimarschi's, <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>.</p>
                         <p>Purveyors to H. H. the KHEDIVE.</p>
-                        <p>35750 Patronized by the Duke of Connaught and the Archduke Otto and all the High
-                            Life of <placeName ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName>. 18-4-80</p>
+                        <p>35750 Patronized by the Duke of Connaught and the Archduke Otto and all the High Life of <placeName ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName>. 18-4-80</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-ncs01">
                         <head>NILE COLD STORAGE<lb/> COMPANY, LIMITED.</head>
-                        <p>PURVEYORS OF THE FINEST COLONIAL<lb/> MEAT, GAME, POULTRY, BUTTER, FISH, etc.,
-                            etc.</p>
-                        <p>The Company have opened a shop in the NEW MARKET, <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> , Nos. 39 &amp; 40, where
-                            the goods imported by them can be inspected and purchased.</p>
+                        <p>PURVEYORS OF THE FINEST COLONIAL<lb/> MEAT, GAME, POULTRY, BUTTER, FISH, etc., etc.</p>
+                        <p>The Company have opened a shop in the NEW MARKET, <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> , Nos. 39 &amp; 40, where the goods imported by them can be inspected and purchased.</p>
                         <p>Telephone No. 1. 5. xxx-xx-xx</p>
                     </div>
                     <cb n="3"/>
                     <div type="item" scope="advertisement" xml:id="deg-ad-aan01">
                         <head>Anglo-American Nile Steamer &amp; Hotel Coy.</head>
-                        <p>Weekly departure during Winter Season by the<lb/> Luxurious First Class Tourist
-                            Steamers VICTORIA, PURITAN &amp; MAYFLOWER.<lb/> Regular weekly Departures to
-                            the SECOND CATARACT by the S.S. INDIANA.<lb/> THROUGH BOOKINGS TO KHARTOUM,
-                            GONDOKORO AND THE WHITE NILE.<lb/> Steamers and Dahabeahs for private charter.
-                            Steam Tugs and Steam Launches for hire.<lb/> FREIGHT SERVICE BY STEAM BARGES
-                            BETWEEN <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>  AND <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>.<lb/> Working in conjunction and under special
-                            arrangement with the<lb/> “Upper <placeName ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName> Hotels Company."</p>
-                        <p>For details and illustrated programmes apply to "THE ANGLO-AMERICAN NILE STEAMER
-                            and<lb/> HOTEL COMPANY."</p>
+                        <p>Weekly departure during Winter Season by the<lb/> Luxurious First Class Tourist Steamers VICTORIA, PURITAN &amp; MAYFLOWER.<lb/> Regular weekly Departures to the SECOND CATARACT by the S.S. INDIANA.<lb/> THROUGH BOOKINGS TO KHARTOUM, GONDOKORO AND THE WHITE NILE.<lb/> Steamers and Dahabeahs for private charter. Steam Tugs and Steam Launches for hire.<lb/> FREIGHT SERVICE BY STEAM BARGES BETWEEN <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> AND <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>.<lb/> Working in conjunction and under special arrangement with the<lb/> “Upper <placeName ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName> Hotels Company."</p>
+                        <p>For details and illustrated programmes apply to "THE ANGLO-AMERICAN NILE STEAMER and<lb/> HOTEL COMPANY."</p>
                         <p> OFFICES IN <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> : Sharia Boulac, "Grand Continental Hotel Buildings.” 31-3-06</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-nll01">
@@ -560,8 +481,7 @@
                         <p>The following steamers are intended to leave <placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName> : </p>
                         <table rows="14" cols="3">
                             <row>
-                                <cell cols="3">HOMEWARD : for Bremen Hamburg via <placeName ref="https://www.wikidata.org/wiki/Q2634">Naples</placeName> , Genoa, (Gibraltar),
-                                    Southampton, Antwerp.</cell>
+                                <cell cols="3">HOMEWARD : for Bremen Hamburg via <placeName ref="https://www.wikidata.org/wiki/Q2634">Naples</placeName> , Genoa, (Gibraltar), Southampton, Antwerp.</cell>
                             </row>
                             <row>
                                 <cell>Zieten</cell>
@@ -589,8 +509,7 @@
                                 <cell>about 28 August</cell>
                             </row>
                             <row>
-                                <cell cols="3">OUTWARD: for <placeName ref="https://www.wikidata.org/wiki/Q148">China</placeName> and JAPAN via <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>, ADEN, COLOMBO, PENANG,
-                                    SINGAPORE.</cell>
+                                <cell cols="3">OUTWARD: for <placeName ref="https://www.wikidata.org/wiki/Q148">China</placeName> and JAPAN via <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>, ADEN, COLOMBO, PENANG, SINGAPORE.</cell>
                             </row>
                             <row>
                                 <cell>Prinz E. Friedrich</cell>
@@ -627,19 +546,15 @@
                             </row>
                         </table>
                         <p>FOR FURTHER PARTICULARS APPLY TO THE AGENTS OF THE </p>
-                        <p>NORDDEUTSCHER LLOYD at <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> , <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>, <placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName>  and <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>. </p>
+                        <p>NORDDEUTSCHER LLOYD at <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> , <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>, <placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName> and <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>. </p>
                         <p>OTTO STERZING, Agent In <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> , Opera Square. </p>
                         <p>C. H. SCHOELLER, Agent In <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>, Cleopatra Lane.</p>
-                        <p>Messrs. THOS. COOK &amp; SON (<placeName ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName>) LTD., and CARL STANGENS REISEBUREAN are
-                            anthorised to sell tickets in <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>  and <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>, 31-8-905</p>
+                        <p>Messrs. THOS. COOK &amp; SON (<placeName ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName>) LTD., and CARL STANGENS REISEBUREAN are anthorised to sell tickets in <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> and <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>, 31-8-905</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-als01">
                         <head>Austrian Lloyd’s Steam Navigation</head>
                         <p><placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>-Brindisi-Venice-Trieste.</p>
-                        <p>Weekly Express Mail Service. Steamers leave <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> every Saturday at 4 p.m.
-                            arrive at Brindisi, Tuesday a.m. in time for express to <placeName ref="https://www.wikidata.org/wiki/Q90">Paris</placeName>, <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName>, <placeName ref="https://www.wikidata.org/wiki/Q2634">Naples</placeName> ,
-                            Rome. Arrival Trieste Wednesday noon connecting with Vienna Express
-                            (Trieste-Ostende through carriage) and expresses to Italy and Germany.</p>
+                        <p>Weekly Express Mail Service. Steamers leave <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> every Saturday at 4 p.m. arrive at Brindisi, Tuesday a.m. in time for express to <placeName ref="https://www.wikidata.org/wiki/Q90">Paris</placeName>, <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName>, <placeName ref="https://www.wikidata.org/wiki/Q2634">Naples</placeName> , Rome. Arrival Trieste Wednesday noon connecting with Vienna Express (Trieste-Ostende through carriage) and expresses to Italy and Germany.</p>
                         <table rows="3" cols="8">
                             <row>
                                 <cell>July 8</cell>
@@ -685,36 +600,23 @@
                                 <cell>Capt. Knezevich</cell>
                             </row>
                         </table>
-                        <p>(Departures from <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>) To Aden, <placeName ref="https://www.wikidata.org/wiki/Q1156">Bombay</placeName>, Colombo, Penang, Singapore, Hong-Kong,
-                            Shanghai, Yokohama, Kobé about July 5 and August 4. To Aden, Karachi, and <placeName ref="https://www.wikidata.org/wiki/Q1156">Bombay</placeName>
-                            accelerated service about August 18. To Aden, Karachi, <placeName ref="https://www.wikidata.org/wiki/Q1156">Bombay</placeName>, Colombo, Madras,
-                            Rangoon, and Calcutta about July 20.</p>
+                        <p>(Departures from <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>) To Aden, <placeName ref="https://www.wikidata.org/wiki/Q1156">Bombay</placeName>, Colombo, Penang, Singapore, Hong-Kong, Shanghai, Yokohama, Kobé about July 5 and August 4. To Aden, Karachi, and <placeName ref="https://www.wikidata.org/wiki/Q1156">Bombay</placeName> accelerated service about August 18. To Aden, Karachi, <placeName ref="https://www.wikidata.org/wiki/Q1156">Bombay</placeName>, Colombo, Madras, Rangoon, and Calcutta about July 20.</p>
                         <p>East African Line.</p>
-                        <p>To Aden, Mombassa, Zanzibar, Beira, Delagoa Bay, Durban, about July 4 and August
-                            3.</p>
+                        <p>To Aden, Mombassa, Zanzibar, Beira, Delagoa Bay, Durban, about July 4 and August 3.</p>
                         <p>Syrian-Cyprus-Caramanian Line.</p>
                         <p>Steamers leaves <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> on or about July 3, 17 and 31.</p>
-                        <p>For information apply to the Agents, <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>, <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> and <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>, Thos. Cook
-                            &amp; Son, Ld., Leon Heller, <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>  Agent, 4, Sharia Maghraby, (Telephone 192),
-                            <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> ; F. Tedeschi, Helouan.</p>
-                        <p>Special passage rates granted to Egyptian Government officials, members of the
-                            Army of Occupation and their families. </p>
+                        <p>For information apply to the Agents, <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>, <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> and <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>, Thos. Cook &amp; Son, Ld., Leon Heller, <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> Agent, 4, Sharia Maghraby, (Telephone 192), <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> ; F. Tedeschi, Helouan.</p>
+                        <p>Special passage rates granted to Egyptian Government officials, members of the Army of Occupation and their families. </p>
                         <p>31-12-905</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-pap01">
                         <head>THE PAPAYANNI LINE.</head>
                         <head type="sub">(The Ellerman Lines, Ltd.)</head>
-                        <p>Frequent Sailings from <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> to <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName>, also Regular Services from
-                            <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName> to <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> and to ALGERIA, <placeName ref="https://www.wikidata.org/wiki/Q233">Malta</placeName>, LEVANT, BLACK SEA, and other
-                            Mediterranean Ports.</p>
-                        <p>Excellent Passenger Accommodation. Stewardess carried. Liberal table and Moderate
-                            Fares for single and retnrn tickets. </p>
-                        <p>The S S. SARDINIA will sail for <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName> (via Bona) on Friday, the 7th inst. at
-                            4 p.m.</p>
-                        <p>CARGO taken by special agreement only. Through Freights quoted for the UNITED
-                            STATES and INLAND TOWNS in GREAT BRITAIN.</p>
-                        <p>For passage or freight apply to the Agents, BARKER &amp; Co., <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>.
-                            2061-17-10-905 </p>
+                        <p>Frequent Sailings from <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> to <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName>, also Regular Services from <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName> to <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> and to ALGERIA, <placeName ref="https://www.wikidata.org/wiki/Q233">Malta</placeName>, LEVANT, BLACK SEA, and other Mediterranean Ports.</p>
+                        <p>Excellent Passenger Accommodation. Stewardess carried. Liberal table and Moderate Fares for single and retnrn tickets. </p>
+                        <p>The S S. SARDINIA will sail for <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName> (via Bona) on Friday, the 7th inst. at 4 p.m.</p>
+                        <p>CARGO taken by special agreement only. Through Freights quoted for the UNITED STATES and INLAND TOWNS in GREAT BRITAIN.</p>
+                        <p>For passage or freight apply to the Agents, BARKER &amp; Co., <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>. 2061-17-10-905 </p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-ell01">
                         <head>Ellerman Lines, Limited.</head>
@@ -722,16 +624,15 @@
                             <row>
                                 <cell cols="3">CITY LINE to <placeName ref="https://www.wikidata.org/wiki/Q233">Malta</placeName>, <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName>, COLOMBO &amp; CALCUTTA.</cell>
                                 <cell cols="3">
-                                    <p>CITY &amp; HALL LINES. Joint Service to <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName>, <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName>, <placeName ref="https://www.wikidata.org/wiki/Q1156">Bombay</placeName>
-                                        &amp; KARACHI.</p>
+                                    <p>CITY &amp; HALL LINES. Joint Service to <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName>, <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName>, <placeName ref="https://www.wikidata.org/wiki/Q1156">Bombay</placeName> &amp; KARACHI.</p>
                                 </cell>
                             </row>
                             <row>
-                                <cell cols="6">The undermentioned First Class Passenger Steamers will be
-                                    dispatched from <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> on or about the following dates for </cell>
+                                <cell cols="6">The undermentioned First Class Passenger Steamers will be dispatched from <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> on or about the following dates for </cell>
                             </row>
                             <row>
-                                <cell><placeName ref="https://www.wikidata.org/wiki/Q233">Malta</placeName> and <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> </cell>
+                                <cell><placeName ref="https://www.wikidata.org/wiki/Q233">Malta</placeName> and <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName>
+                                </cell>
                                 <cell>S.S. City of Corinth </cell>
                                 <cell>July 26</cell>
                                 <cell><placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName> and <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName></cell>
@@ -747,13 +648,8 @@
                                 <cell>July 13</cell>
                             </row>
                         </table>
-                        <p>SALOON FARES:—<placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> to <placeName ref="https://www.wikidata.org/wiki/Q233">Malta</placeName> £4.10.0. <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName>. £8.0.0. <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> or
-                            <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName>, £l2.l0.0. Colombo, Calcutta, <placeName ref="https://www.wikidata.org/wiki/Q1156">Bombay</placeName> or Karachi, £35.0.0. Special
-                            rates for steamers not carrying Doctor or Stewardess. For further particulars
-                            apply to </p>
-                        <p>CORY BROS. &amp; Co., Ltd., Agents for CITY Line, <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>: W. STAPLEDON &amp;
-                            SON, Agents for Hall Line, <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> ; or COOK &amp; SON (<placeName ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName>), Ltd., <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> .
-                            23788-28-8-905 </p>
+                        <p>SALOON FARES:—<placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> to <placeName ref="https://www.wikidata.org/wiki/Q233">Malta</placeName> £4.10.0. <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName>. £8.0.0. <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> or <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName>, £l2.l0.0. Colombo, Calcutta, <placeName ref="https://www.wikidata.org/wiki/Q1156">Bombay</placeName> or Karachi, £35.0.0. Special rates for steamers not carrying Doctor or Stewardess. For further particulars apply to </p>
+                        <p>CORY BROS. &amp; Co., Ltd., Agents for CITY Line, <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>: W. STAPLEDON &amp; SON, Agents for Hall Line, <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> ; or COOK &amp; SON (<placeName ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName>), Ltd., <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> . 23788-28-8-905 </p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-ngi01">
                         <head>Navigation Générale Italienne.</head>
@@ -795,22 +691,15 @@
                         <head>NATIONAL BANK OF <placeName ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName>.</head>
                         <p>CAPITAL: L. 2,500,000. RESERVE (ENVIRON) : L. 862,000.</p>
                         <p>Gouverneur: Sir ELWIN PALMER, K.C.B., K.C.M.G.</p>
-                        <p>Siège Social au Caire, Succursale à <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>, Agence à Assiout, Assuoan, Benha,
-                            Beni-Suef, Chibin el Kom, Damanhour, Fayoum, Khartoum, Kéneh, Mansourah. Minieh,
-                            <placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName> , Suakin, Sohag, Tantah, Zagazig, Mouski (Caire) et Londres (4 et 5,
-                            King William Street).</p>
-                        <p>La National Bank of <placeName ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName> reçoit des dépots à termes fixes, fait des avances et
-                            ouvre des comptes courants sur titres, valeurs et marchandises. Elle s’occupe de
-                            l’achat et de la vente d'effets sur l’Etranger, de l'escompte, ainsi que de
-                            toutes opérations de Banque. 31-12-904</p>
+                        <p>Siège Social au Caire, Succursale à <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>, Agence à Assiout, Assuoan, Benha, Beni-Suef, Chibin el Kom, Damanhour, Fayoum, Khartoum, Kéneh, Mansourah. Minieh, <placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName> , Suakin, Sohag, Tantah, Zagazig, Mouski (Caire) et Londres (4 et 5, King William Street).</p>
+                        <p>La National Bank of <placeName ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName> reçoit des dépots à termes fixes, fait des avances et ouvre des comptes courants sur titres, valeurs et marchandises. Elle s’occupe de l’achat et de la vente d'effets sur l’Etranger, de l'escompte, ainsi que de toutes opérations de Banque. 31-12-904</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-abw01">
                         <head><placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> BONDED WAREHOUSE COMPANY, LTD.</head>
                         <p>(Société des Entrepôts d'Alexandrie)</p>
                         <p>Bonded Warehouses</p>
                         <p>IN <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>, <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> , <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>, AND <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>.</p>
-                        <p>Special Departments for clearing and forwarding and for a luggage and parcel
-                            Express Service.</p>
+                        <p>Special Departments for clearing and forwarding and for a luggage and parcel Express Service.</p>
                         <p>Goods delivered against cash for account of shippers. 1-6-906</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-ela01">
@@ -845,11 +734,9 @@
                     <div type="item" scope="advertisement" xml:id="deg-ad-eeh01">
                         <head>EASTERN EXCHANGE HOTEL, PORT SAID.</head>
                         <p>First Class Hotel. Modern in all respects.</p>
-                        <p>Fire-proof, Drained to the Sea, Lifts, Electric Light, English and French
-                            Billiards, Fresh and Salt Water Baths.</p>
+                        <p>Fire-proof, Drained to the Sea, Lifts, Electric Light, English and French Billiards, Fresh and Salt Water Baths.</p>
                         <p>The Coolest Summer Residence in Egypt.</p>
-                        <p>Special terms to Cairo Residents and their families desirous of enjoying the cool
-                            air and sea bathing during the summer months.</p>
+                        <p>Special terms to Cairo Residents and their families desirous of enjoying the cool air and sea bathing during the summer months.</p>
                         <p>Dragomans in Hotel Uniform Meet all Trains and Steamers.</p>
                         <p>22941-23-8-905</p>
                     </div>
@@ -861,10 +748,8 @@
                         <p>The most charming Sea-side Residence in Egypt.</p>
                         <p>First Class Family Hotel with Every Modern Comfort.</p>
                         <p>Unique Situation on the Beach.</p>
-                        <p>Lovely Garden. Lawn Tennis. Large Terrace. Electric Light. Sea Baths. Own
-                            springs. Perfect sanitary arrangements. Stables for horses and carriages.</p>
-                        <p>Moderate Charges. -- Special terms for Government Officials and Officers of the
-                            Army of Occupation.</p>
+                        <p>Lovely Garden. Lawn Tennis. Large Terrace. Electric Light. Sea Baths. Own springs. Perfect sanitary arrangements. Stables for horses and carriages.</p>
+                        <p>Moderate Charges. -- Special terms for Government Officials and Officers of the Army of Occupation.</p>
                         <p>252-17.1.906</p>
                         <p>G. RUNCKEWITZ, Proprietor.</p>
                     </div>
@@ -916,10 +801,8 @@
                         <p>DIRECT IMPORTER OF BRITISH AND IRISH TEXTILE MANUFACTURES.</p>
                         <p>LADIES’ SUMMER STOCKINGS.</p>
                         <p> IN SPUN SILK at P.T. 20 per pair.</p>
-                        <p>LISLE THREAD, in plain and lace open-work, in black, white, tan and usual shades,
-                            to suit boots worn in Egypt, frpm P.T. 5 per pair.</p>
-                        <p>Every pair is marked “Au De Rouge" which is a guarantee that the Color is
-                            absolutely fast and stainless.</p>
+                        <p>LISLE THREAD, in plain and lace open-work, in black, white, tan and usual shades, to suit boots worn in Egypt, frpm P.T. 5 per pair.</p>
+                        <p>Every pair is marked “Au De Rouge" which is a guarantee that the Color is absolutely fast and stainless.</p>
                         <p>24916-15-11-905</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-jma01">
@@ -935,7 +818,7 @@
                         <p>Brewers, Burton-on-Trent and Romford.</p>
                         <p>Pale Ale &amp; Double Stout, specially brewed for export.</p>
                         <p>Agents: Messrs. John Ross &amp; Co., Alexandria &amp; Cairo:</p>
-                        <p>48047  30-2-904</p>
+                        <p>48047 30-2-904</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-jbc01">
                         <head>John B. Caffari's "Economical Stores"</head>
@@ -953,8 +836,7 @@
                     <div type="item" scope="advertisement" xml:id="deg-ad-spa01">
                         <head>Spathi's Grill Room.</head>
                         <p>Old Bourse St., Alexandria.</p>
-                        <p>Greatly enlarged and improved. New Chef. Unrivalled cooking. English specially
-                              catered for</p>
+                        <p>Greatly enlarged and improved. New Chef. Unrivalled cooking. English specially catered for</p>
                         <p>2063-14-1-906</p>
                     </div>
                     <!-- TODO Magasins Victoria: Selling of Surplus Drapery Stock -->
@@ -1049,7 +931,7 @@
                             </row>
                             <row>
                                 <cell>Cairo Halouan</cell>
-                                <cell>35</cell><lb/>
+                                <cell>35</cell>
                                 <cell>22</cell>
                             </row>
                             <row>
@@ -1155,23 +1037,12 @@
                 <div type="section" scope="newspaper">
                     <div type="item" scope="newspaper">
                         <head>THE EGYPTIAN GAZETTE.</head>
-                        <p>SUBSCRIPTIONS.—Alexandria, Cairo, and the Interior of Egypt (including
-                            delivery in Alexandria or postage to subscriber’s address) P.T. 231½ per
-                            annum, P.T. 116 for six months, P.T. 80 for three months. To other countries
-                            in the Postal Union P.T. 273 (£2.16s.) per annum. Six months P.T. 136½
-                            (£1.8s.), three months P.T. 92 (£0.19s.) N.B.—Subscriptions commence from
-                            the 1st or 16th of any month. </p>
-                        <p>ADVERTISEMENTS.—P.T. 4 per line. Minimum charge P.T. 20. Births, Marriages,
-                            or Deaths, not exceeding three lines, P.T. 20. Every additional line P.T.
-                            10. Notices in news column P.T. 20 per line. Contracts entered into for
-                            standing advertisements. </p>
-                        <p>SUBSCRIPTIONS and ADVERTISEMENTS are due in advance. P.O. Orders and Cheques
-                            to be made payable to the Editor and Manager, Rowland Snelling, Alexandria. </p>
+                        <p>SUBSCRIPTIONS.—Alexandria, Cairo, and the Interior of Egypt (including delivery in Alexandria or postage to subscriber’s address) P.T. 231½ per annum, P.T. 116 for six months, P.T. 80 for three months. To other countries in the Postal Union P.T. 273 (£2.16s.) per annum. Six months P.T. 136½ (£1.8s.), three months P.T. 92 (£0.19s.) N.B.—Subscriptions commence from the 1st or 16th of any month. </p>
+                        <p>ADVERTISEMENTS.—P.T. 4 per line. Minimum charge P.T. 20. Births, Marriages, or Deaths, not exceeding three lines, P.T. 20. Every additional line P.T. 10. Notices in news column P.T. 20 per line. Contracts entered into for standing advertisements. </p>
+                        <p>SUBSCRIPTIONS and ADVERTISEMENTS are due in advance. P.O. Orders and Cheques to be made payable to the Editor and Manager, Rowland Snelling, Alexandria. </p>
                         <p>London Offices : 36, New Broad-street. B.C. </p>
-                        <p>THE EGYPTIAN GAZETTE can be obtained in London at our office, 36, New Broad
-                            Street, E.C., and also at Messrs. May &amp; Williams 160, Piccadilly, W. </p>
-                        <p>THE “EGYPTIAN GAZETTE” IS PRINTED ON PAPER MANUFACTURED AND SUPPLIED BY THE
-                            LONDON PAPER MILLS Co., LIMITED (SALES OFFICE: 27, CANNON STREET, E.C.) </p>
+                        <p>THE EGYPTIAN GAZETTE can be obtained in London at our office, 36, New Broad Street, E.C., and also at Messrs. May &amp; Williams 160, Piccadilly, W. </p>
+                        <p>THE “EGYPTIAN GAZETTE” IS PRINTED ON PAPER MANUFACTURED AND SUPPLIED BY THE LONDON PAPER MILLS Co., LIMITED (SALES OFFICE: 27, CANNON STREET, E.C.) </p>
                     </div>
                     <div type="item" scope="newspaper">
                         <p>The "Egyptian Gazette" is printed on<lb/> paper manufactured and supplied<lb/>by the London Paper Mills Co., Limited<lb/>(Sales office: 27, Cannon Street, E.C.</p>
@@ -1192,18 +1063,18 @@
                     <!-- TODO The Crisis at Budapest -->
                 </div>
                 <div type="item" scope="calendar">
-                    <table cols="3" xml:id="CalendarOfTheWeek">
-                        <head>Calendar of Coming Events.</head>
-                        <div type="subsection">
-                            <head>Alexandria</head>
-                            <head type="sub">October</head>
+                    <head>Calendar of Coming Events.</head>
+                    <div type="subsection">
+                        <head>Alexandria</head>
+                        <head type="sub">October</head>
+                        <table cols="3" xml:id="CalendarOfTheWeek">
                             <row>
                                 <cell>Mon.</cell>
                                 <cell>2</cell>
                                 <cell>
                                     <p>Mex Casino. Reunion des Familles. 9:30 P.M.</p>
-                                    <p>Mex. Princes's Restauraunt des Bains<lb/>Roumanian orchestra, every after-noon.  Sundays, morning.</p>
-                                    <p>Windsor Hotel.  Orchestra.  6 to 11:30 p.m. every day.</p>
+                                    <p>Mex. Princes's Restauraunt des Bains<lb/>Roumanian orchestra, every after-noon. Sundays, morning.</p>
+                                    <p>Windsor Hotel. Orchestra. 6 to 11:30 p.m. every day.</p>
                                     <p>Alhambra -- Italian company. -- I Fourchambault. 9.15. p.m.</p>
                                 </cell>
                             </row>
@@ -1226,13 +1097,15 @@
                                 <cell>14</cell>
                                 <cell>
                                     <p>Alex. Swimming Club. 60yds Juniors' 100yds. Seniors' Chapmpionships. Customs Gate 23. 4 p.m.</p>
-                                    <p>B.R.C. Mustapha Pasha Range.  Practice and Cup Compeittion. 3 p.m.</p>
+                                    <p>B.R.C. Mustapha Pasha Range. Practice and Cup Compeittion. 3 p.m.</p>
                                 </cell>
                             </row>
-                        </div>
-                        <div type="subsection">
-                            <head>Cairo</head>
-                            <head type="sub">October</head>
+                        </table>
+                    </div>
+                    <div type="subsection">
+                        <head>Cairo</head>
+                        <head type="sub">October</head>
+                        <table>
                             <row>
                                 <cell>Mon.</cell>
                                 <cell>2</cell>
@@ -1259,17 +1132,18 @@
                             <row>
                                 <cell>Mon.</cell>
                                 <cell>16</cell>
-                                <cell>Cairo Musical and Dramatic Society.  Concert in aid of Calabrian Victims.  Distinguished Patronage.</cell>
+                                <cell>Cairo Musical and Dramatic Society. Concert in aid of Calabrian Victims. Distinguished Patronage.</cell>
                             </row>
-                        </div>
-                    </table>
+                        </table>
+                    </div>
                 </div>
                 <!-- TODO Advertisement: Marseille; Grand hotel Du Louvre & Paix-->
             </div>
             <div type="page" n="3">
                 <head>THE Egyptian GAZETTE, MONDAY, OCTOBER 2 1905</head>
                 <div type="section">
-                    <div type="article"><!-- TODO: CHECK ITEM AGAINST IMAGE OF THE NEWSPAPER -->
+                    <div type="article">
+                        <!-- TODO: CHECK ITEM AGAINST IMAGE OF THE NEWSPAPER -->
                         <head>RUSSIA AND GERMANY</head>
                         <head>PROPOSED ENTENTE</head>
                         <head type="sub">RUSSIAN PRESS OPINION:</head>
@@ -1359,7 +1233,7 @@
                         <byline>(Reuter)</byline>
                     </div>
                 </div>
-                <div type="section" scope="local and general">
+                <div type="section" scope="local">
                     <head>LOCAL AND GENERAL</head>
                     <div type="article">
                         <head>Bubonic Plague</head>
@@ -1376,7 +1250,7 @@
                     <div type="article">
                         <head>THE SIRDARS ARRIVAL</head>
                         <p>H. E. the Sirdar, Sir Reginald Wingate Pasha, and Lady Wingate arrived at <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> by the Austrian Lloyd mail boat this morning. Sir R. Von Slatin Pasha also arrived by the same boat.</p>
-                        <p>The Sirdar and Lady Wingate left for <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>  by the nine o'clock train taking a special saloon carriage Shortly before the arrival of the train at <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>  a guard of honor, consisting of three officers, a hundred nor.-commissioned officers men with the battalions colours, and the cavalry band were drawn up inside the station and as the train steamed into the station at 12.2ft p m. \ salute of 19 guns was fired. A large it of officers both of the Egyptian Army and the Army of Occupation were present on the platform, and after shaking hands with all who bad come to meet him the Sirdar, escorted by a guard of one officer and twenty five non-commissioned officers and men, drove to the Sirdarieh.</p>
+                        <p>The Sirdar and Lady Wingate left for <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> by the nine o'clock train taking a special saloon carriage Shortly before the arrival of the train at <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> a guard of honor, consisting of three officers, a hundred nor.-commissioned officers men with the battalions colours, and the cavalry band were drawn up inside the station and as the train steamed into the station at 12.2ft p m. \ salute of 19 guns was fired. A large it of officers both of the Egyptian Army and the Army of Occupation were present on the platform, and after shaking hands with all who bad come to meet him the Sirdar, escorted by a guard of one officer and twenty five non-commissioned officers and men, drove to the Sirdarieh.</p>
                         <p>Among those awaiting his Excellency on the platform we noticed Brigadier-General Bullock, Lord Edward Cecil Pasha, E. Bernard Pasha, the Staffs of the headquarters of the Egyptian Army and the Army of Occupation, the War Office, and the Sudan Administrative Office,</p>
                     </div>
                     <div type="article">
@@ -1420,11 +1294,13 @@
                     </div>
                     <div type="article">
                         <head>A Kidnapping Case.</head>
-                        <p>In August of last year the Slave Trade Department received advice that a Sudanese boy, son of Mulazim Awal Farag Effendi Ibrahim, had been napped. Subsequently one of the inspectors of he department arrested a Bedouin of the Besbariab tribe named Hassabo Mohamed for having taken part with another Bedouin of the Ababda tribe in the kidnapping of the boy and selling him to some Bedouins in the Hedjez. A special court which assembled on Saturday at the Native Tribunal in <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> , consisting of Yemen Buy Ibrahim, who presided, Messrs de Hults and Willmore, Ahmed Bey Ziwar and Mohamed Bey Mehrez, for the trial of Hassabo Mobamed, found the accused guilty and sentenced him to two and a half years’ imprisonment with hard labour. Abdel Hamid Bey Hilmi appeared on behalf of the Parquet and Saghologasi Ahmed Effendi Bahir, inspector of the Slave Trade Department, who arrested the accused, represented the depart-ment,</p>
+                        <p>In August of last year the Slave Trade Department received advice that a Sudanese boy, son of Mulazim Awal Farag Effendi Ibrahim, had been napped. Subsequently one of the inspectors of he department arrested a Bedouin of the Besbariab tribe named Hassabo Mohamed for having taken part with another Bedouin of the Ababda tribe in the kidnapping of the boy and selling him to some Bedouins in the Hedjez. A special court which assembled on Saturday at the Native Tribunal in <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> , consisting of Yemen Buy Ibrahim, who presided, Messrs de Hults and Willmore, Ahmed Bey Ziwar and Mohamed Bey Mehrez, for the trial of Hassabo Mobamed, found the accused guilty and sentenced him to two and a half years’ imprisonment with hard labour. Abdel Hamid Bey Hilmi appeared on behalf of the Parquet and Saghologasi Ahmed Effendi Bahir, inspector of the Slave Trade Department, who arrested the accused, represented the
+                            depart-ment,</p>
                     </div>
                     <div type="article">
                         <head>ARMENT TEFTISH.</head>
-                        <p>Some time ago, on the transfer of the Daira Sanieh lands to the Daira Sanieh Company, the inhabitants of four villages comprised in the above teftish sent a petition to the former administration protesting against the sale of their lands, alleging that these belonged to them by right and that they had been unjustly deprived of them some sixty years ago by the Viceroy Mohamed Ali, and that later the lands were incorporated with those of The Daira Sanieh of the Khedive Ismail. The administration granted the petitioners’ request by leasing the lands in perpetuity to the inhabitants at a very low rental, equivalent to the Government tax. Oar <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>  Correspondent states that the authorities have now decided upon returning the lands in question to the rightful owners, the conditions being that they pay half the estimated cost in 20 yearly instalments with interest at 5 per cent, plus the usual tax. The of the properties in question is 12.000 feddans. and their present value is estimated ₤50 the feddan.</p>
+                        <p>Some time ago, on the transfer of the Daira Sanieh lands to the Daira Sanieh Company, the inhabitants of four villages comprised in the above teftish sent a petition to the former administration protesting against the sale of their lands, alleging that these belonged to them by right and that they had been unjustly deprived of them some sixty years ago by the Viceroy Mohamed Ali, and that later the lands were incorporated with those of The Daira Sanieh of the Khedive Ismail. The administration granted the petitioners’ request by leasing the lands in perpetuity to the inhabitants at a very low rental, equivalent to the Government tax. Oar <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> Correspondent states that the authorities have now decided upon returning the lands in question to the rightful owners, the conditions being that they pay half the estimated cost in 20 yearly instalments with interest at 5 per cent, plus the usual tax. The
+                            of the properties in question is 12.000 feddans. and their present value is estimated ₤50 the feddan.</p>
                         <p>Oar Correspondent adds that it is probable that the Government will ask the Agricultural Bank or the National Bank to undertake the sale of these lands, and The collection of the annuities as they become due. Some of the native papers express their approval of the settlement of this long-standing dispute, and praise the Government for the equitable way in which it has arranged matters.</p>
                     </div>
                     <div type="article">
@@ -1436,9 +1312,10 @@
                         <head>ENGINEER COMMANDER WEBB</head>
                         <head>THE MC.MILLAN EXPEDITION.</head>
                         <head>INTERESTING INTERVIEW.</head>
-                        <p>Mr. W. McMillan, the well-known American explorer, who arrived in <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>  last week from England with bis party, is leaving there tomorrow for Port 8aid to join the P. &amp; Q. steamer Persia, by which the expedition proceeds to Aden, and thence by British India steamer to Mombasa, and from the latter port by rail to their destination. The other members of the party are Messrs. Bulpett, Jessen, Bayliss, Kay, Marlow, and Towell.</p>
-                        <p>In an interview with one of these gentlemen on Saturday, our <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>  correspondent elicited some interesting particulars of a country still very little known to the outside world.</p>
-                        <p>Last year Mr. McMillan paid a visit to this same oountry, and was so struck with it that he is now returning to take ap a tract of land 15,000 acres in extent, which he and two others of The party have purchased from the Protectorate of British East Africa with the intention of introducing ostrich farming on an extensive scale. This part of the country is admirably adapted to ostrich farming, and also farming in general, as a great portion of it consists of lands naturally fertile, and resembles some of the most beautiful districts of southern England in its picturesqueness. The property acquired is situated 35 miles to the north east of Nairobi, the capital of the Protectorate, and 330 miles distant from the coast,on the Attir plains, close to the Donyo-Sabuk mountain ranges which is 1,500 feet above the plain, the mountain itself being 5,000 feet above sea level. The rainy season Lasts for three months in these districts, from the beginning of April to the end of June, and daring this period the rainfall is about 25 metres. The rest of the year the climate may be described as almost perfect, the nights being cold and the thermometer falling about 35° Fahrenheit Nairobi is 30 hours distant from Mombasa by the Uganda railway. Mr. Mc Millan intends raising his first stock of ostriches by incubation; the eggs of the wild birds will be gathered by trained natives and placed under incubators, of which a large munber are being taken out by the party, and in this way it is hoped to get in time a fine race of ostriches, equalling in plumage and value those of South Africa. He is of opinion that most parts of British Bast Africa are most suitable for European colonisation, and thinks that the Zionists made a great mistake in declining the generous offer made them by the British Government lately of a free grant of a large tract of country.</p>
+                        <p>Mr. W. McMillan, the well-known American explorer, who arrived in <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> last week from England with bis party, is leaving there tomorrow for Port 8aid to join the P. &amp; Q. steamer Persia, by which the expedition proceeds to Aden, and thence by British India steamer to Mombasa, and from the latter port by rail to their destination. The other members of the party are Messrs. Bulpett, Jessen, Bayliss, Kay, Marlow, and Towell.</p>
+                        <p>In an interview with one of these gentlemen on Saturday, our <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> correspondent elicited some interesting particulars of a country still very little known to the outside world.</p>
+                        <p>Last year Mr. McMillan paid a visit to this same oountry, and was so struck with it that he is now returning to take ap a tract of land 15,000 acres in extent, which he and two others of The party have purchased from the Protectorate of British East Africa with the intention of introducing ostrich farming on an extensive scale. This part of the country is admirably adapted to ostrich farming, and also farming in general, as a great portion of it consists of lands naturally fertile, and resembles some of the most beautiful districts of southern England in its picturesqueness. The property acquired is situated 35 miles to the north east of Nairobi, the capital of the Protectorate, and 330 miles distant from the coast,on the Attir plains, close to the Donyo-Sabuk mountain ranges which is 1,500 feet above the plain, the mountain itself being 5,000 feet above sea level. The rainy season Lasts for three months in these districts, from the beginning of April to the
+                            end of June, and daring this period the rainfall is about 25 metres. The rest of the year the climate may be described as almost perfect, the nights being cold and the thermometer falling about 35° Fahrenheit Nairobi is 30 hours distant from Mombasa by the Uganda railway. Mr. Mc Millan intends raising his first stock of ostriches by incubation; the eggs of the wild birds will be gathered by trained natives and placed under incubators, of which a large munber are being taken out by the party, and in this way it is hoped to get in time a fine race of ostriches, equalling in plumage and value those of South Africa. He is of opinion that most parts of British Bast Africa are most suitable for European colonisation, and thinks that the Zionists made a great mistake in declining the generous offer made them by the British Government lately of a free grant of a large tract of country.</p>
                         <p>We wish the adventurous American explorer and his party every success in this their first attempt at colonisation, and the opening up of an almost unknown district to civilisation.</p>
                     </div>
                     <div type="article">
@@ -1447,7 +1324,8 @@
                         <head type="sub">INQUEST ADJOURNED</head>
                         <p>The inquest touching the death of Tom, Peter,who committed suicide at the San Stefano Casino at 8 p.m. on Friday, took place at the Deaconesses’ Hospital on Saturday.</p>
                         <p>The jurors were Messrs. Douglas Allen, H. S. Martin and Otho. S. Constantino. After the body had been viewed by the jurors it was identified by The manager of the San Stefano Casino as that of a man he bad seen at 8.9 p.m. lying dead on the beach in front of the between the gentlemen’s and the ladies’ bathing place, with a revolver containing three undischarged and two empty cartridge cases beside him.</p>
-                        <p>One bullet was sticking in the forehead of the deceased, the other had penetrated his heart. From the medical evidence it appeared that the deceased had died of a self inflicted wound. He was presumably of about 85 years of age and had P.S. tattooed on one of his arms. In his pockets were found a registered postal packet addressed to Mrs. Schablousky of Arnold Street, <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName>, and some postal odrders made out to Joanna Shcablousky, also of <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName>. The deceased has been given at <placeName ref="https://www.wikidata.org/wiki/Q90">Paris</placeName> a passport to travel in Russia, which had been visaed by the Russian consularauthorities, on the strength of a passport from Christiania., He is described in the <placeName ref="https://www.wikidata.org/wiki/Q90">Paris</placeName> passport as a British subject named Tom Peter, resident in Ceylon, and a Christian by religion. As some doubt was fait whether the deceased was really a British subject it was decided to adjourn the inquest sine die pending farther enquiries.</p>
+                        <p>One bullet was sticking in the forehead of the deceased, the other had penetrated his heart. From the medical evidence it appeared that the deceased had died of a self inflicted wound. He was presumably of about 85 years of age and had P.S. tattooed on one of his arms. In his pockets were found a registered postal packet addressed to Mrs. Schablousky of Arnold Street, <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName>, and some postal odrders made out to Joanna Shcablousky, also of <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName>. The deceased has been given at <placeName ref="https://www.wikidata.org/wiki/Q90">Paris</placeName> a passport to travel in Russia, which had been visaed by the Russian consularauthorities, on the strength of a passport from Christiania., He is described in the <placeName ref="https://www.wikidata.org/wiki/Q90">Paris</placeName> passport as a British subject named Tom Peter,
+                            resident in Ceylon, and a Christian by religion. As some doubt was fait whether the deceased was really a British subject it was decided to adjourn the inquest sine die pending farther enquiries.</p>
                     </div>
                     <div type="article">
                         <head>THE CALABRIAN DISASTER.</head>
@@ -1485,37 +1363,47 @@
                     </div>
                     <div type="article">
                         <byline>(By Telegraph).</byline>
-                        <dateline>Monday, <date value="1905-10-02">10</date>. 16 a.m.</dateline>
+                        <dateline>Monday, <date when="1905-10-02">10</date>. 16 a.m.</dateline>
                         <p>Mr. Harris and his two assistants will probably leave next Sunday. The homeward mails <unclear/></p>
                     </div>
                     <div type="article">
                         <p>The Italian Consul General, Baron Acton has addressed the following letter to the press.</p>
+                        <!--
                         <quotedLetter>
                             <opener>
-                                <dateline>Alessandria, li <date value="1905-09-30">30 settembre 1905</date>.</dateline>
+                                <dateline>Alessandria, li <date value="1905-09-30">30 settembre
+                                        1905</date>.</dateline>
                                 <salute>Gentilissimi Signori,</salute>
                             </opener>
                             <p>Mi pregie seguare riceruta e ringraziaro de</p>
-                            <p>SS.VV. della loro lettera di ieri con cai mi confermano la rimessa a questo Consolato della somma di P T. 5493, ammontare del ricavo netto della serata data dalla stamps alessanddrina la sera del 18 corrente, a favore dalle vittime del terremoto della Calabria.</p>
-                            <p>Colgo l'occaisione per pregare le SS.VV. di voler gradire ed esprimere i miei sentimenti di viva gratitudine ai membri della stampa che vollero organizzare la serata di beneficenza, cosi ben riuscita grazie allo slacio ammirevole di carita di questa cittadinanza</p>
+                            <p>SS.VV. della loro lettera di ieri con cai mi confermano la rimessa a
+                                questo Consolato della somma di P T. 5493, ammontare del ricavo
+                                netto della serata data dalla stamps alessanddrina la sera del 18
+                                corrente, a favore dalle vittime del terremoto della Calabria.</p>
+                            <p>Colgo l'occaisione per pregare le SS.VV. di voler gradire ed
+                                esprimere i miei sentimenti di viva gratitudine ai membri della
+                                stampa che vollero organizzare la serata di beneficenza, cosi ben
+                                riuscita grazie allo slacio ammirevole di carita di questa
+                                cittadinanza</p>
                             <closer>
                                 <salute>Con distintissima considerazione</salute>
                                 <signed>Il R. Console Generale E. Acton.</signed>
-                            </closer>
-                        </quotedLetter>
+                            </closer> 
+                        </quotedLetter> 
+                        -->
                         <p>The issue of the unique newspaper published yesterday in five languages by the Associazione Internationale dei Soccorsi Sanatari d’Urgenza was a great success, and reflects not a little credit upon those who were charged with its publication and the organisation on the day’s proceedings, which consisted chiefly in distributing the paper and making a street collection. In this way a sum of P.T. 10,270.5 was collected, and will be handed over to the Gouvernorat for transmission to the proper quarter. The collection was made by a number of young ladies, each wearing a broad rad band with the words "Pro Calabria" written across it in large gold characters, and the sam collected shows that bat few closed their ears to the appeals, or their eyes to the charms, of these</p>
                     </div>
                 </div>
-                <div type="section" scope="personal and social">
+                <div type="section" scope="social">
                     <head>PERSONAL AND SOCIAL.</head>
                     <div type="item">
                         <p>Among those who arrived by the Austrian Lloyd mail boat we noticed Sir Reginald and Lady Wingate, Sir R. Von Slatin Pasha, Johnson Pasha, Baron Menasce, and many others.</p>
                     </div>
                     <div type="item">
-                        <p>Mr. M. di Collaito, the <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>  correspondent of the “Phare d’Alexandrie”, has been appointed editor of the "Progress" in succession to Mr. Marengo, who has joined the firm of H. Devries &amp; Co.</p>
+                        <p>Mr. M. di Collaito, the <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> correspondent of the “Phare d’Alexandrie”, has been appointed editor of the "Progress" in succession to Mr. Marengo, who has joined the firm of H. Devries &amp; Co.</p>
                     </div>
                     <div type="item">
-                        <p>Antoine Bey Mesciaca returned to <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>  from leave and resumed his duties as director of the administrative service of the Sanitary Department.</p>
+                        <p>Antoine Bey Mesciaca returned to <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> from leave and resumed his duties as director of the administrative service of the Sanitary Department.</p>
                     </div>
                     <div type="article">
                         <head>PASSENGER LIST.</head>
@@ -1536,63 +1424,22 @@
                         <p>Mr. Simpson, manager of the National Bank, Shoonah, and M. A. Arbib, of the Bank of <placeName ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName>, have been selected as members of the Mixed Tribunal.</p>
                     </div>
                 </div>
-                <div type="section" scope="sport and play">
-                    <head>SPORT AND PLAY.</head>  <!-- TODO Re-OCR this section -->
+                <div type="section" scope="sporting">
+                    <head>SPORT AND PLAY.</head>
+                    <!-- TODO Re-OCR this section -->
                     <div type="article">
-                        <head>CRICKET.</head> <!-- TODO Put information into a proper table -->
-                        OVER 29 v. UNDER 29.
-                        Played on Saturday resulting in a draw. The good batting of Brereton, McLean and Dawson pat the senior XI. in a strong position though their opponents were not in good fielding form. For the under 29 XI. da Regemont played a good innings of 36. The other batsmen mostly found Maraden's bowling too tempting. Score and analysis.
-                        Over 29.
-                            O.	M.	R. W.
-                        Byrne...		 13	4	42 -
-                        Barnard		 13	8	51 1
-                        Robertson	... 10	1	47 1
-                        Watt ...		 4	1	18 -
-                        Cheesman		 2	1	7 -
-                        Henley.		 4 Under 89.	..	21 -
-                        r. Weedon o. Freeman, b. Marsden ...
-                        de Rougemont b. Marsden .........................................
-                        Barnard b. Marsden ...................................... __
-                        Byrne o. Logan, b. Marsden.......................................
-                        Henley st. Dawson, b. Marsden...
-                        Macaulay not out..................................................
-                        CHeesman c. Dawson, b. Graves ... Harrison not out .................................................
-                        did not bat
-                        Mr. Stacey run out ........................ 18
-                        „ Graves b. Robertson
-                        „ Marsden run out .............
-                        „ R. McLean b. Barnard ..
-                        „ Breveton not out ... . 39
-                        „ Dawson not out ..............
-                        Capt. Bingley
-                        Mr. Winter
-                        „ Logan	 did not bot
-                         Freeman  Lucas
-                        B. 16, l. b. 1, w. 2 .................
-                        7, n.b. 1.
-                        Total for six wickets . Over 29 Bowling.
-                        0.	M.	R
-                        11	2	28
-                        5	2	7
-                        •	2	52
+                        <head>CRICKET.</head>
+                        <!-- TODO Put information into a proper table -->
+                        <p>OVER 29 v. UNDER 29. Played on Saturday resulting in a draw. The good batting of Brereton, McLean and Dawson pat the senior XI. in a strong position though their opponents were not in good fielding form. For the under 29 XI. da Regemont played a good innings of 36. The other batsmen mostly found Maraden's bowling too tempting. Score and analysis. Over 29. O. M. R. W. Byrne... 13 4 42 - Barnard 13 8 51 1 Robertson ... 10 1 47 1 Watt ... 4 1 18 - Cheesman 2 1 7 - Henley. 4 Under 89. .. 21 - r. Weedon o. Freeman, b. Marsden ... de Rougemont b. Marsden ......................................... Barnard b. Marsden ...................................... __ Byrne o. Logan, b. Marsden....................................... Henley st. Dawson, b. Marsden... Macaulay not out.................................................. CHeesman c. Dawson, b. Graves ... Harrison not out ................................................. did not bat Mr. Stacey run out
+                            ........................ 18 „ Graves b. Robertson „ Marsden run out ............. „ R. McLean b. Barnard .. „ Breveton not out ... . 39 „ Dawson not out .............. Capt. Bingley Mr. Winter „ Logan did not bot Freeman Lucas B. 16, l. b. 1, w. 2 ................. 7, n.b. 1. Total for six wickets . Over 29 Bowling. 0. M. R 11 2 28 5 2 7 • 2 52 </p>
                     </div>
                     <div type="article">
                         <head>ARRIVALS.</head>
-                        Le paqubot Hasburg, da Lloyd Autriohien arrive ce matin de Trieste avait a bord:
-                        M. et Mme Rose et 2 enfants, M. et Mme Fracca, Riga Bey, M. et Mme Stabile, M. et Mme Kobn et 3 enfants, Mme Milcnvich et 4 enfants, Palelogo, M. et Mme Aghion, Castro et 6 de fam., Blaicher, Mardulfo et 3 de fam., Menasce et 6 de famille, Mme Ades et sa fille, Cohen, Castiglioni, Col. Nikie, Mamlouk et 4 de fam., M. et Mme Moroni, Zagdoun et 6 de fam., Nahum, Israel et 9 de fam., M. et Mme Tilche, Mme Tilche et 4 enfants, M. et Mme Jabos, Lindemann et 4 de fam., Francia, Sadler, Lidy Wingate, S.E Wingate Pacha, Cottins, Fenderl, Pini Bey, Reinhardt, Kenny Herbert, Sir von 8latin Pacha, Levy, Aghion et 2 de fam., Bialobos Bey, S.E. Johnson Pacha, Mortera, Husgar, Mme Kauky et 8 enfants, M. et Mme Constantin Sava, Arthur Wilson, G. Heller, Mme Victor Aghion et 3 enfants, Mme Stakia nos et 2 fils, L Sarkissian, D. A. Rizzi Mustafa Bey Fayed, Skill, Dietterle, Vangam, Srack, Mr. Graves 11 2 28 Aghion, Greaves, Kolischkine, Michalek, et 62 , passengers de 3me classe.
-                        Watt
-                        Lester
+                        <p>Le paqubot Hasburg, da Lloyd Autriohien arrive ce matin de Trieste avait a bord: M. et Mme Rose et 2 enfants, M. et Mme Fracca, Riga Bey, M. et Mme Stabile, M. et Mme Kobn et 3 enfants, Mme Milcnvich et 4 enfants, Palelogo, M. et Mme Aghion, Castro et 6 de fam., Blaicher, Mardulfo et 3 de fam., Menasce et 6 de famille, Mme Ades et sa fille, Cohen, Castiglioni, Col. Nikie, Mamlouk et 4 de fam., M. et Mme Moroni, Zagdoun et 6 de fam., Nahum, Israel et 9 de fam., M. et Mme Tilche, Mme Tilche et 4 enfants, M. et Mme Jabos, Lindemann et 4 de fam., Francia, Sadler, Lidy Wingate, S.E Wingate Pacha, Cottins, Fenderl, Pini Bey, Reinhardt, Kenny Herbert, Sir von 8latin Pacha, Levy, Aghion et 2 de fam., Bialobos Bey, S.E. Johnson Pacha, Mortera, Husgar, Mme Kauky et 8 enfants, M. et Mme Constantin Sava, Arthur Wilson, G. Heller, Mme Victor Aghion et 3 enfants, Mme Stakia nos et 2 fils, L Sarkissian, D. A. Rizzi Mustafa Bey Fayed, Skill, Dietterle, Vangam, Srack, Mr.
+                            Graves 11 2 28 Aghion, Greaves, Kolischkine, Michalek, et 62 , passengers de 3me classe. Watt Lester </p>
                     </div>
                     <div type="article">
-                        By kind permission of Lieut Colonel C. J. Markham commanding, and officers, 1st Battn. King’s Royal Rifle*, the Band will play the following programme of mosio by special request in the Esbekieh Gardens to-morrow (Tuesday) evening, commencing at 9 p.m.
-                        1 March-The BnlewlThe Qtrl-CerylL 1 Overton-Mlrelle-Oooood.
-                        » Oeenlee- I» Derain imoar-Ottng'1.
-                        Two-etep—Weldmera—Doeoy.
-                        S Selection—Ure Cloche* 4* Ocroertlle -PlecooeUe.
-                        T Velee—Le Premier Belem-Leroolhe.
-                        DU Wetohtpeiede Kmmnt
-                        BetlmraanjUr^ ^ tin*	.
-                        Tran* Blows.
+                        <p>By kind permission of Lieut Colonel C. J. Markham commanding, and officers, 1st Battn. King’s Royal Rifle*, the Band will play the following programme of mosio by special request in the Esbekieh Gardens to-morrow (Tuesday) evening, commencing at 9 p.m. 1 March-The BnlewlThe Qtrl-CerylL 1 Overton-Mlrelle-Oooood. » Oeenlee- I» Derain imoar-Ottng'1. Two-etep—Weldmera—Doeoy. S Selection—Ure Cloche* 4* Ocroertlle -PlecooeUe. T Velee—Le Premier Belem-Leroolhe. DU Wetohtpeiede Kmmnt BetlmraanjUr^ ^ tin* . Tran* Blows.</p>
                     </div>
                 </div>
             </div>

--- a/1905-10-03.xml
+++ b/1905-10-03.xml
@@ -30,24 +30,36 @@
         <body>
             <div type="page" n="1">
                 <head>THE EGYPTIAN GAZETTE</head>
-                <head type="sub">No. 7239] <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>, Thurdsay, October 5, 1905. [SIX PAGES P.T. 1.</head>
+                <head type="sub">No. 7239] <placeName ref="https://www.wikidata.org/wiki/Q87"
+                        >Alexandria</placeName>, Thurdsay, October 5, 1905. [SIX PAGES P.T.
+                    1.</head>
                 <div type="section" scope="advertisement">
                     <cb n="1"/>
                     <div type="item" scope="advertisement" xml:id="deg-ad-pos01">
                         <head>Peninsular and Oriental S. N. Company.</head>
                         <p>Summer Rates will be charged from 2 May to 31 October. </p>
-                        <p>For the convenience of families and others, a large portion of each ship’s
-                            accommodation has been reserved for Egypt, so that Berths can be definitely
-                            engaged at once, as if the voyage were commencing at <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>. Plans can be
-                            seen at the Offices of the Company’s Agents. </p>
-                        <p>The through Steamers for <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName> and <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> are intended to leave <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>
-                            after the arrival of the 11 a.m. train from <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> , every Tuesday for the present
-                            except the MONGOLIA, which is taking passengers to the Anglo-French Naval
-                            Review, and will not wait at <placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName>  on 24/25 July. A steam tender will meet
-                            the train to convey passengers to the ship. </p>
+                        <p>For the convenience of families and others, a large portion of each
+                            ship’s accommodation has been reserved for Egypt, so that Berths can be
+                            definitely engaged at once, as if the voyage were commencing at
+                                <placeName ref="https://www.wikidata.org/wiki/Q134509">Port
+                                Said</placeName>. Plans can be seen at the Offices of the Company’s
+                            Agents. </p>
+                        <p>The through Steamers for <placeName
+                                ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName>
+                            and <placeName ref="https://www.wikidata.org/wiki/Q84"
+                                >London</placeName> are intended to leave <placeName
+                                ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>
+                            after the arrival of the 11 a.m. train from <placeName
+                                ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> , every
+                            Tuesday for the present except the MONGOLIA, which is taking passengers
+                            to the Anglo-French Naval Review, and will not wait at <placeName
+                                ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName> on
+                            24/25 July. A steam tender will meet the train to convey passengers to
+                            the ship. </p>
                         <table>
                             <row>
-                                <cell><placeName ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName></cell>
+                                <cell><placeName ref="https://www.wikidata.org/wiki/Q79"
+                                        >Egypt</placeName></cell>
                                 <cell>4 July</cell>
                                 <cell>Arcadia </cell>
                                 <cell>1 August</cell>
@@ -67,39 +79,59 @@
                                 <cell>18 July</cell>
                                 <cell>Arabia </cell>
                                 <cell>15 August</cell>
-                                <cell><placeName ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName></cell>
+                                <cell><placeName ref="https://www.wikidata.org/wiki/Q79"
+                                        >Egypt</placeName></cell>
                                 <cell>12 Sept.</cell>
                             </row>
                             <row>
                                 <cell>Mongolia</cell>
                                 <cell>25 July</cell>
-                                <cell><placeName ref="https://www.wikidata.org/wiki/Q148">China</placeName></cell>
+                                <cell><placeName ref="https://www.wikidata.org/wiki/Q148"
+                                        >China</placeName></cell>
                                 <cell>22 August</cell>
                                 <cell>Macedonia</cell>
                                 <cell>19 Sept.</cell>
                             </row>
                         </table>
-                        <p>The Brindisi Express Steamers leave <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> directly the Indian Mails arrive.
-                            Passengers can go on board the evening before. The Fare remains as usual. </p>
+                        <p>The Brindisi Express Steamers leave <placeName
+                                ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>
+                            directly the Indian Mails arrive. Passengers can go on board the evening
+                            before. The Fare remains as usual. </p>
                         <p>For all further information apply to the Company's Agents, </p>
-                        <p>Messrs. THOS. COOK &amp; SON (Egypt) Ltd. <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> . </p>
-                        <p>GEORGE ROYLE, Esq. <placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName> . </p>
-                        <p>Messrs. HABELDEN &amp; Co. <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>. </p>
-                        <p> F. G. DAVIDSON, Superintendent P. &amp; O. S. N. Company in <placeName ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName><placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>. </p>
+                        <p>Messrs. THOS. COOK &amp; SON (Egypt) Ltd. <placeName
+                                ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> . </p>
+                        <p>GEORGE ROYLE, Esq. <placeName ref="https://www.wikidata.org/wiki/Q134509"
+                                >Port-Said</placeName> . </p>
+                        <p>Messrs. HABELDEN &amp; Co. <placeName
+                                ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>. </p>
+                        <p> F. G. DAVIDSON, Superintendent P. &amp; O. S. N. Company in <placeName
+                                ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName><placeName
+                                ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>. </p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-opl01">
                         <head>Orient-Pacific Line of Royal Mail Steamers.</head>
                         <p>REDUCED SUMMER FARES FROM MAY TO OCTOBER INCLUSIVE.</p>
-                        <p>OUTWARDS to <placeName ref="https://www.wikidata.org/wiki/Q408">Australia</placeName>.</p>
-                        <p>R.M.S. “Orotava" will leave <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName> about July 28 | R.M.S "Ormuz" will leave <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>
-                            about August 11. </p>
-                        <p>HOMEWARDS to NAPLES <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName>, GIBRALTAR, PLYMOUTH, <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName>, TILBURY</p>
-                        <p>R.M.S. "Oroya" will leave <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> about July 18 | R.M.S. “Ortona" will leave
-                            <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> about August 1</p>
+                        <p>OUTWARDS to <placeName ref="https://www.wikidata.org/wiki/Q408"
+                                >Australia</placeName>.</p>
+                        <p>R.M.S. “Orotava" will leave <placeName
+                                ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName> about
+                            July 28 | R.M.S "Ormuz" will leave <placeName
+                                ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName> about
+                            August 11. </p>
+                        <p>HOMEWARDS to NAPLES <placeName
+                                ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName>,
+                            GIBRALTAR, PLYMOUTH, <placeName ref="https://www.wikidata.org/wiki/Q84"
+                                >London</placeName>, TILBURY</p>
+                        <p>R.M.S. "Oroya" will leave <placeName
+                                ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>
+                            about July 18 | R.M.S. “Ortona" will leave <placeName
+                                ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>
+                            about August 1</p>
                         <table>
                             <row>
                                 <cell rows="4">Reduced Summer Fares</cell>
-                                <cell><placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName>  to Naples</cell>
+                                <cell><placeName ref="https://www.wikidata.org/wiki/Q134509"
+                                        >Port-Said</placeName> to Naples</cell>
                                 <cell>1st Class</cell>
                                 <cell>£ 11</cell>
                                 <cell>2nd Class</cell>
@@ -108,7 +140,10 @@
                                 <cell>£ 4.8</cell>
                             </row>
                             <row>
-                                <cell><placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName>  to <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName></cell>
+                                <cell><placeName ref="https://www.wikidata.org/wiki/Q134509"
+                                        >Port-Said</placeName> to <placeName
+                                        ref="https://www.wikidata.org/wiki/Q579613"
+                                        >Marseilles</placeName></cell>
                                 <cell>1st Class</cell>
                                 <cell>£ 12.12</cell>
                                 <cell>2nd Class</cell>
@@ -117,7 +152,8 @@
                                 <cell>£ 5.10</cell>
                             </row>
                             <row>
-                                <cell><placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName>  to Gibraltar</cell>
+                                <cell><placeName ref="https://www.wikidata.org/wiki/Q134509"
+                                        >Port-Said</placeName> to Gibraltar</cell>
                                 <cell>1st Class</cell>
                                 <cell>£ 18.0</cell>
                                 <cell>2nd Class</cell>
@@ -126,7 +162,8 @@
                                 <cell>£ 5.10</cell>
                             </row>
                             <row>
-                                <cell><placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName>  to Plymouth or Tilbury</cell>
+                                <cell><placeName ref="https://www.wikidata.org/wiki/Q134509"
+                                        >Port-Said</placeName> to Plymouth or Tilbury</cell>
                                 <cell>1st Class</cell>
                                 <cell>£ 16.16</cell>
                                 <cell>2nd Class</cell>
@@ -135,55 +172,100 @@
                                 <cell>£ 8.16</cell>
                             </row>
                         </table>
-                        <p>Egyptian Government Officials allowed a rebate of 15% off the above fares.</p>
-                        <p>Return tickets no longer issued, but passengers paying full fare in one direction
-                            allowed abatement of 1/3 fare back if return voyage be within 4 months of
-                            arrival, or abatement of 20 o/o if return voyage be made within 8 months of
-                            arrival.</p>
-                        <p>Agents. <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> :—Thos. Cook &amp; Son. <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> : —R. J. Moss &amp; Co.—For all
-                            information apply </p>
-                        <p>Wm. STAPLEDON &amp; Sons, <placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName>  &amp; PORT-TEWFIK (<placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>) 31-12-904</p>
+                        <p>Egyptian Government Officials allowed a rebate of 15% off the above
+                            fares.</p>
+                        <p>Return tickets no longer issued, but passengers paying full fare in one
+                            direction allowed abatement of 1/3 fare back if return voyage be within
+                            4 months of arrival, or abatement of 20 o/o if return voyage be made
+                            within 8 months of arrival.</p>
+                        <p>Agents. <placeName ref="https://www.wikidata.org/wiki/Q85"
+                                >Cairo</placeName> :—Thos. Cook &amp; Son. <placeName
+                                ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> : —R.
+                            J. Moss &amp; Co.—For all information apply </p>
+                        <p>Wm. STAPLEDON &amp; Sons, <placeName
+                                ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName>
+                            &amp; PORT-TEWFIK (<placeName
+                                ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>)
+                            31-12-904</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-blm01">
                         <head>BIBBY LINE MAIL STEAMERS.</head>
                         <p>Special Reduced Rates During Summer Season,</p>
-                        <p>OUTWARDS to COLOMBO, TUTICORIN, etc., and RANGOON. Departures from <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>.</p>
+                        <p>OUTWARDS to COLOMBO, TUTICORIN, etc., and RANGOON. Departures from
+                                <placeName ref="https://www.wikidata.org/wiki/Q134514"
+                                >Suez</placeName>.</p>
                         <p>S.S. Derbyshire 6,635 tons, leaves about July 20.</p>
                         <p>S.S. Lancashire 4,244 tons, leaves about August 3.</p>
-                        <p>HOMEWARDS to <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName> and <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName>. Departures from <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>.</p>
+                        <p>HOMEWARDS to <placeName ref="https://www.wikidata.org/wiki/Q579613"
+                                >Marseilles</placeName> and <placeName
+                                ref="https://www.wikidata.org/wiki/Q84">London</placeName>.
+                            Departures from <placeName ref="https://www.wikidata.org/wiki/Q134509"
+                                >Port Said</placeName>.</p>
                         <p>S.S. Worcestershire 7,160 tons, leaves about July 26.</p>
                         <p>S.S. Yorkshire 4,196 tons leaves about August 9,</p>
-                        <p>FARES from <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> to <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName> £12.0.0, <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> £17.0.0, Colombo £32.10.0,
-                            Rangoon £37.10.0. </p>
-                        <p>Agents <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> : THOS. COOK &amp; SON. <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName> &amp; <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> : WM. STAPLEDON &amp; SONS,
-                            31-12-905</p>
+                        <p>FARES from <placeName ref="https://www.wikidata.org/wiki/Q134509">Port
+                                Said</placeName> to <placeName
+                                ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName>
+                            £12.0.0, <placeName ref="https://www.wikidata.org/wiki/Q84"
+                                >London</placeName> £17.0.0, Colombo £32.10.0, Rangoon £37.10.0. </p>
+                        <p>Agents <placeName ref="https://www.wikidata.org/wiki/Q85"
+                                >Cairo</placeName> : THOS. COOK &amp; SON. <placeName
+                                ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName> &amp;
+                                <placeName ref="https://www.wikidata.org/wiki/Q134509">Port
+                                Said</placeName> : WM. STAPLEDON &amp; SONS, 31-12-905</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-kml01">
                         <head>KHEDIVIAL MAIL LINE.</head>
                         <head type="sub">FAST BRITISH PASSENGER STEAMERS</head>
-                        <head type="sub"><placeName ref="https://www.wikidata.org/wiki/Q41">Greece</placeName> - <placeName ref="https://www.wikidata.org/wiki/Q43">Turkey</placeName> LINE.</head>
-                        <p>Express Steamers leave <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> every Wednesday at 4 p.m. for PIRAEUS, SMYRNA,
-                            MITYLENE, and CONSTANTINOPLE, in connection with Orient Express train-de-luxe
-                            for Vienna, <placeName ref="https://www.wikidata.org/wiki/Q90">Paris</placeName>, and <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName>.</p>
-                        <head type="sub">PALESTINE - SYRIA LINE.</head>
-                        <p>Fast steamers leave <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> every Saturday at 6 p.m., and <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> every
-                            Sunday at 6 p.m., for JAFFA (for Jerusalem), CAIFFA (for Nazareth), BEYROUT (for
-                            Damascus), TRIPOLI, ALEXANDRETTA, MESSINA, continuing in alternate weeks to
-                            LARNACA and LIMASSOL (Cyprus).</p>
-                        <head type="sub">RED SEA LINE.</head>
-                        <p>Steamers leave <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName> fortnightly on Wednesday at 6 p.m. for JEDDAH, SUAKIN,
-                            MASSOWAH, HODBIDAH, and ADEN ; and in the intervening weeks for PORT SUDAN and
-                            SUAKIN direct. Calls will be made at TOR (for Mount Sinai) as required.</p>
-                        <p>N.B.—Deck chairs provided for the use of passengers, excellent cuisine and table
-                            wine free.</p>
-                        <p>Steamer plans may be seen and passages booked at the Company’s Agencies at
-                            <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>, <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> , <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>, and <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>, or at THOS. COOK &amp; SON or other
-                            Tourist Agency. 31-12-904</p>
+                        <head type="sub"><placeName ref="https://www.wikidata.org/wiki/Q41"
+                                >Greece</placeName> - <placeName
+                                ref="https://www.wikidata.org/wiki/Q43">Turkey</placeName>
+                            LINE.</head>
+                        <p>Express Steamers leave <placeName ref="https://www.wikidata.org/wiki/Q87"
+                                >Alexandria</placeName> every Wednesday at 4 p.m. for PIRAEUS,
+                            SMYRNA, MITYLENE, and CONSTANTINOPLE, in connection with Orient Express
+                            train-de-luxe for Vienna, <placeName
+                                ref="https://www.wikidata.org/wiki/Q90">Paris</placeName>, and
+                                <placeName ref="https://www.wikidata.org/wiki/Q84"
+                                >London</placeName>.</p>
+                        <div type="subsection">
+                            <head type="sub">PALESTINE - SYRIA LINE.</head>
+                            <p>Fast steamers leave <placeName
+                                    ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>
+                                every Saturday at 6 p.m., and <placeName
+                                    ref="https://www.wikidata.org/wiki/Q134509">Port
+                                    Said</placeName> every Sunday at 6 p.m., for JAFFA (for
+                                Jerusalem), CAIFFA (for Nazareth), BEYROUT (for Damascus), TRIPOLI,
+                                ALEXANDRETTA, MESSINA, continuing in alternate weeks to LARNACA and
+                                LIMASSOL (Cyprus).</p>
+                        </div>
+                        <div type="subsection">
+                            <head type="sub">RED SEA LINE.</head>
+                            <p>Steamers leave <placeName ref="https://www.wikidata.org/wiki/Q134514"
+                                    >Suez</placeName> fortnightly on Wednesday at 6 p.m. for JEDDAH,
+                                SUAKIN, MASSOWAH, HODBIDAH, and ADEN ; and in the intervening weeks
+                                for PORT SUDAN and SUAKIN direct. Calls will be made at TOR (for
+                                Mount Sinai) as required.</p>
+                            <p>N.B.—Deck chairs provided for the use of passengers, excellent
+                                cuisine and table wine free.</p>
+                            <p>Steamer plans may be seen and passages booked at the Company’s
+                                Agencies at <placeName ref="https://www.wikidata.org/wiki/Q87"
+                                    >Alexandria</placeName>, <placeName
+                                    ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> ,
+                                    <placeName ref="https://www.wikidata.org/wiki/Q134509">Port
+                                    Said</placeName>, and <placeName
+                                    ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>, or
+                                at THOS. COOK &amp; SON or other Tourist Agency. 31-12-904</p>
+                        </div>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-mss01">
                         <head>The Moss S.S. Company, Ltd.</head>
-                        <p>For <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName> calling at <placeName ref="https://www.wikidata.org/wiki/Q233">Malta</placeName> (Messrs. JAMES MOSS &amp; Co. 31, James St,
-                            <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName>, Managers.)</p>
+                        <p>For <placeName ref="https://www.wikidata.org/wiki/Q24826"
+                                >Liverpool</placeName> calling at <placeName
+                                ref="https://www.wikidata.org/wiki/Q233">Malta</placeName> (Messrs.
+                            JAMES MOSS &amp; Co. 31, James St, <placeName
+                                ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName>,
+                            Managers.)</p>
                         <table rows="3" cols="8">
                             <row>
                                 <cell>*Amasis</cell>
@@ -216,129 +298,217 @@
                                 <cell>(Building)</cell>
                             </row>
                         </table>
-                        <p>*Second class accommodation only, unless specially reserved.—Fares : <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>
-                            to <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName>, 1st, £14 Single, £25 Return. 2nd, £9 Single, £15 Return.—To <placeName ref="https://www.wikidata.org/wiki/Q233">Malta</placeName>,
-                            1st, £5 Single, £9 Return, 2nd, £3 Single, £5 Return.—Return tickets available
+                        <p>*Second class accommodation only, unless specially reserved.—Fares :
+                                <placeName ref="https://www.wikidata.org/wiki/Q87"
+                                >Alexandria</placeName> to <placeName
+                                ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName>,
+                            1st, £14 Single, £25 Return. 2nd, £9 Single, £15 Return.—To <placeName
+                                ref="https://www.wikidata.org/wiki/Q233">Malta</placeName>, 1st, £5
+                            Single, £9 Return, 2nd, £3 Single, £5 Return.—Return tickets available
                             for six months.</p>
-                        <p>S.S. Seti now on the berth, will sail on or about Monday, July 17, to be followed
-                            by S.S. Menes.</p>
-                        <p>S.S Tabor for Havre via <placeName ref="https://www.wikidata.org/wiki/Q233">Malta</placeName> to sail about Saturday l5th inst.</p>
-                        <p>Through freight rates on cotton, etc., to Lancashire inland towns, Boston, New
-                            York and other U.S.A. towns, obtained on application. Cargo taken by special
-                            agreement only. </p>
-                        <p>Passenger Tickets also issued inclusive of Railway fare through to and from
-                            <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> . Particulars on application to </p>
-                        <p>R. J. MOSS &amp; Co., <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>, Agents. 26-12-905</p>
+                        <p>S.S. Seti now on the berth, will sail on or about Monday, July 17, to be
+                            followed by S.S. Menes.</p>
+                        <p>S.S Tabor for Havre via <placeName
+                                ref="https://www.wikidata.org/wiki/Q233">Malta</placeName> to sail
+                            about Saturday l5th inst.</p>
+                        <p>Through freight rates on cotton, etc., to Lancashire inland towns,
+                            Boston, New York and other U.S.A. towns, obtained on application. Cargo
+                            taken by special agreement only. </p>
+                        <p>Passenger Tickets also issued inclusive of Railway fare through to and
+                            from <placeName ref="https://www.wikidata.org/wiki/Q85"
+                                >Cairo</placeName> . Particulars on application to </p>
+                        <p>R. J. MOSS &amp; Co., <placeName ref="https://www.wikidata.org/wiki/Q87"
+                                >Alexandria</placeName>, Agents. 26-12-905</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-mic01">
                         <head>MARINE INSURANCE COMPANY, LIMITED.</head>
                         <p>Established 1836. Capital £1,000,000. Reserve Fund £650,000. </p>
-                        <p>THE IMPERIAL FIRE OFFICE united with THE ALLIANCE ASSURANCE, Co., Ltd.</p>
-                        <p>1, Old Broad Street, <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName>—Estabished 1806.—Total Funds exceed £10,000,000.</p>
-                        <p>31-12-905. Policies issued at <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName> by G. BEYTS &amp; Co., Agents.</p>
+                        <p>THE IMPERIAL FIRE OFFICE united with THE ALLIANCE ASSURANCE, Co.,
+                            Ltd.</p>
+                        <p>1, Old Broad Street, <placeName ref="https://www.wikidata.org/wiki/Q84"
+                                >London</placeName>—Estabished 1806.—Total Funds exceed
+                            £10,000,000.</p>
+                        <p>31-12-905. Policies issued at <placeName
+                                ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName> by G.
+                            BEYTS &amp; Co., Agents.</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-tce01">
                         <head>Telephone Company of Egypt, Limited.</head>
-                        <p><placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> -<placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> TELEPHONE.--Rates as follows P.T. 5 for each 3 minutes, or
-                            fraction of 3 minutes; P.T. 10 for over 3 up to 8 minutes communication.</p>
-                        <p>PUBLIC CALL-OFFICES : <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> , Central Office, Opera Square, and New Bar; Helouan,
-                            Central Office, Maison Purvis ; <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>, St Mark’s Buildings, Egyptian Bar,
-                            I. Castelli &amp; Co.; Ramleh, Central Office. San Stefano Casino 30.4.906</p>
+                        <p><placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>
+                                -<placeName ref="https://www.wikidata.org/wiki/Q87"
+                                >Alexandria</placeName> TELEPHONE.--Rates as follows P.T. 5 for each
+                            3 minutes, or fraction of 3 minutes; P.T. 10 for over 3 up to 8 minutes
+                            communication.</p>
+                        <p>PUBLIC CALL-OFFICES : <placeName ref="https://www.wikidata.org/wiki/Q85"
+                                >Cairo</placeName> , Central Office, Opera Square, and New Bar;
+                            Helouan, Central Office, Maison Purvis ; <placeName
+                                ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>, St
+                            Mark’s Buildings, Egyptian Bar, I. Castelli &amp; Co.; Ramleh, Central
+                            Office. San Stefano Casino 30.4.906</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-hcl01">
                         <head>P. HENDERSON &amp; CO’s LINE.</head>
-                        <p>Steamers leave <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName> and <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> fortnightly for <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> or <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName> direct.</p>
+                        <p>Steamers leave <placeName ref="https://www.wikidata.org/wiki/Q134514"
+                                >Suez</placeName> and <placeName
+                                ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>
+                            fortnightly for <placeName ref="https://www.wikidata.org/wiki/Q84"
+                                >London</placeName> or <placeName
+                                ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName>
+                            direct.</p>
                         <p>(Electric Light.) SALOON (Amidships) FARE £12. (Latest improvements.)</p>
-                        <p>S.S. RANGOON 6000 Tons will leave <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> about July 23 for <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName>.</p>
-                        <p>S.S. BURMA 5600 Tons will leave <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> about August 6 for <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName>.</p>
-                        <p>S.S. ARRACAN 5800 Tons will leave <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> about 20 for <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName></p>
-                        <p>Due in <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> or <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName> 12 days thereafter.</p>
-                        <p>Apply WORMS &amp; Co., <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> and <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>. THOS. COOK &amp; SON, (EGYPT) LD.,
-                            <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>  ;</p>
-                        <p>G. J. GRACE &amp; CO., <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>.</p>
+                        <p>S.S. RANGOON 6000 Tons will leave <placeName
+                                ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>
+                            about July 23 for <placeName ref="https://www.wikidata.org/wiki/Q84"
+                                >London</placeName>.</p>
+                        <p>S.S. BURMA 5600 Tons will leave <placeName
+                                ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>
+                            about August 6 for <placeName ref="https://www.wikidata.org/wiki/Q84"
+                                >London</placeName>.</p>
+                        <p>S.S. ARRACAN 5800 Tons will leave <placeName
+                                ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>
+                            about 20 for <placeName ref="https://www.wikidata.org/wiki/Q24826"
+                                >Liverpool</placeName></p>
+                        <p>Due in <placeName ref="https://www.wikidata.org/wiki/Q84"
+                                >London</placeName> or <placeName
+                                ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName> 12
+                            days thereafter.</p>
+                        <p>Apply WORMS &amp; Co., <placeName
+                                ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>
+                            and <placeName ref="https://www.wikidata.org/wiki/Q134514"
+                                >Suez</placeName>. THOS. COOK &amp; SON, (EGYPT) LD., <placeName
+                                ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> ;</p>
+                        <p>G. J. GRACE &amp; CO., <placeName ref="https://www.wikidata.org/wiki/Q87"
+                                >Alexandria</placeName>.</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-tcs01">
                         <head>Thos. Cook &amp; Son,</head>
-                        <p>(EGYPT), LIMITED, HEAD OFFICE—LUDGATE CIRCUS—<placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName>.</p>
-                        <p>CHIEF EGYPTIAN OFFICE — <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> , near SHEPHEARD'S HOTEL. </p>
-                        <p><placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>, <placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName> , <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>, Luxor, Assuan, Haifa, &amp; Khartum.</p>
+                        <p>(EGYPT), LIMITED, HEAD OFFICE—LUDGATE CIRCUS—<placeName
+                                ref="https://www.wikidata.org/wiki/Q84">London</placeName>.</p>
+                        <p>CHIEF EGYPTIAN OFFICE — <placeName
+                                ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> , near
+                            SHEPHEARD'S HOTEL. </p>
+                        <p><placeName ref="https://www.wikidata.org/wiki/Q87"
+                            >Alexandria</placeName>, <placeName
+                                ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName> ,
+                                <placeName ref="https://www.wikidata.org/wiki/Q134514"
+                                >Suez</placeName>, Luxor, Assuan, Haifa, &amp; Khartum.</p>
                         <p>GENERAL RAILWAY AND STEAMSHIP AGENTS. BANKERS.</p>
                         <p>BAGGAGE AND FORWARDING AGENTS.</p>
-                        <p>Officially appointed &amp; Sole Agents in <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>  to the P.&amp;O. S.N. Co.</p>
-                        <p>RESIDENTS IN <placeName ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName>proceeding to Europe for the summer are requested to apply to
-                            our offices for information respecting their Passages, where steamer plans may
-                            be consulted and Berths secured by all Lines of Steamers to all parts of the
-                            Globe; arrangements can also be made for the collection and forwarding of their
-                            baggage and clearance at port of arrival.</p>
+                        <p>Officially appointed &amp; Sole Agents in <placeName
+                                ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> to the
+                            P.&amp;O. S.N. Co.</p>
+                        <p>RESIDENTS IN <placeName ref="https://www.wikidata.org/wiki/Q79"
+                                >Egypt</placeName>proceeding to Europe for the summer are requested
+                            to apply to our offices for information respecting their Passages, where
+                            steamer plans may be consulted and Berths secured by all Lines of
+                            Steamers to all parts of the Globe; arrangements can also be made for
+                            the collection and forwarding of their baggage and clearance at port of
+                            arrival.</p>
                         <p>CIRCULAR NOTES issued payable at the current rate of exchange in all the
-                            principal cities of Europe. Cook’s Interpreters in uniform are present at the
-                            principal Railway stations and Landing-places in Europe to assist passengers
-                            holding their travelling tickets.</p>
-                        <p>Large and splendidly appointed steamers belonging to the Co. leave <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>  thrice
-                            weekly, between November and March, for Luxor, Assouan and Wady-Halfa in
-                            connection with trains de luxe to Khartoum. Moderate fares. </p>
-                        <p>FREIGHT SERVICE, Steamers leave <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>  every Saturday and Tuesday for Assouan and
-                            Halfa.</p>
+                            principal cities of Europe. Cook’s Interpreters in uniform are present
+                            at the principal Railway stations and Landing-places in Europe to assist
+                            passengers holding their travelling tickets.</p>
+                        <p>Large and splendidly appointed steamers belonging to the Co. leave
+                                <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>
+                            thrice weekly, between November and March, for Luxor, Assouan and
+                            Wady-Halfa in connection with trains de luxe to Khartoum. Moderate
+                            fares. </p>
+                        <p>FREIGHT SERVICE, Steamers leave <placeName
+                                ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> every
+                            Saturday and Tuesday for Assouan and Halfa.</p>
                         <p>Special Steamers and Dahabeahs for private parties.</p>
-                        <p>Special arrangements for tour in PALESTINE, SYRIA and the DESERT, Lowest Rates.</p>
+                        <p>Special arrangements for tour in PALESTINE, SYRIA and the DESERT, Lowest
+                            Rates.</p>
                         <p>Best camp equipment in the country! 10 12-904 </p>
                     </div>
                     <cb n="2"/>
                     <div type="item" scope="advertisement" xml:id="deg-ad-bis01">
-                        <head>British <placeName ref="https://www.wikidata.org/wiki/Q668">India</placeName> S. N. Company, Limited.</head>
+                        <head>British <placeName ref="https://www.wikidata.org/wiki/Q668"
+                                >India</placeName> S. N. Company, Limited.</head>
                         <p>MAIL AND PASSENGER STEAM SHIPS.</p>
-                        <p>SAILINGS FROM <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>, <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> and CALCUTTA LINE.</p>
-                        <p>Calling at ADEN, COLOMBO and MADRAS Outward, and <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName> (GENOA and PLYMOUTH
-                            optional) Homeward. </p>
-                        <p>Fortnightly Service in connection with the Co's Indian Mail Lines and monthly
-                            with the East African Mail Line between ADEN, MOMBASSA and Zanzibar. </p>
+                        <p>SAILINGS FROM <placeName ref="https://www.wikidata.org/wiki/Q134514"
+                                >Suez</placeName>, <placeName
+                                ref="https://www.wikidata.org/wiki/Q84">London</placeName> and
+                            CALCUTTA LINE.</p>
+                        <p>Calling at ADEN, COLOMBO and MADRAS Outward, and <placeName
+                                ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName>
+                            (GENOA and PLYMOUTH optional) Homeward. </p>
+                        <p>Fortnightly Service in connection with the Co's Indian Mail Lines and
+                            monthly with the East African Mail Line between ADEN, MOMBASSA and
+                            Zanzibar. </p>
                         <p>OUTWARD.—S.S. Fazilka ... July 22 | HOMEWARD.—S.S. Mombassa ... July 21 </p>
-                        <p>Queensland Line of Steamers Between <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> and Brisbane.</p>
+                        <p>Queensland Line of Steamers Between <placeName
+                                ref="https://www.wikidata.org/wiki/Q84">London</placeName> and
+                            Brisbane.</p>
                         <p>Calling at Colombo, Batavia, Cooktown, Townsville, and Rockhamptom.</p>
-                        <p>The S.S. .................. will sail from <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName> on about ..................</p>
+                        <p>The S.S. .................. will sail from <placeName
+                                ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName> on
+                            about ..................</p>
                         <table rows="2" cols="9">
                             <row>
-                                <cell>First Class Fares from <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName> to</cell>
+                                <cell>First Class Fares from <placeName
+                                        ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>
+                                    to</cell>
                                 <cell>Aden</cell>
                                 <cell>£11. 8</cell>
                                 <cell>Colombo</cell>
                                 <cell>£14.14</cell>
                                 <cell>Calcutta</cell>
                                 <cell>£31. 0</cell>
-                                <cell><placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName></cell>
+                                <cell><placeName ref="https://www.wikidata.org/wiki/Q579613"
+                                        >Marseilles</placeName></cell>
                                 <cell>£15.12</cell>
                             </row>
                             <row>
                                 <cell/>
-                                <cell><placeName ref="https://www.wikidata.org/wiki/Q1156">Bombay</placeName></cell>
+                                <cell><placeName ref="https://www.wikidata.org/wiki/Q1156"
+                                        >Bombay</placeName></cell>
                                 <cell>£31.10</cell>
                                 <cell>Madras</cell>
                                 <cell>£xx.11</cell>
                                 <cell>Genoa</cell>
                                 <cell>£13.10</cell>
-                                <cell><placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName></cell>
+                                <cell><placeName ref="https://www.wikidata.org/wiki/Q84"
+                                        >London</placeName></cell>
                                 <cell>£19. 0</cell>
                             </row>
                         </table>
-                        <p>From <placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName>  £2 less Homeward, and £2 more Outward. Second class, two thirds of
-                            1st Class Fares.</p>
-                        <p>Agents at <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>, for the <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName>, Calcutta and Persian Gulf Lines, Messrs.
-                            Worms &amp; Co.</p>
-                        <p>Agents at <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>, for the <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> and Queensland Line, Messrs. Wills &amp; Co.,
-                            Limited.</p>
-                        <p>Messrs. Thos. Cook &amp; Son and the Anglo-American Hotel &amp; Steamer Company,
-                            <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>  &amp; <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>.</p>
-                        <p>For further particulars. Freight and Passage apply to G. BEYTS &amp; Co. Agents,
-                            <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>. 31-12-905</p>
+                        <p>From <placeName ref="https://www.wikidata.org/wiki/Q134509"
+                                >Port-Said</placeName> £2 less Homeward, and £2 more Outward. Second
+                            class, two thirds of 1st Class Fares.</p>
+                        <p>Agents at <placeName ref="https://www.wikidata.org/wiki/Q134509">Port
+                                Said</placeName>, for the <placeName
+                                ref="https://www.wikidata.org/wiki/Q84">London</placeName>, Calcutta
+                            and Persian Gulf Lines, Messrs. Worms &amp; Co.</p>
+                        <p>Agents at <placeName ref="https://www.wikidata.org/wiki/Q134509">Port
+                                Said</placeName>, for the <placeName
+                                ref="https://www.wikidata.org/wiki/Q84">London</placeName> and
+                            Queensland Line, Messrs. Wills &amp; Co., Limited.</p>
+                        <p>Messrs. Thos. Cook &amp; Son and the Anglo-American Hotel &amp; Steamer
+                            Company, <placeName ref="https://www.wikidata.org/wiki/Q85"
+                                >Cairo</placeName> &amp; <placeName
+                                ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>.</p>
+                        <p>For further particulars. Freight and Passage apply to G. BEYTS &amp; Co.
+                            Agents, <placeName ref="https://www.wikidata.org/wiki/Q134514"
+                                >Suez</placeName>. 31-12-905</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-all01">
                         <head>ANCHOR LINE, LIMITED.</head>
-                        <p>(HENDERSON BROTHERS,) <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName>, <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName> AND GLASGOW.</p>
-                        <p>Booking Passengers and Cargo through to Ports in <placeName ref="https://www.wikidata.org/wiki/Q668">India</placeName>, Europe &amp; America</p>
-                        <p>First class passengers steamers. Sailing fortnightly from <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>.</p>
+                        <p>(HENDERSON BROTHERS,) <placeName ref="https://www.wikidata.org/wiki/Q84"
+                                >London</placeName>, <placeName
+                                ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName> AND
+                            GLASGOW.</p>
+                        <p>Booking Passengers and Cargo through to Ports in <placeName
+                                ref="https://www.wikidata.org/wiki/Q668">India</placeName>, Europe
+                            &amp; America</p>
+                        <p>First class passengers steamers. Sailing fortnightly from <placeName
+                                ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>.</p>
                         <table rows="2" cols="6">
                             <row>
-                                <cell>For <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName> &amp; <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName></cell>
+                                <cell>For <placeName ref="https://www.wikidata.org/wiki/Q579613"
+                                        >Marseilles</placeName> &amp; <placeName
+                                        ref="https://www.wikidata.org/wiki/Q24826"
+                                        >Liverpool</placeName></cell>
                                 <cell>S.S. “Bohemia”</cell>
                                 <cell>July 26</cell>
                                 <cell>For CALCUTTA</cell>
@@ -346,45 +516,73 @@
                                 <cell>August 3</cell>
                             </row>
                             <row>
-                                <cell>For <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName></cell>
+                                <cell>For <placeName ref="https://www.wikidata.org/wiki/Q84"
+                                        >London</placeName></cell>
                                 <cell>S.S. “Persia"</cell>
                                 <cell>July 28</cell>
-                                <cell>For <placeName ref="https://www.wikidata.org/wiki/Q1156">Bombay</placeName></cell>
-                                <cell>S.S. "<placeName ref="https://www.wikidata.org/wiki/Q408">Australia</placeName>"</cell>
+                                <cell>For <placeName ref="https://www.wikidata.org/wiki/Q1156"
+                                        >Bombay</placeName></cell>
+                                <cell>S.S. "<placeName ref="https://www.wikidata.org/wiki/Q408"
+                                        >Australia</placeName>"</cell>
                                 <cell>July 23</cell>
                             </row>
                         </table>
-                        <p>Saloon Fares: from <placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName> , to Gibraltar £9; <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName> £9: <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName> (all sea
-                            route) £15; <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> (all sea route) £ 12 <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> via <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName> £15.5.0.
-                            Passengers embarking at <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName> £2 more, 10 % reduction for officers of army of
-                            Occupation and Government employés. Through tickets issued to New-York (via
-                            Glasgow). Fares on application. </p>
-                        <p> Agents in <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> , Messrs. Thos. Cook &amp; Son. <placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName> , Messrs. Cory Brothers
-                            &amp; Co., Ltd.</p>
-                        <p>For further partienlan of Freight or Passage apply to G. BEYTS &amp; Co., <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>.
-                            31-12-905</p>
+                        <p>Saloon Fares: from <placeName ref="https://www.wikidata.org/wiki/Q134509"
+                                >Port-Said</placeName> , to Gibraltar £9; <placeName
+                                ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName>
+                            £9: <placeName ref="https://www.wikidata.org/wiki/Q24826"
+                                >Liverpool</placeName> (all sea route) £15; <placeName
+                                ref="https://www.wikidata.org/wiki/Q84">London</placeName> (all sea
+                            route) £ 12 <placeName ref="https://www.wikidata.org/wiki/Q84"
+                                >London</placeName> via <placeName
+                                ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName>
+                            £15.5.0. Passengers embarking at <placeName
+                                ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName> £2
+                            more, 10 % reduction for officers of army of Occupation and Government
+                            employés. Through tickets issued to New-York (via Glasgow). Fares on
+                            application. </p>
+                        <p> Agents in <placeName ref="https://www.wikidata.org/wiki/Q85"
+                                >Cairo</placeName> , Messrs. Thos. Cook &amp; Son. <placeName
+                                ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName> ,
+                            Messrs. Cory Brothers &amp; Co., Ltd.</p>
+                        <p>For further partienlan of Freight or Passage apply to G. BEYTS &amp; Co.,
+                                <placeName ref="https://www.wikidata.org/wiki/Q134514"
+                                >Suez</placeName>. 31-12-905</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-dll01">
                         <head>Deutsche Levante-Linie.</head>
-                        <p>Mail and Passenger Steamships. Regular three-weekly Service from <lb/> HAMBURG,
-                            via ANTWERP &amp; <placeName ref="https://www.wikidata.org/wiki/Q233">Malta</placeName>, to <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> and vice-versa, admitting<lb/> goods from
-                            all chief German Railway Stations on direct Bill of Landing to<lb/> <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>
-                            and all chief ports of Egypt, Syria, etc., at favourable through<lb/> rates of
-                            DEUTSCHE <lb/> VERKEHR (traffic).</p>
-                        <p>EXPECTED AT <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>.</p>
+                        <p>Mail and Passenger Steamships. Regular three-weekly Service from <lb/>
+                            HAMBURG, via ANTWERP &amp; <placeName
+                                ref="https://www.wikidata.org/wiki/Q233">Malta</placeName>, to
+                                <placeName ref="https://www.wikidata.org/wiki/Q87"
+                                >Alexandria</placeName> and vice-versa, admitting<lb/> goods from
+                            all chief German Railway Stations on direct Bill of Landing to<lb/>
+                            <placeName ref="https://www.wikidata.org/wiki/Q87"
+                                >Alexandria</placeName> and all chief ports of Egypt, Syria, etc.,
+                            at favourable through<lb/> rates of DEUTSCHE <lb/> VERKEHR
+                            (traffic).</p>
+                        <p>EXPECTED AT <placeName ref="https://www.wikidata.org/wiki/Q87"
+                                >Alexandria</placeName>.</p>
                         <p>S.S. Lesbos July 20 from Antwerp.</p>
                         <p>S.S. Androos July 20 from Hamburg bound for Beyrout.</p>
                         <p>S.S. Lemnos July 31 from Hamburg bound for Beyrout.</p>
-                        <p>For tariff and particulars apply to ADOLPHE STROSS, <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>, Agent. </p>
+                        <p>For tariff and particulars apply to ADOLPHE STROSS, <placeName
+                                ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>,
+                            Agent. </p>
                         <p>15-2-905 </p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-mma01">
                         <head>Messageries Maritimes.</head>
-                        <p>From <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName></p>
+                        <p>From <placeName ref="https://www.wikidata.org/wiki/Q87"
+                                >Alexandria</placeName></p>
                         <table rows="12" cols="6">
-                            <head><hi rend="bold">Sailing from <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> in July, 1905.</hi></head>
+                            <head><hi rend="bold">Sailing from <placeName
+                                        ref="https://www.wikidata.org/wiki/Q87"
+                                        >Alexandria</placeName> in July, 1905.</hi></head>
                             <row>
-                                <cell cols="6"><hi rend="bold">For <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName> direct</hi></cell>
+                                <cell cols="6"><hi rend="bold">For <placeName
+                                            ref="https://www.wikidata.org/wiki/Q579613"
+                                            >Marseilles</placeName> direct</hi></cell>
                             </row>
                             <row>
                                 <cell>Friday</cell>
@@ -427,7 +625,9 @@
                                 <cell>Capt. Vincenti</cell>
                             </row>
                             <row>
-                                <cell cols="6"><hi rend="bold">For <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> and Beyrouth</hi></cell>
+                                <cell cols="6"><hi rend="bold">For <placeName
+                                            ref="https://www.wikidata.org/wiki/Q134509">Port
+                                            Said</placeName> and Beyrouth</hi></cell>
                             </row>
                             <row>
                                 <cell>Thursday</cell>
@@ -446,7 +646,9 @@
                                 <cell>Capt. Aillaud</cell>
                             </row>
                             <row>
-                                <cell cols="6"><hi rend="bold">For <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>, Jaffa and Beyrouth</hi></cell>
+                                <cell cols="6"><hi rend="bold">For <placeName
+                                            ref="https://www.wikidata.org/wiki/Q134509">Port
+                                            Said</placeName>, Jaffa and Beyrouth</hi></cell>
                             </row>
                             <row>
                                 <cell>Thursday</cell>
@@ -474,61 +676,97 @@
                                 <cell>2nd Class</cell>
                             </row>
                             <row>
-                                <cell>From <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> or <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> (directly or via <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>) To
-                                    <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName></cell>
+                                <cell>From <placeName ref="https://www.wikidata.org/wiki/Q87"
+                                        >Alexandria</placeName> or <placeName
+                                        ref="https://www.wikidata.org/wiki/Q134509">Port
+                                        Said</placeName> (directly or via <placeName
+                                        ref="https://www.wikidata.org/wiki/Q87"
+                                        >Alexandria</placeName>) To <placeName
+                                        ref="https://www.wikidata.org/wiki/Q579613"
+                                        >Marseilles</placeName></cell>
                                 <cell>£12.9.8 </cell>
                                 <cell>£9.10.3</cell>
                             </row>
                             <row>
-                                <cell>From <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> To <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName></cell>
+                                <cell>From <placeName ref="https://www.wikidata.org/wiki/Q87"
+                                        >Alexandria</placeName> To <placeName
+                                        ref="https://www.wikidata.org/wiki/Q134509">Port
+                                        Said</placeName></cell>
                                 <cell>£1.15.10</cell>
                                 <cell>£1.7.10</cell>
                             </row>
                             <row>
-                                <cell>From <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> to Jaffa</cell>
+                                <cell>From <placeName ref="https://www.wikidata.org/wiki/Q87"
+                                        >Alexandria</placeName> to Jaffa</cell>
                                 <cell>£3.3.5</cell>
                                 <cell>£2.2.5</cell>
                             </row>
                             <row>
-                                <cell>From <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> to Beyrouth</cell>
+                                <cell>From <placeName ref="https://www.wikidata.org/wiki/Q87"
+                                        >Alexandria</placeName> to Beyrouth</cell>
                                 <cell>£4.7.2</cell>
                                 <cell>£3.3.2.</cell>
                             </row>
                             <row>
-                                <cell>Through tickets for <placeName ref="https://www.wikidata.org/wiki/Q90">Paris</placeName> (via <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName> from <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>) </cell>
+                                <cell>Through tickets for <placeName
+                                        ref="https://www.wikidata.org/wiki/Q90">Paris</placeName>
+                                    (via <placeName ref="https://www.wikidata.org/wiki/Q579613"
+                                        >Marseilles</placeName> from <placeName
+                                        ref="https://www.wikidata.org/wiki/Q87"
+                                        >Alexandria</placeName>) </cell>
                                 <cell>£15.12.1</cell>
                                 <cell>£10.12.5</cell>
                             </row>
                             <row>
-                                <cell>Through tickets for <placeName ref="https://www.wikidata.org/wiki/Q90">Paris</placeName> (via <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName>) from <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> (directly or
-                                    via <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>) </cell>
+                                <cell>Through tickets for <placeName
+                                        ref="https://www.wikidata.org/wiki/Q90">Paris</placeName>
+                                    (via <placeName ref="https://www.wikidata.org/wiki/Q579613"
+                                        >Marseilles</placeName>) from <placeName
+                                        ref="https://www.wikidata.org/wiki/Q134509">Port
+                                        Said</placeName> (directly or via <placeName
+                                        ref="https://www.wikidata.org/wiki/Q87"
+                                        >Alexandria</placeName>) </cell>
                                 <cell>£16.5.11</cell>
                                 <cell>£12.1.5</cell>
                             </row>
                             <row>
-                                <cell>Through tickets for <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> (via <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName>) (Calais-Douvree) from
-                                    <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> or <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> (directly or via <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>)</cell>
+                                <cell>Through tickets for <placeName
+                                        ref="https://www.wikidata.org/wiki/Q84">London</placeName>
+                                    (via <placeName ref="https://www.wikidata.org/wiki/Q579613"
+                                        >Marseilles</placeName>) (Calais-Douvree) from <placeName
+                                        ref="https://www.wikidata.org/wiki/Q87"
+                                        >Alexandria</placeName> or <placeName
+                                        ref="https://www.wikidata.org/wiki/Q134509">Port
+                                        Said</placeName> (directly or via <placeName
+                                        ref="https://www.wikidata.org/wiki/Q87"
+                                        >Alexandria</placeName>)</cell>
                                 <cell>£16.12.10</cell>
                                 <cell>£12.9.8</cell>
                             </row>
                             <row>
-                                <cell>Interchangeable return tickets with the Austrian Lloyd Cy. (available
-                                    one way by Messageries</cell>
+                                <cell>Interchangeable return tickets with the Austrian Lloyd Cy.
+                                    (available one way by Messageries</cell>
                                 <cell>£21.11.10</cell>
                                 <cell>£15.11.2</cell>
                             </row>
                         </table>
                         <table rend="frame" xml:id="SailingfromPortSaid">
-                            <head><hi rend="bold">Sailing from <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> in July, 1905</hi></head>
+                            <head><hi rend="bold">Sailing from <placeName
+                                        ref="https://www.wikidata.org/wiki/Q134509">Port
+                                        Said</placeName> in July, 1905</hi></head>
                             <row>
-                                <cell rows="5">For <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName> Direct</cell>
+                                <cell rows="5">For <placeName
+                                        ref="https://www.wikidata.org/wiki/Q579613"
+                                        >Marseilles</placeName> Direct</cell>
                                 <cell>Probably on</cell>
                                 <cell>Thursday</cell>
                                 <cell>6</cell>
                                 <cell>July</cell>
                                 <cell>Polynesien</cell>
                                 <cell>Capt. Broc</cell>
-                                <cell>returning from <placeName ref="https://www.wikidata.org/wiki/Q1239">Indian Ocean</placeName></cell>
+                                <cell>returning from <placeName
+                                        ref="https://www.wikidata.org/wiki/Q1239">Indian
+                                        Ocean</placeName></cell>
                             </row>
                             <row>
                                 <cell>Probably on</cell>
@@ -537,7 +775,9 @@
                                 <cell>July</cell>
                                 <cell>Iraouaddy</cell>
                                 <cell>Capt. Riquier</cell>
-                                <cell>returning from <placeName ref="https://www.wikidata.org/wiki/Q148">China</placeName></cell>
+                                <cell>returning from <placeName
+                                        ref="https://www.wikidata.org/wiki/Q148"
+                                    >China</placeName></cell>
                             </row>
                             <row>
                                 <cell>Probably on</cell>
@@ -546,7 +786,9 @@
                                 <cell>July</cell>
                                 <cell>Caledonian</cell>
                                 <cell>Capt. Grégory</cell>
-                                <cell>returning from <placeName ref="https://www.wikidata.org/wiki/Q1239">Indian Ocean</placeName></cell>
+                                <cell>returning from <placeName
+                                        ref="https://www.wikidata.org/wiki/Q1239">Indian
+                                        Ocean</placeName></cell>
                             </row>
                             <row>
                                 <cell>Probably on</cell>
@@ -555,7 +797,9 @@
                                 <cell>July</cell>
                                 <cell>Natal</cell>
                                 <cell>Capt. Fabre</cell>
-                                <cell>returning from <placeName ref="https://www.wikidata.org/wiki/Q148">China</placeName></cell>
+                                <cell>returning from <placeName
+                                        ref="https://www.wikidata.org/wiki/Q148"
+                                    >China</placeName></cell>
                             </row>
                             <row>
                                 <cell>Probably on</cell>
@@ -564,14 +808,18 @@
                                 <cell>July</cell>
                                 <cell>Ville de la Ciatat</cell>
                                 <cell>Capt. Etienne</cell>
-                                <cell>returning from <placeName ref="https://www.wikidata.org/wiki/Q408">Australia</placeName></cell>
+                                <cell>returning from <placeName
+                                        ref="https://www.wikidata.org/wiki/Q408"
+                                        >Australia</placeName></cell>
                             </row>
                         </table>
                         <table rend="frame" xml:id="SailingfromSuez">
-                            <head><hi rend="bold">Sailing from <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName> in July, 1905</hi></head>
+                            <head><hi rend="bold">Sailing from <placeName
+                                        ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>
+                                    in July, 1905</hi></head>
                             <row>
-                                <cell rows="2">For Aden, Colombo, Singapore, Saigon, Hong-Kong, Shanghai,
-                                    Kobe and Yokohama</cell>
+                                <cell rows="2">For Aden, Colombo, Singapore, Saigon, Hong-Kong,
+                                    Shanghai, Kobe and Yokohama</cell>
                                 <cell>Saturday</cell>
                                 <cell>1</cell>
                                 <cell>July</cell>
@@ -586,8 +834,8 @@
                                 <cell>Capt. Bourdon</cell>
                             </row>
                             <row>
-                                <cell>For Djibouti, Colombo, Singapore, Saigon, Hong-Kong, Shanghai, Kobe
-                                    and Yokohama</cell>
+                                <cell>For Djibouti, Colombo, Singapore, Saigon, Hong-Kong, Shanghai,
+                                    Kobe and Yokohama</cell>
                                 <cell>Saturday</cell>
                                 <cell>15</cell>
                                 <cell>July</cell>
@@ -595,8 +843,8 @@
                                 <cell>Capt. Guionnet</cell>
                             </row>
                             <row>
-                                <cell>For Djibouti, Zanzibar, Mutsamudu, Mayotte, Majunga, Nossi-Bé, D.
-                                    Suares, Tamatave, La Réunion and Maurice</cell>
+                                <cell>For Djibouti, Zanzibar, Mutsamudu, Mayotte, Majunga, Nossi-Bé,
+                                    D. Suares, Tamatave, La Réunion and Maurice</cell>
                                 <cell>Sunday</cell>
                                 <cell>16</cell>
                                 <cell>July</cell>
@@ -604,8 +852,8 @@
                                 <cell>Capt. Jourdan</cell>
                             </row>
                             <row>
-                                <cell rows="2">For Djibouti, Aden, Mabé Diego-Suares, Ste. Marie, Tamatave,
-                                    La Réunion and Maurice</cell>
+                                <cell rows="2">For Djibouti, Aden, Mabé Diego-Suares, Ste. Marie,
+                                    Tamatave, La Réunion and Maurice</cell>
                                 <cell>Saturday</cell>
                                 <cell>1</cell>
                                 <cell>July</cell>
@@ -620,8 +868,9 @@
                                 <cell>Capt. Riquier</cell>
                             </row>
                             <row>
-                                <cell>For Aden, <placeName ref="https://www.wikidata.org/wiki/Q1156">Bombay</placeName>, Colombo, Freemantle, Adelaide, Melbourne, Sidney, and
-                                    Noumes</cell>
+                                <cell>For Aden, <placeName ref="https://www.wikidata.org/wiki/Q1156"
+                                        >Bombay</placeName>, Colombo, Freemantle, Adelaide,
+                                    Melbourne, Sidney, and Noumes</cell>
                                 <cell>Monday</cell>
                                 <cell>10</cell>
                                 <cell>July</cell>
@@ -629,7 +878,8 @@
                                 <cell>Capt. Boyer</cell>
                             </row>
                         </table>
-                        <p><placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>  Agency (Shepheard's Hotel) 28-2-905</p>
+                        <p><placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>
+                            Agency (Shepheard's Hotel) 28-2-905</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-pri01">
                         <head>Prince Line.</head>
@@ -764,8 +1014,13 @@
                             </row>
                         </table>
                         <p>Good Accommodation for Passengers.</p>
-                        <p>Sailings every 10 days from Manchester and <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName> and fortnightly from Antwerp
-                            and <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> to <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> and Syrian Coast. The dates are approximate</p>
+                        <p>Sailings every 10 days from Manchester and <placeName
+                                ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName> and
+                            fortnightly from Antwerp and <placeName
+                                ref="https://www.wikidata.org/wiki/Q84">London</placeName> to
+                                <placeName ref="https://www.wikidata.org/wiki/Q87"
+                                >Alexandria</placeName> and Syrian Coast. The dates are
+                            approximate</p>
                         <table rows="4" cols="8">
                             <row>
                                 <cell>OCEAN PRINCE</cell>
@@ -780,11 +1035,15 @@
                             <row>
                                 <cell>PERSIAN PRINCE</cell>
                                 <cell>due from</cell>
-                                <cell>Antwerp &amp; <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName></cell>
+                                <cell>Antwerp &amp; <placeName
+                                        ref="https://www.wikidata.org/wiki/Q84"
+                                    >London</placeName></cell>
                                 <cell>July 23</cell>
                                 <cell>CARIB PRINCE</cell>
                                 <cell>due from</cell>
-                                <cell>Antwerp &amp; <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName></cell>
+                                <cell>Antwerp &amp; <placeName
+                                        ref="https://www.wikidata.org/wiki/Q84"
+                                    >London</placeName></cell>
                                 <cell>August 15</cell>
                             </row>
                             <row>
@@ -800,17 +1059,23 @@
                             <row>
                                 <cell>TROJAN PRINCE</cell>
                                 <cell>due from</cell>
-                                <cell>Antwerp &amp; <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName></cell>
+                                <cell>Antwerp &amp; <placeName
+                                        ref="https://www.wikidata.org/wiki/Q84"
+                                    >London</placeName></cell>
                                 <cell>July 31</cell>
                                 <cell>CREOLE PRINCE</cell>
                                 <cell>due from</cell>
-                                <cell>Antwerp &amp; <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName></cell>
+                                <cell>Antwerp &amp; <placeName
+                                        ref="https://www.wikidata.org/wiki/Q84"
+                                    >London</placeName></cell>
                                 <cell>August 29</cell>
                             </row>
                         </table>
-                        <p>HOMEWARD SAILINGS: -- The S.S. SPARTAN PRINCE is now loading for Manchester.</p>
-                        <p>For terms of freight or passage apply to C. J. Grace &amp; Co., <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>,
-                            Agents. 31-12-904</p>
+                        <p>HOMEWARD SAILINGS: -- The S.S. SPARTAN PRINCE is now loading for
+                            Manchester.</p>
+                        <p>For terms of freight or passage apply to C. J. Grace &amp; Co.,
+                                <placeName ref="https://www.wikidata.org/wiki/Q87"
+                                >Alexandria</placeName>, Agents. 31-12-904</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-nml01">
                         <head>THE NATIONAL MUTUAL LIFE ASSOCIATION OF AUSTRALASIA, LIMITED.</head>
@@ -818,8 +1083,8 @@
                         <p>With Profits Distributed every 3 Years. </p>
                         <p>Nearest Age 30.-Sun Assured £1,000.-Payable at age 50.</p>
                         <p>ANNUAL PREMIUM £47:18:4 TOTAL COST £958:6:8</p>
-                        <p>Minimum Return Over Cost exclusive of Bonuses £41:13:4. Several options at the
-                            end of 20 years. Guaranteed benefits during 20 years.</p>
+                        <p>Minimum Return Over Cost exclusive of Bonuses £41:13:4. Several options
+                            at the end of 20 years. Guaranteed benefits during 20 years.</p>
                         <table rend="frame">
                             <row>
                                 <cell/>
@@ -858,7 +1123,8 @@
                             </row>
                         </table>
                         <p>Full particulars on application to</p>
-                        <p>AGENTS IN <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> :</p>
+                        <p>AGENTS IN <placeName ref="https://www.wikidata.org/wiki/Q85"
+                                >Cairo</placeName> :</p>
                         <p>S. &amp; A. DE BILINSKI,</p>
                         <p>Khedivial Bourse Court.</p>
                         <p>LOW RATES. LIBERAL CONTRACTS. LARGE BONUSES.</p>
@@ -866,37 +1132,57 @@
                     <div type="item" scope="advertisement" xml:id="deg-ad-bal01">
                         <head>BANK OF ATHENS, LIMITED.</head>
                         <p><hi rend="bold">Capital 20,000,000 (Fully paid up).</hi></p>
-                        <p>BRANCHES: <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> 55-56 Bishops gate-street Within-<placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>, <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> ,
-                            Constantinople, Smyrna, At Candia and throughout <placeName ref="https://www.wikidata.org/wiki/Q41">Greece</placeName>.</p>
-                        <p>The Bank undertakes all banking business in Egypt, <placeName ref="https://www.wikidata.org/wiki/Q41">Greece</placeName>,<lb/> etc.
-                            Interest, on cash deposits: 3 0/0 per ann. at sight; 3 1/2 0/0 <lb/> per
-                            ann. for 6 months ; 4 0/0 per ann. for 12 months ; 5 0/0 per<lb/> ann.
-                            for 3 years and over. Savings Bank Branch receives de-<lb/>posits at 3
-                            1/2 0/0 per ann., from P.T. 30 to P.T. 10,000. 23538-19-1.905</p>
+                        <p>BRANCHES: <placeName ref="https://www.wikidata.org/wiki/Q84"
+                                >London</placeName> 55-56 Bishops gate-street Within-<placeName
+                                ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>,
+                                <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>
+                            , Constantinople, Smyrna, At Candia and throughout <placeName
+                                ref="https://www.wikidata.org/wiki/Q41">Greece</placeName>.</p>
+                        <p>The Bank undertakes all banking business in Egypt, <placeName
+                                ref="https://www.wikidata.org/wiki/Q41">Greece</placeName>,<lb/>
+                            etc. Interest, on cash deposits: 3 0/0 per ann. at sight; 3 1/2 0/0
+                            <lb/> per ann. for 6 months ; 4 0/0 per ann. for 12 months ; 5 0/0
+                            per<lb/> ann. for 3 years and over. Savings Bank Branch receives
+                            de-<lb/>posits at 3 1/2 0/0 per ann., from P.T. 30 to P.T. 10,000.
+                            23538-19-1.905</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-iob01">
                         <head>IMPERIAL OTTOMAN BANK.</head>
                         <p>CAPITAL: £10,000,000.</p>
-                        <p>HEAD OFFIOE IN CONSTANTINOPLE. CHIEF AGENCIES: <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> &amp; <placeName ref="https://www.wikidata.org/wiki/Q90">Paris</placeName>.</p>
-                        <p>BRANCHES IN ALL THE PRINCIPAL TOWNS IN <placeName ref="https://www.wikidata.org/wiki/Q43">Turkey</placeName>.</p>
-                        <p>Agencies in <placeName ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName>: <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>, <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> , &amp; <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>.</p>
-                        <p>Advances on Merchandise and Securities in current account and for fixed periods.
-                            Purchase and sale of stocks and Shares on the <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> and Continental exchanges,
-                            letters of credit issued, valuables reoeived in safe custody. Drafts, cheques
-                            and telegraphic transfers issued on the principal towns of the world. Foreign
-                            exchange purchased, bills discounted, bills, invoices, annuities and dividends
-                            collected and every description of banking business transacted. 18-4-906</p>
+                        <p>HEAD OFFIOE IN CONSTANTINOPLE. CHIEF AGENCIES: <placeName
+                                ref="https://www.wikidata.org/wiki/Q84">London</placeName> &amp;
+                                <placeName ref="https://www.wikidata.org/wiki/Q90"
+                            >Paris</placeName>.</p>
+                        <p>BRANCHES IN ALL THE PRINCIPAL TOWNS IN <placeName
+                                ref="https://www.wikidata.org/wiki/Q43">Turkey</placeName>.</p>
+                        <p>Agencies in <placeName ref="https://www.wikidata.org/wiki/Q79"
+                                >Egypt</placeName>: <placeName
+                                ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>,
+                                <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>
+                            , &amp; <placeName ref="https://www.wikidata.org/wiki/Q134509">Port
+                                Said</placeName>.</p>
+                        <p>Advances on Merchandise and Securities in current account and for fixed
+                            periods. Purchase and sale of stocks and Shares on the <placeName
+                                ref="https://www.wikidata.org/wiki/Q84">London</placeName> and
+                            Continental exchanges, letters of credit issued, valuables reoeived in
+                            safe custody. Drafts, cheques and telegraphic transfers issued on the
+                            principal towns of the world. Foreign exchange purchased, bills
+                            discounted, bills, invoices, annuities and dividends collected and every
+                            description of banking business transacted. 18-4-906</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-sgr01">
                         <head>SUDAN GOVERNMENT RAILWAYS.</head>
-                        <p><placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> -KHARTOUM SUMMER MAIL SERVICE.</p>
+                        <p><placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>
+                            -KHARTOUM SUMMER MAIL SERVICE.</p>
 
-                            <table rows="3" cols="7">
+                        <table rows="3" cols="7">
                             <row>
                                 <cell>Wednesday and *Saturday</cell>
                                 <cell>8 p.m.</cell>
                                 <cell>depart</cell>
-                                <cell><placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> </cell>
+                                <cell><placeName ref="https://www.wikidata.org/wiki/Q85"
+                                        >Cairo</placeName>
+                                </cell>
                                 <cell>arrive</cell>
                                 <cell>*Monday and *Friday</cell>
                                 <cell>7.20 a.m.</cell>
@@ -929,45 +1215,62 @@
                                 <cell>12 noon</cell>
                             </row>
                         </table>
-                        <p>Mail delivered Khartoum, Sun. and Wednesday evening, and <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> , Mon. and Friday
-                            evening. *Dining and Sleeping Cars.</p>
+                        <p>Mail delivered Khartoum, Sun. and Wednesday evening, and <placeName
+                                ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> , Mon. and
+                            Friday evening. *Dining and Sleeping Cars.</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-sde01">
                         <head>SUDAN DEVELOPMENT &amp; EXPLORATION COMPANY, LIMITED</head>
-                        <p>KHARTOUM: <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>  Office, Sharia Kasr-el-Nil.</p>
-                        <p>TRANSPORT DEPARTMENT. Six days White Nile Tourist Trip dep. Khartoum Tuesdays.
-                            Steamer plans may be seen and passages booked at all <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>  Tourist Agents. -
-                            Special Steamers for private charter. - Trips arranged and transport of goods
-                            undertaken to all places on White and Blue Niles within navigation limits.</p>
-                        <p>ENGINEERING DEPARTMENT. Shipyard for construction of sternwheel steamers, barges,
-                            stream, motor launches, etc. Contractors for supply and erection of all classes
-                            of machinery, buildings, irrigation pumps, etc.</p>
-                        <p>SOLE AGENTS FOR Dudbridges Oil Engines from 1 to 25 B.H.P. as supplied to Sudan
-                            Government. Seamless xxxxxxxxxxxxxxxxxxxxx</p>
+                        <p>KHARTOUM: <placeName ref="https://www.wikidata.org/wiki/Q85"
+                                >Cairo</placeName> Office, Sharia Kasr-el-Nil.</p>
+                        <p>TRANSPORT DEPARTMENT. Six days White Nile Tourist Trip dep. Khartoum
+                            Tuesdays. Steamer plans may be seen and passages booked at all
+                                <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>
+                            Tourist Agents. - Special Steamers for private charter. - Trips arranged
+                            and transport of goods undertaken to all places on White and Blue Niles
+                            within navigation limits.</p>
+                        <p>ENGINEERING DEPARTMENT. Shipyard for construction of sternwheel steamers,
+                            barges, stream, motor launches, etc. Contractors for supply and erection
+                            of all classes of machinery, buildings, irrigation pumps, etc.</p>
+                        <p>SOLE AGENTS FOR Dudbridges Oil Engines from 1 to 25 B.H.P. as supplied to
+                            Sudan Government. Seamless xxxxxxxxxxxxxxxxxxxxx</p>
                     </div>
                     <cb n="3"/>
                     <div type="item" scope="advertisement" xml:id="deg-ad-aan01">
                         <head>Anglo-American Nile Steamer &amp; Hotel Coy.</head>
-                        <p>Weekly departure during Winter Season by the<lb/> Luxurious First Class Tourist
-                            Steamers VICTORIA, PURITAN &amp; MAYFLOWER.<lb/> Regular weekly Departures to
-                            the SECOND CATARACT by the S.S. IndianA.<lb/> THROUGH BOOKINGS TO KHARTOUM,
-                            GONDOKORO AND THE WHITE NILE.<lb/> Steamers and Dahabeahs for private charter.
-                            Steam Tugs and Steam Launches for hire.<lb/> FREIGHT SERVICE BY STEAM BARGES
-                            BETWEEN <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>  AND <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>.<lb/> Working in conjunction and under special
-                            arrangement with the<lb/> “Upper <placeName ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName>Hotels Company."</p>
-                        <p>For details and illustrated programmes apply to "THE ANGLO-AMERICAN NILE STEAMER
-                            and<lb/> HOTEL COMPANY."</p>
-                        <p> OFFICES IN <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> : Sharia Boulac, "Grand Continental Hotel Buildings.” 31-3-06</p>
+                        <p>Weekly departure during Winter Season by the<lb/> Luxurious First Class
+                            Tourist Steamers VICTORIA, PURITAN &amp; MAYFLOWER.<lb/> Regular weekly
+                            Departures to the SECOND CATARACT by the S.S. IndianA.<lb/> THROUGH
+                            BOOKINGS TO KHARTOUM, GONDOKORO AND THE WHITE NILE.<lb/> Steamers and
+                            Dahabeahs for private charter. Steam Tugs and Steam Launches for
+                            hire.<lb/> FREIGHT SERVICE BY STEAM BARGES BETWEEN <placeName
+                                ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> AND
+                                <placeName ref="https://www.wikidata.org/wiki/Q87"
+                                >Alexandria</placeName>.<lb/> Working in conjunction and under
+                            special arrangement with the<lb/> “Upper <placeName
+                                ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName>Hotels
+                            Company."</p>
+                        <p>For details and illustrated programmes apply to "THE ANGLO-AMERICAN NILE
+                            STEAMER and<lb/> HOTEL COMPANY."</p>
+                        <p> OFFICES IN <placeName ref="https://www.wikidata.org/wiki/Q85"
+                                >Cairo</placeName> : Sharia Boulac, "Grand Continental Hotel
+                            Buildings.” 31-3-06</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-nll01">
                         <head>NORDDEUTSCHER LLOYD.</head>
-                        <p>Regular Service from <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> (Passenger and Freight) to NAPLES-<placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName>.</p>
-                        <p> SCHLESWIG will leave <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> at 4 p.m. July 26, August 30, September 20, etc. </p>
-                        <p>The following steamers are intended to leave <placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName> : </p>
+                        <p>Regular Service from <placeName ref="https://www.wikidata.org/wiki/Q87"
+                                >Alexandria</placeName> (Passenger and Freight) to NAPLES-<placeName
+                                ref="https://www.wikidata.org/wiki/Q579613"
+                            >Marseilles</placeName>.</p>
+                        <p> SCHLESWIG will leave <placeName ref="https://www.wikidata.org/wiki/Q87"
+                                >Alexandria</placeName> at 4 p.m. July 26, August 30, September 20,
+                            etc. </p>
+                        <p>The following steamers are intended to leave <placeName
+                                ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName> : </p>
                         <table rows="14" cols="3">
                             <row>
-                                <cell cols="3">HOMEWARD : for Bremen Hamburg via Naples, Genoa, (Gibraltar),
-                                    Southampton, Antwerp.</cell>
+                                <cell cols="3">HOMEWARD : for Bremen Hamburg via Naples, Genoa,
+                                    (Gibraltar), Southampton, Antwerp.</cell>
                             </row>
                             <row>
                                 <cell>Zieten</cell>
@@ -995,8 +1298,11 @@
                                 <cell>about 28 August</cell>
                             </row>
                             <row>
-                                <cell cols="3">OUTWARD: for <placeName ref="https://www.wikidata.org/wiki/Q148">China</placeName> and JAPAN via <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>, ADEN, COLOMBO, PENANG,
-                                    SINGAPORE.</cell>
+                                <cell cols="3">OUTWARD: for <placeName
+                                        ref="https://www.wikidata.org/wiki/Q148">China</placeName>
+                                    and JAPAN via <placeName
+                                        ref="https://www.wikidata.org/wiki/Q134514"
+                                    >Suez</placeName>, ADEN, COLOMBO, PENANG, SINGAPORE.</cell>
                             </row>
                             <row>
                                 <cell>Prinz E. Friedrich</cell>
@@ -1014,7 +1320,11 @@
                                 <cell>about 7 August</cell>
                             </row>
                             <row>
-                                <cell cols="3">For <placeName ref="https://www.wikidata.org/wiki/Q408">Australia</placeName> via <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>, ADEN, COLOMBO.</cell>
+                                <cell cols="3">For <placeName
+                                        ref="https://www.wikidata.org/wiki/Q408"
+                                        >Australia</placeName> via <placeName
+                                        ref="https://www.wikidata.org/wiki/Q134514"
+                                    >Suez</placeName>, ADEN, COLOMBO.</cell>
                             </row>
                             <row>
                                 <cell>Seydlitz</cell>
@@ -1033,19 +1343,36 @@
                             </row>
                         </table>
                         <p>FOR FURTHER PARTICULARS APPLY TO THE AGENTS OF THE </p>
-                        <p>NORDDEUTSCHER LLOYD at <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> , <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>, <placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName>  and <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>. </p>
-                        <p>OTTO STERZING, Agent In <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> , Opera Square. </p>
-                        <p>C. H. SCHOELLER, Agent In <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>, Cleopatra Lane.</p>
-                        <p>Messrs. THOS. COOK &amp; SON (Egypt) LTD., and CARL STANGENS REISEBUREAN are
-                            anthorised to sell tickets in <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>  and <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>, 31-8-905</p>
+                        <p>NORDDEUTSCHER LLOYD at <placeName ref="https://www.wikidata.org/wiki/Q85"
+                                >Cairo</placeName> , <placeName
+                                ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>,
+                                <placeName ref="https://www.wikidata.org/wiki/Q134509"
+                                >Port-Said</placeName> and <placeName
+                                ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>. </p>
+                        <p>OTTO STERZING, Agent In <placeName
+                                ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> , Opera
+                            Square. </p>
+                        <p>C. H. SCHOELLER, Agent In <placeName
+                                ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>,
+                            Cleopatra Lane.</p>
+                        <p>Messrs. THOS. COOK &amp; SON (Egypt) LTD., and CARL STANGENS REISEBUREAN
+                            are anthorised to sell tickets in <placeName
+                                ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> and
+                                <placeName ref="https://www.wikidata.org/wiki/Q87"
+                                >Alexandria</placeName>, 31-8-905</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-als01">
                         <head>Austrian Lloyd’s Steam Navigation</head>
-                        <p><placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>-Brindisi-Venice-Trieste.</p>
-                        <p>Weekly Express Mail Service. Steamers leave <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> every Saturday at 4 p.m.
-                            arrive at Brindisi, Tuesday a.m. in time for express to <placeName ref="https://www.wikidata.org/wiki/Q90">Paris</placeName>, <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName>, Naples,
-                            Rome. Arrival Trieste Wednesday noon connecting with Vienna Express
-                            (Trieste-Ostende through carriage) and expresses to Italy and Germany.</p>
+                        <p><placeName ref="https://www.wikidata.org/wiki/Q87"
+                            >Alexandria</placeName>-Brindisi-Venice-Trieste.</p>
+                        <p>Weekly Express Mail Service. Steamers leave <placeName
+                                ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> every
+                            Saturday at 4 p.m. arrive at Brindisi, Tuesday a.m. in time for express
+                            to <placeName ref="https://www.wikidata.org/wiki/Q90">Paris</placeName>,
+                                <placeName ref="https://www.wikidata.org/wiki/Q84"
+                                >London</placeName>, Naples, Rome. Arrival Trieste Wednesday noon
+                            connecting with Vienna Express (Trieste-Ostende through carriage) and
+                            expresses to Italy and Germany.</p>
                         <table rows="3" cols="8">
                             <row>
                                 <cell>July 8</cell>
@@ -1078,7 +1405,8 @@
                                 <cell/>
                             </row>
                         </table>
-                        <p>Fortnightly Service: <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>-Brindisi-Venice-Trieste </p>
+                        <p>Fortnightly Service: <placeName ref="https://www.wikidata.org/wiki/Q87"
+                                >Alexandria</placeName>-Brindisi-Venice-Trieste </p>
                         <table rows="1" cols="8">
                             <row>
                                 <cell>June 21</cell>
@@ -1091,28 +1419,46 @@
                                 <cell>Capt. Knezevich</cell>
                             </row>
                         </table>
-                        <p>(Departures from <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>) To Aden, <placeName ref="https://www.wikidata.org/wiki/Q1156">Bombay</placeName>, Colombo, Penang, Singapore, Hong-Kong,
-                            Shanghai, Yokohama, Kobé about July 5 and August 4. To Aden, Karachi, and <placeName ref="https://www.wikidata.org/wiki/Q1156">Bombay</placeName>
-                            accelerated service about August 18. To Aden, Karachi, <placeName ref="https://www.wikidata.org/wiki/Q1156">Bombay</placeName>, Colombo, Madras,
-                            Rangoon, and Calcutta about July 20.</p>
+                        <p>(Departures from <placeName ref="https://www.wikidata.org/wiki/Q134514"
+                                >Suez</placeName>) To Aden, <placeName
+                                ref="https://www.wikidata.org/wiki/Q1156">Bombay</placeName>,
+                            Colombo, Penang, Singapore, Hong-Kong, Shanghai, Yokohama, Kobé about
+                            July 5 and August 4. To Aden, Karachi, and <placeName
+                                ref="https://www.wikidata.org/wiki/Q1156">Bombay</placeName>
+                            accelerated service about August 18. To Aden, Karachi, <placeName
+                                ref="https://www.wikidata.org/wiki/Q1156">Bombay</placeName>,
+                            Colombo, Madras, Rangoon, and Calcutta about July 20.</p>
                         <p>East African Line.</p>
-                        <p>To Aden, Mombassa, Zanzibar, Beira, Delagoa Bay, Durban, about July 4 and August
-                            3.</p>
+                        <p>To Aden, Mombassa, Zanzibar, Beira, Delagoa Bay, Durban, about July 4 and
+                            August 3.</p>
                         <p>Syrian-Cyprus-Caramanian Line.</p>
-                        <p>Steamers leaves <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> on or about July 3, 17 and 31.</p>
-                        <p>For information apply to the Agents, <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>, <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> and <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>, Thos. Cook
-                            &amp; Son, Ld., Leon Heller, <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>  Agent, 4, Sharia Maghraby, (Telephone 192),
-                            <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> ; F. Tedeschi, Helouan.</p>
-                        <p>Special passage rates granted to Egyptian Government officials, members of the
-                            Army of Occupation and their families. </p>
+                        <p>Steamers leaves <placeName ref="https://www.wikidata.org/wiki/Q87"
+                                >Alexandria</placeName> on or about July 3, 17 and 31.</p>
+                        <p>For information apply to the Agents, <placeName
+                                ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>,
+                                <placeName ref="https://www.wikidata.org/wiki/Q134509">Port
+                                Said</placeName> and <placeName
+                                ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>, Thos.
+                            Cook &amp; Son, Ld., Leon Heller, <placeName
+                                ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> Agent, 4,
+                            Sharia Maghraby, (Telephone 192), <placeName
+                                ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> ; F.
+                            Tedeschi, Helouan.</p>
+                        <p>Special passage rates granted to Egyptian Government officials, members
+                            of the Army of Occupation and their families. </p>
                         <p>31-12-905</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-cun01">
                         <head>Cunard Line.</head>
                         <table rows="4" cols="6">
-                            <head><placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> to New-York and Boston via the Continent and <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName></head>
+                            <head><placeName ref="https://www.wikidata.org/wiki/Q87"
+                                    >Alexandria</placeName> to New-York and Boston via the Continent
+                                and <placeName ref="https://www.wikidata.org/wiki/Q24826"
+                                    >Liverpool</placeName></head>
                             <row>
-                                <cell cols="6">Sailings from <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName> on Saturdays and Tuesdays. Royal Mail
+                                <cell cols="6">Sailings from <placeName
+                                        ref="https://www.wikidata.org/wiki/Q24826"
+                                        >Liverpool</placeName> on Saturdays and Tuesdays. Royal Mail
                                     Steamers:</cell>
                             </row>
                             <row>
@@ -1141,10 +1487,12 @@
                             </row>
                         </table>
                         <table rows="3" cols="4">
-                            <head><placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> to New-York via Trieste, Fiume or Palermo</head>
+                            <head><placeName ref="https://www.wikidata.org/wiki/Q87"
+                                    >Alexandria</placeName> to New-York via Trieste, Fiume or
+                                Palermo</head>
                             <row>
-                                <cell cols="4">Regular twin-screw Passenger Service from the Adriatic.
-                                    Excellent accommodation.</cell>
+                                <cell cols="4">Regular twin-screw Passenger Service from the
+                                    Adriatic. Excellent accommodation.</cell>
                             </row>
                             <row>
                                 <cell>Carpathia</cell>
@@ -1159,45 +1507,73 @@
                                 <cell>10,402 tons</cell>
                             </row>
                         </table>
-                        <p>All steamers fitted with Marconi's wireless telegraphy. For through tickets from
-                            Egypt, and particulars aply to the Agents Rodacanachi &amp; Co., <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>;
-                            Nic. Kerzis, <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> ; R. Broadbent, <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>. 19-1-905</p>
+                        <p>All steamers fitted with Marconi's wireless telegraphy. For through
+                            tickets from Egypt, and particulars aply to the Agents Rodacanachi &amp;
+                            Co., <placeName ref="https://www.wikidata.org/wiki/Q87"
+                                >Alexandria</placeName>; Nic. Kerzis, <placeName
+                                ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> ; R.
+                            Broadbent, <placeName ref="https://www.wikidata.org/wiki/Q134509">Port
+                                Said</placeName>. 19-1-905</p>
                     </div>
                     <!-- TODO Russian Steam Navigation -->
                     <div type="item" scope="advertisement" xml:id="deg-ad-pap01">
                         <head>THE PAPAYANNI LINE.</head>
                         <head type="sub">(The Ellerman Lines, Ltd.)</head>
-                        <p>Frequent Sailings from <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> to <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName>, also Regular Services from
-                            <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName> to <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> and to ALGERIA, <placeName ref="https://www.wikidata.org/wiki/Q233">Malta</placeName>, LEVANT, BLACK SEA, and other
-                            Mediterranean Ports.</p>
-                        <p>Excellent Passenger Accommodation. Stewardess carried. Liberal table and Moderate
-                            Fares for single and retnrn tickets. </p>
-                        <p>The S S. SARDINIA will sail for <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName> (via Bona) on Friday, the 7th inst. at
-                            4 p.m.</p>
-                        <p>CARGO taken by special agreement only. Through Freights quoted for the UNITED
-                            STATES and INLAND TOWNS in GREAT BRITAIN.</p>
-                        <p>For passage or freight apply to the Agents, BARKER &amp; Co., <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>.
+                        <p>Frequent Sailings from <placeName ref="https://www.wikidata.org/wiki/Q87"
+                                >Alexandria</placeName> to <placeName
+                                ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName>,
+                            also Regular Services from <placeName
+                                ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName> to
+                                <placeName ref="https://www.wikidata.org/wiki/Q87"
+                                >Alexandria</placeName> and to ALGERIA, <placeName
+                                ref="https://www.wikidata.org/wiki/Q233">Malta</placeName>, LEVANT,
+                            BLACK SEA, and other Mediterranean Ports.</p>
+                        <p>Excellent Passenger Accommodation. Stewardess carried. Liberal table and
+                            Moderate Fares for single and retnrn tickets. </p>
+                        <p>The S S. SARDINIA will sail for <placeName
+                                ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName>
+                            (via Bona) on Friday, the 7th inst. at 4 p.m.</p>
+                        <p>CARGO taken by special agreement only. Through Freights quoted for the
+                            UNITED STATES and INLAND TOWNS in GREAT BRITAIN.</p>
+                        <p>For passage or freight apply to the Agents, BARKER &amp; Co., <placeName
+                                ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>.
                             2061-17-10-905 </p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-ell01">
                         <head>Ellerman Lines, Limited.</head>
                         <table rows="3" cols="6">
                             <row>
-                                <cell cols="3">CITY LINE to <placeName ref="https://www.wikidata.org/wiki/Q233">Malta</placeName>, <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName>, COLOMBO &amp; CALCUTTA.</cell>
+                                <cell cols="3">CITY LINE to <placeName
+                                        ref="https://www.wikidata.org/wiki/Q233">Malta</placeName>,
+                                        <placeName ref="https://www.wikidata.org/wiki/Q84"
+                                        >London</placeName>, COLOMBO &amp; CALCUTTA.</cell>
                                 <cell cols="3">
-                                    <p>CITY &amp; HALL LINES. Joint Service to <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName>, <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName>, <placeName ref="https://www.wikidata.org/wiki/Q1156">Bombay</placeName>
-                                        &amp; KARACHI.</p>
+                                    <p>CITY &amp; HALL LINES. Joint Service to <placeName
+                                            ref="https://www.wikidata.org/wiki/Q579613"
+                                            >Marseilles</placeName>, <placeName
+                                            ref="https://www.wikidata.org/wiki/Q24826"
+                                            >Liverpool</placeName>, <placeName
+                                            ref="https://www.wikidata.org/wiki/Q1156"
+                                            >Bombay</placeName> &amp; KARACHI.</p>
                                 </cell>
                             </row>
                             <row>
-                                <cell cols="6">The undermentioned First Class Passenger Steamers will be
-                                    dispatched from <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> on or about the following dates for </cell>
+                                <cell cols="6">The undermentioned First Class Passenger Steamers
+                                    will be dispatched from <placeName
+                                        ref="https://www.wikidata.org/wiki/Q134509">Port
+                                        Said</placeName> on or about the following dates for </cell>
                             </row>
                             <row>
-                                <cell><placeName ref="https://www.wikidata.org/wiki/Q233">Malta</placeName> and <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> </cell>
+                                <cell><placeName ref="https://www.wikidata.org/wiki/Q233"
+                                        >Malta</placeName> and <placeName
+                                        ref="https://www.wikidata.org/wiki/Q84">London</placeName>
+                                </cell>
                                 <cell>S.S. City of Corinth </cell>
                                 <cell>July 26</cell>
-                                <cell><placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName> and <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName></cell>
+                                <cell><placeName ref="https://www.wikidata.org/wiki/Q579613"
+                                        >Marseilles</placeName> and <placeName
+                                        ref="https://www.wikidata.org/wiki/Q24826"
+                                        >Liverpool</placeName></cell>
                                 <cell/>
                                 <cell/>
                             </row>
@@ -1205,62 +1581,94 @@
                                 <cell>Colombo and Calcutta</cell>
                                 <cell>S.S. City of Manchester</cell>
                                 <cell>July 12</cell>
-                                <cell><placeName ref="https://www.wikidata.org/wiki/Q1156">Bombay</placeName></cell>
+                                <cell><placeName ref="https://www.wikidata.org/wiki/Q1156"
+                                        >Bombay</placeName></cell>
                                 <cell>S.S. Anton Hall</cell>
                                 <cell>July 13</cell>
                             </row>
                         </table>
-                        <p>SALOON FARES:—<placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> to <placeName ref="https://www.wikidata.org/wiki/Q233">Malta</placeName> £4.10.0. <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName>. £8.0.0. <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> or
-                            <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName>, £l2.l0.0. Colombo, Calcutta, <placeName ref="https://www.wikidata.org/wiki/Q1156">Bombay</placeName> or Karachi, £35.0.0. Special
-                            rates for steamers not carrying Doctor or Stewardess. For further particulars
-                            apply to </p>
-                        <p>CORY BROS. &amp; Co., Ltd., Agents for CITY Line, <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>: W. STAPLEDON &amp;
-                            SON, Agents for Hall Line, <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> ; or COOK &amp; SON (Egypt), Ltd., <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> .
+                        <p>SALOON FARES:—<placeName ref="https://www.wikidata.org/wiki/Q134509">Port
+                                Said</placeName> to <placeName
+                                ref="https://www.wikidata.org/wiki/Q233">Malta</placeName> £4.10.0.
+                                <placeName ref="https://www.wikidata.org/wiki/Q579613"
+                                >Marseilles</placeName>. £8.0.0. <placeName
+                                ref="https://www.wikidata.org/wiki/Q84">London</placeName> or
+                                <placeName ref="https://www.wikidata.org/wiki/Q24826"
+                                >Liverpool</placeName>, £l2.l0.0. Colombo, Calcutta, <placeName
+                                ref="https://www.wikidata.org/wiki/Q1156">Bombay</placeName> or
+                            Karachi, £35.0.0. Special rates for steamers not carrying Doctor or
+                            Stewardess. For further particulars apply to </p>
+                        <p>CORY BROS. &amp; Co., Ltd., Agents for CITY Line, <placeName
+                                ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>:
+                            W. STAPLEDON &amp; SON, Agents for Hall Line, <placeName
+                                ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> ;
+                            or COOK &amp; SON (Egypt), Ltd., <placeName
+                                ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> .
                             23788-28-8-905 </p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-ell02">
                         <head>The Ellerman Lines, Limited.</head>
                         <head type="sub">(Including Westcott &amp; Laurance Line.)</head>
-                        <p>Regular sailings from <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName>, Glasgow, Antwerp and <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> to <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>.
-                            Frequent sailings from <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> to <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName> and <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName>. Through freight rates
-                            to Inland towns in Great Britain also to the U.S.A</p>
+                        <p>Regular sailings from <placeName
+                                ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName>,
+                            Glasgow, Antwerp and <placeName ref="https://www.wikidata.org/wiki/Q84"
+                                >London</placeName> to <placeName
+                                ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>.
+                            Frequent sailings from <placeName
+                                ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> to
+                                <placeName ref="https://www.wikidata.org/wiki/Q24826"
+                                >Liverpool</placeName> and <placeName
+                                ref="https://www.wikidata.org/wiki/Q84">London</placeName>. Through
+                            freight rates to Inland towns in Great Britain also to the U.S.A</p>
                         <table rows="4" cols="5">
                             <row>
                                 <cell>Westcott S.S. Joshua Nicholson</cell>
                                 <cell>expected from</cell>
-                                <cell>Antwerp, <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> &amp; <placeName ref="https://www.wikidata.org/wiki/Q233">Malta</placeName></cell>
+                                <cell>Antwerp, <placeName ref="https://www.wikidata.org/wiki/Q84"
+                                        >London</placeName> &amp; <placeName
+                                        ref="https://www.wikidata.org/wiki/Q233"
+                                    >Malta</placeName></cell>
                                 <cell>is due on or about</cell>
                                 <cell>July 16</cell>
                             </row>
                             <row>
                                 <cell>Ellerman S.S. City of Dundee</cell>
                                 <cell>expected from</cell>
-                                <cell>Glasgow, Gibraltar &amp; <placeName ref="https://www.wikidata.org/wiki/Q233">Malta</placeName></cell>
+                                <cell>Glasgow, Gibraltar &amp; <placeName
+                                        ref="https://www.wikidata.org/wiki/Q233"
+                                    >Malta</placeName></cell>
                                 <cell>is due on or about</cell>
                                 <cell>July 25</cell>
                             </row>
                             <row>
                                 <cell>Westcott S.S. Plymothian</cell>
                                 <cell>expected from</cell>
-                                <cell>Antwerp, <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> &amp; <placeName ref="https://www.wikidata.org/wiki/Q233">Malta</placeName></cell>
+                                <cell>Antwerp, <placeName ref="https://www.wikidata.org/wiki/Q84"
+                                        >London</placeName> &amp; <placeName
+                                        ref="https://www.wikidata.org/wiki/Q233"
+                                    >Malta</placeName></cell>
                                 <cell>is due on or about</cell>
                                 <cell>July 25</cell>
                             </row>
                             <row>
                                 <cell>Ellerman S.S. City of Oxford</cell>
                                 <cell>expected from</cell>
-                                <cell><placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName> &amp; Melta</cell>
+                                <cell><placeName ref="https://www.wikidata.org/wiki/Q24826"
+                                        >Liverpool</placeName> &amp; Melta</cell>
                                 <cell>is due on or about</cell>
                                 <cell>July 30</cell>
                             </row>
                         </table>
-                        <p>Ellerman S.S. Britannia now on the berth for <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName> is expected to sail about
-                            the 25th inst.</p>
-                        <p>N. E. TAMVACO <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> agents 23186-20-3-3</p>
+                        <p>Ellerman S.S. Britannia now on the berth for <placeName
+                                ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName> is
+                            expected to sail about the 25th inst.</p>
+                        <p>N. E. TAMVACO <placeName ref="https://www.wikidata.org/wiki/Q87"
+                                >Alexandria</placeName> agents 23186-20-3-3</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-ngi01">
                         <head>Navigation Générale Italienne.</head>
-                        <p>Societes Reunies Florio-Rubattino. - Services Postaux. - Departs de Juillet.</p>
+                        <p>Societes Reunies Florio-Rubattino. - Services Postaux. - Departs de
+                            Juillet.</p>
                         <table rows="5" cols="4">
                             <row>
                                 <cell>Les Jeudis</cell>
@@ -1284,7 +1692,9 @@
                                 <cell>Le Lundi</cell>
                                 <cell>24</cell>
                                 <cell>à 4 h. p.m.</cell>
-                                <cell>pour Port-Saïd, <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName> et Massawah.</cell>
+                                <cell>pour Port-Saïd, <placeName
+                                        ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>
+                                    et Massawah.</cell>
                             </row>
                             <row>
                                 <cell>Le Vendredi</cell>
@@ -1317,47 +1727,50 @@
                         <p>Soda Water. Lemonade, Ginger Ale, Ginger Beer. Tonic Water</p>
                         <p>Pomegranade, Orangeaade, Pineapple, Champagne, Cider, etc., etc.</p>
                         <p> Water guaranteed by Chamberlain’s Filter (Pasteur’s System).</p>
-                        <p>Inventor of WHISKY &amp; SODA and BRANDY &amp; SODA, bottled ready for use.</p>
+                        <p>Inventor of WHISKY &amp; SODA and BRANDY &amp; SODA, bottled ready for
+                            use.</p>
                         <p> Sole Agents in Egypt and Soudan for</p>
                         <p> J. Calvet &amp; Co. Bordeaux. Wine &amp; Cognacs.</p>
                         <p>Louis Roederer. Rheims. Champagnes.</p>
                         <p>August Engel. Wiesbaden. Rhine and Moselle Wines.</p>
-                        <p>Mackie &amp; Co. Glasgow. Lagavulin, White Horse Cellar &amp; other Whiskies.</p>
+                        <p>Mackie &amp; Co. Glasgow. Lagavulin, White Horse Cellar &amp; other
+                            Whiskies.</p>
                         <p>Dunville &amp; Co, Ltd. Belfast. Old Irish Whiskies.</p>
                         <p>Wm. Lanahan &amp; Son. Baltimore. Monongshels XXXX Whiskey.</p>
                         <p>The Cook &amp; Bernheimer Co. New York. Old Valley Whiskey and Gold Lion
-                              Cocktails.</p>
+                            Cocktails.</p>
                         <p>Stone &amp; Son. London. Guinness' Stout &amp; Bass' Pale Ale.</p>
                         <p>Freund Ballor &amp; Co. Tornio. Vermouth.</p>
                         <p>Pierre Bisset. Cette. Vermouth &amp; Aperitives.</p>
                         <p>Terrabonatea Company, Ld. Teas.</p>
-                        <p>Depot for Prince Metternich's "Richardsquelle," the best mineral table water in
-                              the world.</p>
-                        <p>Great assortment of Wines, Spirits, Liqueurs, of the finest Brands, etc</p>
+                        <p>Depot for Prince Metternich's "Richardsquelle," the best mineral table
+                            water in the world.</p>
+                        <p>Great assortment of Wines, Spirits, Liqueurs, of the finest Brands,
+                            etc</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-abp01">
                         <head>THE ARTESIAN BORING AND PROSPECTING COMPANY.</head>
                         <p>(SOCIÉTÉ ANONYME)</p>
                         <p>CAIRO, 28, SHARIA-EL-MANAKH,<lb/> (OPPOSITE IMPERIAL OTTOMAN BANK).</p>
-                        <p>I. —Installation of complete Water supplies for drinking, agricultural, and<lb/>
-                              industrial purposes by means of artesian wells.</p>
-                        <p>II. - Deep borings for prospecting purposes in all conditions of soil by means of
-                              the<lb/> “Express Boring System."</p>
+                        <p>I. —Installation of complete Water supplies for drinking, agricultural,
+                            and<lb/> industrial purposes by means of artesian wells.</p>
+                        <p>II. - Deep borings for prospecting purposes in all conditions of soil by
+                            means of the<lb/> “Express Boring System."</p>
                         <p>24,437-12-1-905</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-hom01">
                         <head>"Homocea" "Touches The Spot"</head>
-                        <p>In all cases of cuts, burns, bruises, chafes, sores, ulcers, open Wounds, and
-                              cimilar ills of the flesh, anoint with Homocea on linen or lint.</p>
-                        <p>Homocea for bruises, bites stings, swellings, sore throat, face-ache etc., gently
-                              rob and cover with Homocea on linen</p>
+                        <p>In all cases of cuts, burns, bruises, chafes, sores, ulcers, open Wounds,
+                            and cimilar ills of the flesh, anoint with Homocea on linen or lint.</p>
+                        <p>Homocea for bruises, bites stings, swellings, sore throat, face-ache
+                            etc., gently rob and cover with Homocea on linen</p>
                         <p>Homocea is antiseptic, soothing, and healing,</p>
                         <p>Homocea allays inaflamtive, initature &amp;c.</p>
                         <p>Homocea is the most wonderful relief and cure for piles known.</p>
-                        <p>Homocea Embrocation is for rubbing of in pains of all kinds, rheumatic pains,
-                              strains, stiff joints neuralgia, etc.</p>
-                        <p>Hippacea does in the kennel, stable, and farm, for all animals what Homocea does
-                              in the Household.</p>
+                        <p>Homocea Embrocation is for rubbing of in pains of all kinds, rheumatic
+                            pains, strains, stiff joints neuralgia, etc.</p>
+                        <p>Hippacea does in the kennel, stable, and farm, for all animals what
+                            Homocea does in the Household.</p>
                         <p>Sold by Druggists and Chemists</p>
                         <p>The wholesale trade supplied by: MAX FISCHER, Cairo.</p>
                         <p>24203-52-6</p>
@@ -1370,7 +1783,8 @@
                         <p>de provenance directe et de toutes les meilleures marques</p>
                         <p>Nicolas G Sabbag</p>
                         <p>IMPORTATEUR GENERAL</p>
-                        <p>FOURNISSIUR DE S A LE KHEDIVE et de tous les grands Clubs et Hôtels d'Egypte.</p>
+                        <p>FOURNISSIUR DE S A LE KHEDIVE et de tous les grands Clubs et Hôtels
+                            d'Egypte.</p>
                         <p>2—Rue de la Gare du Caire—2 ALEXANDRIE</p>
                         <p> Adresse Télégraphique : SABBAG Alexandrie</p>
                         <p> Téléphone No 559.</p>
@@ -1399,34 +1813,35 @@
                         <head>Hall's Sanitary Washable Distemper</head>
                         <p>Made in 70 Colors</p>
                         <p>An artistic wall covering.</p>
-                        <p>This celebrated water paint is made in two qualities for Inside and Outside
-                              work</p>
-                        <p>HALL’S SANITARY WASHABLE DISTEMPER is rapidly superseding wall papers in all
-                              tastefully furnished homes. It is made in 70 artistic tints, and only requires
-                              the addition of water to make it ready for use. It is quickly and easily applied
-                              with a whitewash brush, with half the labour and at one third the cost of paint.
-                              HALL’S DISTEMPER ensures cleanliness, and is pleasing to the eye. It appeals
-                              alike to artistic and practical house decoration. HALL’S DISTEMPER is of special
-                              value in hot climates. Owing to its cool, pleasing colours, great
-                              weather-resisting and germ-destroying properties, it lends itself to every kind
-                              of wall, wood, brick or stone coating, possessing all the advantages of paint,
-                              colour- wash, and disinfectant at one third the cost of oil paint. It never
-                              blisters in the hottest sun, and the fact that it can be washed adds greatly to
-                              its sanitary advantages.</p>
+                        <p>This celebrated water paint is made in two qualities for Inside and
+                            Outside work</p>
+                        <p>HALL’S SANITARY WASHABLE DISTEMPER is rapidly superseding wall papers in
+                            all tastefully furnished homes. It is made in 70 artistic tints, and
+                            only requires the addition of water to make it ready for use. It is
+                            quickly and easily applied with a whitewash brush, with half the labour
+                            and at one third the cost of paint. HALL’S DISTEMPER ensures
+                            cleanliness, and is pleasing to the eye. It appeals alike to artistic
+                            and practical house decoration. HALL’S DISTEMPER is of special value in
+                            hot climates. Owing to its cool, pleasing colours, great
+                            weather-resisting and germ-destroying properties, it lends itself to
+                            every kind of wall, wood, brick or stone coating, possessing all the
+                            advantages of paint, colour- wash, and disinfectant at one third the
+                            cost of oil paint. It never blisters in the hottest sun, and the fact
+                            that it can be washed adds greatly to its sanitary advantages.</p>
                         <p>Supplied in Tins and Iron Kegs.</p>
                         <p>Sole Manufacturers :</p>
                         <p>SISSONS BROTHERS &amp; Co., Ltd., HULL.</p>
-                        <p>Stocks are held In Cairo by FRANK RATCLIFFE, Sanitary Contractor and Engineer,
-                              Sharia Saptieh.</p>
+                        <p>Stocks are held In Cairo by FRANK RATCLIFFE, Sanitary Contractor and
+                            Engineer, Sharia Saptieh.</p>
                         <p>In Alexandria by RAMADAN YOUSSEF, Sanitary Contractor, Rue Sesostris.</p>
                         <p>General Agents: GEORGE MORRIS &amp; Co.. Alexandria &amp; Cairo.</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-bla01">
                         <head>Beetham's "Larola"</head>
                         <p>Prevents the attack of mosquitoes.</p>
-                        <p>Will entirely Remove all ROUGHNESS, REDNESS, HEAT, IRRITATION, &amp;c., in a very
-                              short time. IT KEEPS THE SKIN SOFT, SMOOTH, AND WHITE at all seasons, and is
-                              DELIGHTFULLY COOLING and REFRESHING.</p>
+                        <p>Will entirely Remove all ROUGHNESS, REDNESS, HEAT, IRRITATION, &amp;c.,
+                            in a very short time. IT KEEPS THE SKIN SOFT, SMOOTH, AND WHITE at all
+                            seasons, and is DELIGHTFULLY COOLING and REFRESHING.</p>
                         <p>Agent:--MAX FISCHER, CAIRO AND ALEXANDRIA.</p>
                         <p>Sole Makers--M. BEETHAM &amp; SON, CHELTENHAM, ENGLAND.</p>
                     </div>
@@ -1440,10 +1855,10 @@
                         <p>DIRECT IMPORTER OF BRITISH AND IRISH TEXTILE MANUFACTURES.</p>
                         <p>LADIES’ SUMMER STOCKINGS.</p>
                         <p> IN SPUN SILK at P.T. 20 per pair.</p>
-                        <p>LISLE THREAD, in plain and lace open-work, in black, white, tan and usual shades,
-                              to suit boots worn in Egypt, frpm P.T. 5 per pair.</p>
+                        <p>LISLE THREAD, in plain and lace open-work, in black, white, tan and usual
+                            shades, to suit boots worn in Egypt, frpm P.T. 5 per pair.</p>
                         <p>Every pair is marked “Au De Rouge" which is a guarantee that the Color is
-                              absolutely fast and stainless.</p>
+                            absolutely fast and stainless.</p>
                         <p>24916-15-11-905</p>
                     </div>
                     <!-- TODO Lancaster House, Cairo -->
@@ -1451,20 +1866,22 @@
                 </div>
                 <cb n="2"/>
                 <div type="item" scope="calendar">
-                    <table cols="3" xml:id="CalendarOfTheWeek">
-                        <head>Calendar of Coming Events.</head>
-                        <div type="subsection">
-                            <head>Alexandria</head>
-                            <head type="sub">October</head>
+                    <head>Calendar of Coming Events.</head>
+                    <div type="subsection">
+                        <head>Alexandria</head>
+                        <head type="sub">October</head>
+                        <table cols="3" xml:id="CalendarOfComingEvents-Alexandia">
                             <row>
                                 <cell>Tues.</cell>
                                 <cell>3</cell>
                                 <cell>
                                     <p>E.T.C. Cricket Match. Seniors v.<lb/>Juniors. 1.30 p.m.</p>
-                                    <p>Mex Casino.  Reunion des Familles.<lb/>9.30 p.m.</p>
-                                    <p>Mex. Prineaas' Restaurant des Bisins<lb/>Roumanian orchestra, every afternoon<lb/>Sundays, morning.</p>
+                                    <p>Mex Casino. Reunion des Familles.<lb/>9.30 p.m.</p>
+                                    <p>Mex. Prineaas' Restaurant des Bisins<lb/>Roumanian orchestra,
+                                        every afternoon<lb/>Sundays, morning.</p>
                                     <p>Windsor Hotel. Orchestra. 6 to<lb/>11:30 p.m. every day.</p>
-                                    <p>Alhambra -- Italian company --<lb/>I fourchambault. 9.15 p.m.</p>
+                                    <p>Alhambra -- Italian company --<lb/>I fourchambault. 9.15
+                                        p.m.</p>
                                     <p>Crouwn Casino. Ibrahhimieh. 9.30 p.m.</p>
                                     <p>Tour Eiffel. Calabrian Benefit performance<lb/>9 p.m.</p>
                                 </cell>
@@ -1473,27 +1890,33 @@
                                 <cell>Sat.</cell>
                                 <cell>7</cell>
                                 <cell>
-                                    <p>Alex. Swimming Club. 3rd Annual<lb/>Aquatic Sports. New Graving<lb/>Dock, Gabbari. 3 p.m.</p>
+                                    <p>Alex. Swimming Club. 3rd Annual<lb/>Aquatic Sports. New
+                                        Graving<lb/>Dock, Gabbari. 3 p.m.</p>
                                 </cell>
                             </row>
                             <row>
                                 <cell>Sat.</cell>
                                 <cell>14</cell>
                                 <cell>
-                                    <p>Alex. Swimming Club. 60yds Juniors'<lb/>100yds. Seniors' Chapmpionships.<lb/>Customs Gate 23. 4 p.m.</p>
-                                    <p>B.R.C. Mustapha Pasha Range.<lb/>Practice and Cup Compeittion.<lb/>3 p.m.</p>
+                                    <p>Alex. Swimming Club. 60yds Juniors'<lb/>100yds. Seniors'
+                                        Chapmpionships.<lb/>Customs Gate 23. 4 p.m.</p>
+                                    <p>B.R.C. Mustapha Pasha Range.<lb/>Practice and Cup
+                                        Compeittion.<lb/>3 p.m.</p>
                                 </cell>
                             </row>
-                        </div>
-                        <div type="subsection">
-                            <head>Cairo</head>
-                            <head type="sub">October</head>
+                        </table>
+                    </div>
+                    <div type="subsection">
+                        <head>Cairo</head>
+                        <head type="sub">October</head>
+                        <table cols="3" xml:id="CalendarOfComingEvents-Cairo">
                             <row>
                                 <cell>Tues.</cell>
                                 <cell>3</cell>
                                 <cell>
-                                    <p>Esbekieh Gardens. Performances by<lb/>British Military Band. 9 to 11 p.m.</p>
-                                    <p>Esbekieh Theater. French Operetta<lb/>Company.  9.15 p.m.</p>
+                                    <p>Esbekieh Gardens. Performances by<lb/>British Military Band.
+                                        9 to 11 p.m.</p>
+                                    <p>Esbekieh Theater. French Operetta<lb/>Company. 9.15 p.m.</p>
                                     <p>Tehatre des Nouvesutes. 9.30 p.m.</p>
                                     <p>Aloazar Parisien. 9.30 p.m.</p>
                                 </cell>
@@ -1502,16 +1925,18 @@
                                 <cell>Fri.</cell>
                                 <cell>6</cell>
                                 <cell>
-                                    <p>Esbekieh Gardens. Performances by<lb/>British Military Band. 9 to 11 p.m.</p>
+                                    <p>Esbekieh Gardens. Performances by<lb/>British Military Band.
+                                        9 to 11 p.m.</p>
                                 </cell>
                             </row>
                             <row>
                                 <cell>Mon.</cell>
                                 <cell>16</cell>
-                                <cell>Cairo Musical and Dramatic Society.<lb/>Concert in aid of Calabrian Victims.<lb/>Distinguished Patronage.</cell>
+                                <cell>Cairo Musical and Dramatic Society.<lb/>Concert in aid of
+                                    Calabrian Victims.<lb/>Distinguished Patronage.</cell>
                             </row>
-                        </div>
-                    </table>
+                        </table>
+                    </div>
                 </div>
                 <cols n="1"/>
                 <cb n="3"/>
@@ -1554,7 +1979,8 @@
                     </div>
                     <div type="subsection">
                         <head>REMARKS.</head>
-                        <p>The weather continues uncahnged, with the exception of an<lb/>increased degree of humidity.  The barometer is fallling.</p>
+                        <p>The weather continues uncahnged, with the exception of an<lb/>increased
+                            degree of humidity. The barometer is fallling.</p>
                     </div>
                     <div type="subsection">
                         <table cols="3" xml:id="OtherStations">
@@ -1720,12 +2146,18 @@
                         </table>
                         <div type="item">
                             <head>The Planets,</head>
-                            <p>Mercury is invisible at the beginning of the month but becomes an evening star by the 15th.</p>
+                            <p>Mercury is invisible at the beginning of the month but becomes an
+                                evening star by the 15th.</p>
                             <p>Venus is a morning star.</p>
                             <p>Mars sets abou 10 p.m. throughout the month.</p>
-                            <p>Jupiter rises at 9 p.m. at the beginning of the month, and becoems into opposition at the end.</p>
-                            <p>Saturn sets at 3 a.m. at the beginning of the month and 1 a.m. at the end.</p>
-                            <p>The cheif constelations in the South at 9 p.m. are Pegasus (cheif star Merkab) near the zenith, Aquarius about <measure unit="deg">60</measure> and Capricornus about <measure unit="deg">40</measure> above the horizon.</p>
+                            <p>Jupiter rises at 9 p.m. at the beginning of the month, and becoems
+                                into opposition at the end.</p>
+                            <p>Saturn sets at 3 a.m. at the beginning of the month and 1 a.m. at the
+                                end.</p>
+                            <p>The cheif constelations in the South at 9 p.m. are Pegasus (cheif
+                                star Merkab) near the zenith, Aquarius about <measure unit="deg"
+                                    >60</measure> and Capricornus about <measure unit="deg"
+                                    >40</measure> above the horizon.</p>
                         </div>
                     </div>
                 </div>
@@ -1769,9 +2201,9 @@
                 <div type="item" scope="advertisement" xml:id="deg-ad-cah01">
                     <head>CARLTON HOTEL</head>
                     <p>Bulkeley, Ramleh.</p>
-                    <p>Ten minutes from Alexandria. First-Class in every respect Very moderate charges.
-                          Bulkeley is the fashionable English quarter. Visitors fron Cairo alight at Sidi
-                          Gaber Station.</p>
+                    <p>Ten minutes from Alexandria. First-Class in every respect Very moderate
+                        charges. Bulkeley is the fashionable English quarter. Visitors fron Cairo
+                        alight at Sidi Gaber Station.</p>
                     <p>24480-24-5-905</p>
                     <p>G. AQUILINA, Proprieter.</p>
                 </div>
@@ -1783,100 +2215,194 @@
                     <head>RANTS FOR RAILWAY EXTENSION.</head>
                     <head>DEVELOPMENT OF NORTHERN RUSSIA.</head>
                     <dateline><placeName>St. Petersburg</placeName>, October 2.</dateline>
-                    <p>The budget for 1905 provies for extensive railway construction especially for the devel nt of Northern Russia and the construction of a direct line from here to Omsk, it is understood that it has also been decided to doubling the Siberian line (Reuter)</p>
+                    <p>The budget for 1905 provies for extensive railway construction especially for
+                        the devel nt of Northern Russia and the construction of a direct line from
+                        here to Omsk, it is understood that it has also been decided to doubling the
+                        Siberian line (Reuter)</p>
                 </div>
                 <div type="article" scope="international">
                     <head>IMMENSE FIRE IN JAPAN</head>
                     <head>MY STORE BUILDINGS DESTROYED</head>
                     <dateline><placeName>Tokyo</placeName> October 2.</dateline>
-                    <p>Twenty seven army store buildings have been destroyed by fire at Hiroshima The buildings are still blazing and it is believed this is the work of an incendiary. The damage is from five to ten millions of yen.</p>
-                    (Reuter)
+                    <p>Twenty seven army store buildings have been destroyed by fire at Hiroshima
+                        The buildings are still blazing and it is believed this is the work of an
+                        incendiary. The damage is from five to ten millions of yen.</p>
+                    <byline>(Reuter)</byline>
                 </div>
                 <div type="article" scope="international">
                     <head>JAPANESE STEAMER SUNK.</head>
                     <dateline><placeName>Tokio</placeName>, October 2</dateline>
-                    <p>The Hstehho, a brand new steamer ofhcered foreigners, was sunk by a mine in the Yellow Sea on Saturday. Fifteen men were drowned.</p>
+                    <p>The Hstehho, a brand new steamer ofhcered foreigners, was sunk by a mine in
+                        the Yellow Sea on Saturday. Fifteen men were drowned.</p>
                 </div>
                 <div type="article" scope="international">
                     <head>FINANCIAL CONTROL IN MACEDONIA</head>
                     <head>FORTE RENEWS Objection</head>
-                    <p>In answer to collective note from the ambassadors, the Forte renews its objections i international nationalist control in Macedonia.</p>
+                    <p>In answer to collective note from the ambassadors, the Forte renews its
+                        objections i international nationalist control in Macedonia.</p>
                 </div>
                 <div type="article" scope="international">
                     <head>THE TUBERCULOSIS CONGRESS INAUGURATION WELL SUPPORTED</head>
-                    <dateline><placeName><placeName ref="https://www.wikidata.org/wiki/Q90">Paris</placeName></placeName>, October 2</dateline>
-                    <p>President Loubet has opened a most important Congress of tuberculosis specialists. Sixty seven foreign delegations, comprising three thousand doctors and scientists, will sit</p>
-                    <dateline><placeName ref="https://www.wikidata.org/wiki/Q90">Paris</placeName>, October 2.</dateline>
-                    <p>M Loubet has inaugurated the tuberculosis congress at which 3,500 people were present.</p>
+                    <div type="item">
+                        <dateline><placeName><placeName ref="https://www.wikidata.org/wiki/Q90"
+                                    >Paris</placeName></placeName>, October 2</dateline>
+                        <p>President Loubet has opened a most important Congress of tuberculosis
+                            specialists. Sixty seven foreign delegations, comprising three thousand
+                            doctors and scientists, will sit</p>
+                    </div>
+                    <div type="item">
+                        <dateline><placeName ref="https://www.wikidata.org/wiki/Q90"
+                                >Paris</placeName>, October 2.</dateline>
+                        <p>M Loubet has inaugurated the tuberculosis congress at which 3,500 people
+                            were present.</p>
+                    </div>
                 </div>
                 <div type="article" scope="international">
                     <head>THE AMERICAN COTTON CROP LARGE AREA RUINED BY STORMS.</head>
                     <dateline>New Orleans October 2.</dateline>
-                    <p>A terrific storm on the coast of the Gulf of Mexico has devastated the cotton crops in a large area.	(Reuter)</p>
+                    <p>A terrific storm on the coast of the Gulf of Mexico has devastated the cotton
+                        crops in a large area. (Reuter)</p>
                 </div>
-                <div type="article" scope="international">
+                <div type="wireReport" scope="international">
                     <head>A FRENCH CRUISER BREAKS Saigon, October 2.</head>
-                    <p>The armoured cruiser Sully has sank, her armoured deck has broken in two. ( Havas)</p>
-                    <dateline><placeName>Saigon</placeName>, October 2.</dateline>
-                    <p>The French armoured cruiser Sully, which cost a million sterling, has broken in two. (R.)</p>
-                    <p>The armoured cruiser Sully displaced about 10,000 tons, and her engines developed 20.000 horse power, giving her a speed of 21 knots She was built by the Forges et Chantiers do la Mediterrancee et La Seyne, being laid down in 1900 and launched on June 1 1901. She was well armoured for a cruiser, having a 6 in. belt with armoured casemates, turrets and conning tower, and carried two 7.6 in., eight 6.4 in , and six 4 in. quickfirers with twenty-four smaller guns and five 17.7 in. tubes, two armoured and one unarmoured above water, and two submerged. Her complement numbered 600 men. The Sully ran on an uncharted rock at Haiphong Bay, Tonquin, in February 1905, but it was hoped that she might be refloated with the aid of a large caisson recently completed at Hong Kong, which has evidently arrived too late. The Sully cost close on a million pounds.</p>
+                    <div type="item">
+                        <p>The armoured cruiser Sully has sank, her armoured deck has broken in two.
+                            ( Havas)</p>
+                        <dateline><placeName>Saigon</placeName>, October 2.</dateline>
+                    </div>
+                    <div type="item">
+                        <p>The French armoured cruiser Sully, which cost a million sterling, has
+                            broken in two. (R.)</p>
+                    </div>
+                    <div type="item">
+                        <p>The armoured cruiser Sully displaced about 10,000 tons, and her engines
+                            developed 20.000 horse power, giving her a speed of 21 knots She was
+                            built by the Forges et Chantiers do la Mediterrancee et La Seyne, being
+                            laid down in 1900 and launched on June 1 1901. She was well armoured for
+                            a cruiser, having a 6 in. belt with armoured casemates, turrets and
+                            conning tower, and carried two 7.6 in., eight 6.4 in , and six 4 in.
+                            quickfirers with twenty-four smaller guns and five 17.7 in. tubes, two
+                            armoured and one unarmoured above water, and two submerged. Her
+                            complement numbered 600 men. The Sully ran on an uncharted rock at
+                            Haiphong Bay, Tonquin, in February 1905, but it was hoped that she might
+                            be refloated with the aid of a large caisson recently completed at Hong
+                            Kong, which has evidently arrived too late. The Sully cost close on a
+                            million pounds.</p>
+                    </div>
                 </div>
-                <div type="article" scope="international">
+                <div type="wireReport" scope="international">
                     <head>RIOTING AT BRUNN</head>
-                    <dateLine><placeName>Brunn</placeName>, October 2.</dateLine>
-                    <p>Two hundred persons have been injured in rioting between Germans and Czechs here.</p>
-                    (Reuter)
+                    <dateline><placeName>Brunn</placeName>, October 2.</dateline>
+                    <p>Two hundred persons have been injured in rioting between Germans and Czechs
+                        here.</p>
                 </div>
-                <div type="article" scope="international">
-                    <head>BARON ROSEN IN <placeName ref="https://www.wikidata.org/wiki/Q90">Paris</placeName>.</head>
-                    <dateline><placeName><placeName ref="https://www.wikidata.org/wiki/Q90">Paris</placeName></placeName>, October 2.</dateline>
-                    <p>Baron Rosen visited M. Loubet and then attended a theatrical representation at the Opera House, where be occupied the President's box with Prince von Radolin. (Havas)</p>
+                <div type="wireReport" scope="international">
+                    <head>BARON ROSEN IN <placeName ref="https://www.wikidata.org/wiki/Q90"
+                            >Paris</placeName>.</head>
+                    <dateline><placeName><placeName ref="https://www.wikidata.org/wiki/Q90"
+                                >Paris</placeName></placeName>, October 2.</dateline>
+                    <p>Baron Rosen visited M. Loubet and then attended a theatrical representation
+                        at the Opera House, where be occupied the President's box with Prince von
+                        Radolin. (Havas)</p>
                 </div>
-                <div type="article" scope="international">
+                <div type="wireReport" scope="international">
                     <head>THE HOMEWARD MAILS</head>
-                    <placeName><placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName></placeName>October 2.
-                    <p>The mails from nearly thirty ships have been rent to <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> by tog.	(Reuter)</p>
+                    <dateline><placeName><placeName ref="https://www.wikidata.org/wiki/Q134514"
+                                >Suez</placeName></placeName>October 2.</dateline>
+                    <p>The mails from nearly thirty ships have been rent to <placeName
+                            ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> by
+                        tog. (Reuter)</p>
                 </div>
-                <div type="article" scope="international">
+                <div type="wireReport" scope="international">
                     <head>MR MACHELL ENGAGED</head>
-                    <placeName><placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName></placeName>, October 2.
-                    <p>Mr P W Macbell is engaged to Countess Vistoria Glsichen. (Reuter)</p>
+                    <dateline><placeName><placeName ref="https://www.wikidata.org/wiki/Q84"
+                                >London</placeName></placeName>, October 2.</dateline>
+                    <p>Mr P W Macbell is engaged to Countess Vistoria Glsichen.</p>
+                    <byline>(Reuter)</byline>
                 </div>
                 <div type="section" scope="local">
                     <head>LOCAL AND GENERAL</head>
                     <div type="article" scope="local">
                         <head>Esbekieh Gardens.</head>
-                        <p>We are requested to mention that the last concert of the season by the British military bands will be given on Friday the 13th instant.</p>
+                        <p>We are requested to mention that the last concert of the season by the
+                            British military bands will be given on Friday the 13th instant.</p>
                     </div>
                     <div type="article" scope="local">
                         <head>Concert at Kasr En-Nil</head>
-                        <p>An open-air vocal and instrumental concert, the last of the season, will be given this evening, commencing at 9 o'clock, at Karen-Nil barracks</p>
+                        <p>An open-air vocal and instrumental concert, the last of the season, will
+                            be given this evening, commencing at 9 o'clock, at Karen-Nil
+                            barracks</p>
                     </div>
                     <div type="article" scope="local">
-                        <p>A New Weekly under the title of  "Arte e Sport", a new Italian illustrated weekly will appear in the near future The subjects treated will be those mentioned in the title.</p>
-                        <p>We hope that M G E Brandt, the editor of " Arte e Sport" will meet with the success he deserves in this new and interesting departure.</p>
+                        <p>A New Weekly under the title of "Arte e Sport", a new Italian illustrated
+                            weekly will appear in the near future The subjects treated will be those
+                            mentioned in the title.</p>
+                        <p>We hope that M G E Brandt, the editor of " Arte e Sport" will meet with
+                            the success he deserves in this new and interesting departure.</p>
                     </div>
                     <div type="article" scope="local">
-                        <p>T <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>  Steamers Owing to the Post office having failed to inform that no postal van is attached to the train leaving <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> at 4 25 p.m our issue of yesterday was not delivered in <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>  until this morning We have, however, made arrangements by which the "Egyptian Gazette" will henceforth be delivered in <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>  on the evening of the day ot issue, as hitherto.</p>
+                        <p>T <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>
+                            Steamers Owing to the Post office having failed to inform that no postal
+                            van is attached to the train leaving <placeName
+                                ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> at 4
+                            25 p.m our issue of yesterday was not delivered in <placeName
+                                ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> until this
+                            morning We have, however, made arrangements by which the "Egyptian
+                            Gazette" will henceforth be delivered in <placeName
+                                ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> on the
+                            evening of the day ot issue, as hitherto.</p>
                     </div>
                     <div type="article" scope="local">
                         <head>The Charity Fete At Ghezireh</head>
-                        <p>The charity bazaar and fete, organised by some of the leading members of the Italian colony at the Capital in aid of the victims of the Calabrian earthquake, which took place at the Theatre des Ambassadeurs at Ghezireh on Sunday afternoon, was an unqualified success, and, considering the time of year, was largely attended by the eltie of society. It is expected that more than ₤300 will be realised from the bazar after deduction of expenses. The band of the Royal lnai-killing Fusiliers and the orchestra from the Theatre des Ninveantes played alternately during the fete which was kept up until the dinner hour.</p>
+                        <p>The charity bazaar and fete, organised by some of the leading members of
+                            the Italian colony at the Capital in aid of the victims of the Calabrian
+                            earthquake, which took place at the Theatre des Ambassadeurs at Ghezireh
+                            on Sunday afternoon, was an unqualified success, and, considering the
+                            time of year, was largely attended by the eltie of society. It is
+                            expected that more than ₤300 will be realised from the bazar after
+                            deduction of expenses. The band of the Royal lnai-killing Fusiliers and
+                            the orchestra from the Theatre des Ninveantes played alternately during
+                            the fete which was kept up until the dinner hour.</p>
                     </div>
                     <div type="article" scope="local">
                         <head>Crown Casino Iorahimieh</head>
-                        <p>The duettists, M Gaspard and Mde Neva, have, said farewell to the patrons of the music hall in connection with the Crown Brewery at Iorahimieh, after a short spell during which they were mos popular, but the management continue to provide a good programme. The debut of the musical clowns, the Prices, is billed for tonight, and Mlle Pulette d'lcles will also appear this evening for the first time at this theatre, though she is a well-known artiste both in <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>  and <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>. Mlle Marie Fleur continues to attract and charm large audiences, and amongst others Miles Ivenne Pianette and Brunette Abdolkader, whose Arabic songs and dances delight the effendi, are conspicuous successes.</p>
+                        <p>The duettists, M Gaspard and Mde Neva, have, said farewell to the patrons
+                            of the music hall in connection with the Crown Brewery at Iorahimieh,
+                            after a short spell during which they were mos popular, but the
+                            management continue to provide a good programme. The debut of the
+                            musical clowns, the Prices, is billed for tonight, and Mlle Pulette
+                            d'lcles will also appear this evening for the first time at this
+                            theatre, though she is a well-known artiste both in <placeName
+                                ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> and
+                                <placeName ref="https://www.wikidata.org/wiki/Q87"
+                                >Alexandria</placeName>. Mlle Marie Fleur continues to attract and
+                            charm large audiences, and amongst others Miles Ivenne Pianette and
+                            Brunette Abdolkader, whose Arabic songs and dances delight the effendi,
+                            are conspicuous successes.</p>
                     </div>
                     <div type="article" scope="local">
                         <head>Pro Calabria.</head>
-                        <p>An exceedingly successful "soiree de famille" was held at the Mex casino on Saturday evening for the benefit of the Calabrian sufferers, and was attended by a very large number. The entertainment was varied consisting of a short play, orchestral concert, firework display, and a dance There was also a lottery, the winning numbers of which will bo found in another column. A special performance will be given this evening at the Tour Eiffel with the same object,and the programme, which will include items in French, Italian, English German, Greek, etc, should be well received by the large numbers of persons who have bought tickets of admission. The chief attraction will be provided by the three sisters d'Orsay, who sing in several languages and are excellent dancers, and the programme also includes turns by Mlles Orsini, Tina Dumonte, Valincourt, Borgui, etc., etc.</p>
+                        <p>An exceedingly successful "soiree de famille" was held at the Mex casino
+                            on Saturday evening for the benefit of the Calabrian sufferers, and was
+                            attended by a very large number. The entertainment was varied consisting
+                            of a short play, orchestral concert, firework display, and a dance There
+                            was also a lottery, the winning numbers of which will bo found in
+                            another column. A special performance will be given this evening at the
+                            Tour Eiffel with the same object,and the programme, which will include
+                            items in French, Italian, English German, Greek, etc, should be well
+                            received by the large numbers of persons who have bought tickets of
+                            admission. The chief attraction will be provided by the three sisters
+                            d'Orsay, who sing in several languages and are excellent dancers, and
+                            the programme also includes turns by Mlles Orsini, Tina Dumonte,
+                            Valincourt, Borgui, etc., etc.</p>
                     </div>
                 </div>
                 <div type="section" scope="sporting">
                     <head>SPORT AND PLAY.</head>
                     <div type="article" scope="sporting">
                         <head>KHEDIVIALS YACHT CLUB</head>
-                        <head type="sub">REGATTA.</head><!-- TODO finish full table markup with section heads -->
+                        <head type="sub">REGATTA.</head>
+                        <!-- TODO finish full table markup with section heads -->
                         <p>The following is the handicap for tomorrow's regatta</p>
                         <table rows="6" cols="2">
                             <head>Class 1</head>
@@ -1934,25 +2460,59 @@
                             </row>
                         </table>
                         <p>Class I. Course C Class II. Course Q</p>
-                        <p>H. H. the Khedive having promised to visit the club, the races for cups this week will not be sailed but will be postponed until the occaision of his Highness' visit.</p>
+                        <p>H. H. the Khedive having promised to visit the club, the races for cups
+                            this week will not be sailed but will be postponed until the occaision
+                            of his Highness' visit.</p>
                     </div>
                 </div>
                 <div type="section" scope="letters">
                     <head>INTERESTING CORRESPONDENCE.</head>
                     <div type="article" scope="letters">
                         <head>THE PRINCES AND THE DAIRA.</head>
-                        <p>The claim brought by the Princess, heirs of the late Ismail Pasha, against the Egyptian Government tor the return of the surplus accuring from the sales of the Daira Sanieh properties after the satisfaction of all the creditors of the Daira Sanieh, is to be heard on the 30th inst.</p>
-                        <p>The claim of the princes interested was presented to the Khedive early in February 1905. A letter containing the terms of the demand and explaining its motives, was forwarded by Prince Ibrahim Pasha, in the name of the claimants, to Lord Cromer, and gave rise to the following correspondence, the discussion of which we leave to our readers, as the affair is sub-judice.</p>
+                        <p>The claim brought by the Princess, heirs of the late Ismail Pasha,
+                            against the Egyptian Government tor the return of the surplus accuring
+                            from the sales of the Daira Sanieh properties after the satisfaction of
+                            all the creditors of the Daira Sanieh, is to be heard on the 30th
+                            inst.</p>
+                        <p>The claim of the princes interested was presented to the Khedive early in
+                            February 1905. A letter containing the terms of the demand and
+                            explaining its motives, was forwarded by Prince Ibrahim Pasha, in the
+                            name of the claimants, to Lord Cromer, and gave rise to the following
+                            correspondence, the discussion of which we leave to our readers, as the
+                            affair is sub-judice.</p>
                         <quotedLetter>
                             <opener>
                                 <head>The British Agency.</head>
-                                <dateline><placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> , March 1, 1905.</dateline>
+                                <dateline><placeName ref="https://www.wikidata.org/wiki/Q85"
+                                        >Cairo</placeName> , March 1, 1905.</dateline>
                                 <salute>Your Highness,</salute>
                             </opener>
-                            <p>I have the honor to inform you that the Legal Adviser of the Egyptian Government has given his opinion on the question raised in the note appended to the letter dated January 29, which your Highness was good enongh to forward me. After a detailed examination of the question at issue, the Legal Adviser concludes his summary in the following terms. "The demand of the heirs of Ismail Pasha has no chance of being entertained by the tribunals."</p>
-                            <p>It is clear that in virtue of article 40 of the Law of Liquidation the full entire right over the properties in question are vested in the State. While I support the view expressed by the Legal Adviser to the Government, I should like to draw the attention of your Highness to the opinion I expressed on this subject as a member of the Commission of Inquiry.</p>
-                            <p>"The domains of the Dairas have been acquired at the expense and to the detriment of the country. It is therefore only just then the Khedive should restore a property which has been illegally acquired."</p>
-                            <p>I am of the same opinion to day. Sir Charles Rivers Wilson, President of the Commission, also emphasised the fact that the property of the Dairas had been acquired with the funds of the State Under these circumstances I regret not only that I cannot support the claim made by certain members of the Khedivial family hot that, in the highly improbable case of the Egyptian Government favoring this claim, I would be obliged to formally oppose it in the interests of the people and taxpayers of <placeName ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName>.</p>
+                            <p>I have the honor to inform you that the Legal Adviser of the Egyptian
+                                Government has given his opinion on the question raised in the note
+                                appended to the letter dated January 29, which your Highness was
+                                good enongh to forward me. After a detailed examination of the
+                                question at issue, the Legal Adviser concludes his summary in the
+                                following terms. "The demand of the heirs of Ismail Pasha has no
+                                chance of being entertained by the tribunals."</p>
+                            <p>It is clear that in virtue of article 40 of the Law of Liquidation
+                                the full entire right over the properties in question are vested in
+                                the State. While I support the view expressed by the Legal Adviser
+                                to the Government, I should like to draw the attention of your
+                                Highness to the opinion I expressed on this subject as a member of
+                                the Commission of Inquiry.</p>
+                            <p>"The domains of the Dairas have been acquired at the expense and to
+                                the detriment of the country. It is therefore only just then the
+                                Khedive should restore a property which has been illegally
+                                acquired."</p>
+                            <p>I am of the same opinion to day. Sir Charles Rivers Wilson, President
+                                of the Commission, also emphasised the fact that the property of the
+                                Dairas had been acquired with the funds of the State Under these
+                                circumstances I regret not only that I cannot support the claim made
+                                by certain members of the Khedivial family hot that, in the highly
+                                improbable case of the Egyptian Government favoring this claim, I
+                                would be obliged to formally oppose it in the interests of the
+                                people and taxpayers of <placeName
+                                    ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName>.</p>
                             <closer>
                                 <Signed>(Signed) Cromer.</Signed>
                                 <p>To. H H Prince Ibrahim Pasha.</p>
@@ -1961,130 +2521,376 @@
                         <p>To this letter the Prince replied as follows.</p>
                         <quotedLetter>
                             <opener>
-                                <dateline><placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> , March 20, 1905.</dateline>
+                                <dateline><placeName ref="https://www.wikidata.org/wiki/Q85"
+                                        >Cairo</placeName> , March 20, 1905.</dateline>
                                 <salute>My Lord.</salute>
                             </opener>
-                            <p>I have the honor to acknowledge the receipt of the letter addressed to me by your Lordship under date of the 1st inst which I have communicated to the Princes, my brothers. We cannot but regret the opinion expressed by the Legal Adviser and especially the declaration that your Lordship has decided, in the interests of the Egyptian people, to oppose any favorable reception to our demand that the Government may make. We are reserving our reply to the government until we receive the reasons adduced by its legal advisers in support of their contention."</p>
+                            <p>I have the honor to acknowledge the receipt of the letter addressed
+                                to me by your Lordship under date of the 1st inst which I have
+                                communicated to the Princes, my brothers. We cannot but regret the
+                                opinion expressed by the Legal Adviser and especially the
+                                declaration that your Lordship has decided, in the interests of the
+                                Egyptian people, to oppose any favorable reception to our demand
+                                that the Government may make. We are reserving our reply to the
+                                government until we receive the reasons adduced by its legal
+                                advisers in support of their contention."</p>
                         </quotedLetter>
-                        <p>Prince Ibrahim continues by protesting against Lord Cromer’s view that the Daira properties wore obtained at the expense and to the detriment of the country. The properties of the Khedivial house of Mohamed Ali were acquired by right of conquest and with the consent of the Sultan from whom the Pasha of <placeName ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName> derived his powers. The Seigneurial rights over landed property in Europe had the same origin. In fact Henry VIII. in England and Cromwell in Ireland had established domains founded on the same right, viz., conquest and the consent of the supreme power, and the present possessors of these domains are not likely to find their titles called in question. The late Ismail Pasha, who was in possesion of many of the Daira properties by hereditary right before he became Viceroy of <placeName ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName>, did much to improve and benefit these properties, and the expression “illegally acquired" would never have been employed had the Commision of Enquiry been able to study the facts. "England in the past prevented Daniel O’Connell from proclaiming that the owners of large Irish estates were in possession of properties illegally acquired. Of yon, my Lord, who personify in <placeName ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName> the public opinion of the freest country in the world, we only ask for an explanation of a statement, revived after twenty five years’ silence, and based upon incomplete information." Prince Ibrahim farther states that the fact that an original right is based on conquest is no bar to its enjoyment bv the heirs of the first occupant under such a right—in this particular case the late Khedive Ismail. Farther if hie estates had been taken by force and illegally from the Egyptian people, the Government would not have disposed of them to any but the persons dispossessed or their heirs. The fact that it has disposed of them to others seems to show that it does not consider these Daira estates to have been illegally acquired.</p>
-                        <p>To this letter Lord Cromer replied as follows under the date of March 25.</p>
+                        <p>Prince Ibrahim continues by protesting against Lord Cromer’s view that
+                            the Daira properties wore obtained at the expense and to the detriment
+                            of the country. The properties of the Khedivial house of Mohamed Ali
+                            were acquired by right of conquest and with the consent of the Sultan
+                            from whom the Pasha of <placeName
+                                ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName> derived
+                            his powers. The Seigneurial rights over landed property in Europe had
+                            the same origin. In fact Henry VIII. in England and Cromwell in Ireland
+                            had established domains founded on the same right, viz., conquest and
+                            the consent of the supreme power, and the present possessors of these
+                            domains are not likely to find their titles called in question. The late
+                            Ismail Pasha, who was in possesion of many of the Daira properties by
+                            hereditary right before he became Viceroy of <placeName
+                                ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName>, did much
+                            to improve and benefit these properties, and the expression “illegally
+                            acquired" would never have been employed had the Commision of Enquiry
+                            been able to study the facts. "England in the past prevented Daniel
+                            O’Connell from proclaiming that the owners of large Irish estates were
+                            in possession of properties illegally acquired. Of yon, my Lord, who
+                            personify in <placeName ref="https://www.wikidata.org/wiki/Q79"
+                                >Egypt</placeName> the public opinion of the freest country in the
+                            world, we only ask for an explanation of a statement, revived after
+                            twenty five years’ silence, and based upon incomplete information."
+                            Prince Ibrahim farther states that the fact that an original right is
+                            based on conquest is no bar to its enjoyment bv the heirs of the first
+                            occupant under such a right—in this particular case the late Khedive
+                            Ismail. Farther if hie estates had been taken by force and illegally
+                            from the Egyptian people, the Government would not have disposed of them
+                            to any but the persons dispossessed or their heirs. The fact that it has
+                            disposed of them to others seems to show that it does not consider these
+                            Daira estates to have been illegally acquired.</p>
+                        <p>To this letter Lord Cromer replied as follows under the date of March
+                            25.</p>
                         <quotedLetter>
                             <opener>
                                 <salute>Your Highness,</salute>
                             </opener>
-                            <p>I beg to acknowledge the receipt of the letter which your Highness was kind enough to address to me under date of the 23rd inst. Since I see no possibility of altering the opinion I expressed in my letter of the 1st inst., or of modifying the terms in which I expressed my opinion, I hope your Highness will recognise with me that farther correspondence on this subject is of no use. I therefore beg your Highness to be good enough to excuse me for refraining to discuss the points raised in your letter. If your Highness, in agreement with the other Princess of the Khedivial family, wishes to pursue your claim on the Daira properties, you can at any time have recourse to the Tribunals, which will decide whether the claim is or is not well founded, etc., etc.</p>
+                            <p>I beg to acknowledge the receipt of the letter which your Highness
+                                was kind enough to address to me under date of the 23rd inst. Since
+                                I see no possibility of altering the opinion I expressed in my
+                                letter of the 1st inst., or of modifying the terms in which I
+                                expressed my opinion, I hope your Highness will recognise with me
+                                that farther correspondence on this subject is of no use. I
+                                therefore beg your Highness to be good enough to excuse me for
+                                refraining to discuss the points raised in your letter. If your
+                                Highness, in agreement with the other Princess of the Khedivial
+                                family, wishes to pursue your claim on the Daira properties, you can
+                                at any time have recourse to the Tribunals, which will decide
+                                whether the claim is or is not well founded, etc., etc.</p>
                             <closer>
                                 <signed>(Signed) Cromer.</signed>
                             </closer>
                         </quotedLetter>
                     </div>
                     <div type="article" scope="letters">
-                        <head>ARCHEOLOGY IN <placeName ref="https://www.wikidata.org/wiki/Q43">Turkey</placeName>.</head>
+                        <head>ARCHEOLOGY IN <placeName ref="https://www.wikidata.org/wiki/Q43"
+                                >Turkey</placeName>.</head>
                         <head>A SHORT REVIEW</head>
                         <p>(From a Constantinople Correspondent).</p>
-                        <p>No other country in the world has been so richly endowed with archaeological remains as <placeName ref="https://www.wikidata.org/wiki/Q43">Turkey</placeName>. Nowhere are ancient monuments and relics so varied, in point of style and epoch, as those hidden beneath the soil of the Otto man Empire, and more particularly in its Asiatic dominions. Assyria, <placeName ref="https://www.wikidata.org/wiki/Q41">Greece</placeName>, Rome, each in turn have bequeathed to their successor treasures which but await the antiquarian’s spade in order to be properly estimated and which, valued according to their commercial worth, would, such is the irony of fate, replenish the proverbially empty coffers of State. But it has required the introduction of European civilisation to gradually awaken the Turks to this fact. Not so many years ago archaeological research was carried on under very restricted if not vexations conditions, arising out of the rooted dislike of the Turkish official to foreigners tampering with his sacred soil; he could not understand the object in digging among ruins which, unless they contained a certain amount of marble for building purposes were no better than a dung-hill, a place for owls and bats. But it is no less true that he objected, and very rightly, to numerous cases of wholesale depredation committed by a certain sect of the archaeological world who had been brought up in Lord Elgin's school. Those days are past alike for official objection and brigand depredation. The status of the archaeologist has been legalised, and the proper authorities have been appointed to attend to this department of the State. Pan Athenaic Freizess can no longer be smuggled out of the country, and the value of  archaeology having been appreciated, the efforts of the provincial authorities are now devoted to a more perfect mode of preservation than that afforded to antiquities by a superstratum of earth.</p>
-                        <p>The subject title “Archaeology in <placeName ref="https://www.wikidata.org/wiki/Q43">Turkey</placeName>" ebraces too wide a field for general survey, and it will be necessary, therefore, to deal separately with each district in which explorations are now in progress. Before so doing, however, it may be well to devote some attention to an institution which, in the Capital of the Empire, is directly interested in all that appertains to archaeological research on either side of the Bosphorus. Moreover, the happy era which bas dawned, or more correctly speaking the official recognition of archaeology, dates from the foundation of Tochinili kiosk, or the Stamboul museum, in 1875. The collection preserved in this museum may well rank with that of any other European capital and the continual addition of newly-discovered antiquities, amongst others those of the Temple of Diana at Ephesus, mentioned in the "Times," have increased in like measure its value. The grounds on which the kiosk and the other buildings of the museum stand, on the summit of the Acropolis of St. Demetrius, or Serai Bournou, are, both historically and for pucturesque scenery, unique in Constantinople.</p>
-                        <p>Half-hidden in groves of cypress and plane the museum stands between the quaint old Mint and the Church of St Irene whose now silent belfry crowns the whole scene. It is an enchanting spot, the natural theatre of many an incident in political and church history, as the strange appearance of a Christian be fry amidst so much of oriental scenery is enough to show. The battlefield of Brands, who lost the day on yon velvet sward, the promenade of the Greek Emperors, these and countless other scenes of its ancient history crowd the memory as the vision lingers lovingly on the sacred soil. A worthy shrine for the monuments of ancient art which are associated with the past.</p>
-                        <p>It was in. 1850 that the nucleus of the present collection was formed by Fethi Ahmed Pasha, Grand Master of Artillery, within the hall of the ancient church of St. Irene already named, which, from being being the chapel royal of Byzantium, has been degraded into an armoury called the Jeb Heneh. This hall, however, proved inadequate for the continual additions which now began to be made from the collector from all parts of the country,and,in 1875 daring the ministry of Subhi Pasha, Minister of Publio Instruction, and a numismatist of note, an Imperial irade was promulgated authorising its transfer to Tchinili kiosk. After the discovery in 1887-1888, by the museum, of twenty one sarcophagi at Saida (ancient Sidon), of which several may be said to be of the best Greek sculputre, Tchinili kiosk also became in tarn too small for the collection, and in virtue of another irade, a new building was erected, purposely to receive these tombs, opposite Tchinili kiosk.</p>
-                        <p>The new museum was opened in 1892, since when such a number of additions have been made to it that two wings have had to be erected it.</p>
-                        <p>The character of nearly all the relics preserved in the new musem is funeral, it having been the intention of Hamdi Bey to give it that distinctive character.</p>
-                        <p>Entrance to the museum grounds is through one of the lower gates of the old Seraglio, the tram line from Karakeui bridge landing the visitor at the threshold. From here a gravel path, lined with antique monuments and statues wind amid the cypresses as far Tchinili kiosk.</p>
-                        <p>The kiosk was built by Sultan Fatih Mah- opposite it is the new museum, much larger, and now being added to by a building of about the same size, which, among other recent arrivals is to receive the antiquities discovered at Ephesus in the excavation of the seventh temple of Artemis. Forming the and of the enclosure is a wing containing more rooms filled with sarcophagi, the offices of the museum, and a library of 15,000 volumes bequeathed by the late Djevad Pasha, and of these works 8,000 an Oriental.</p>
+                        <p>No other country in the world has been so richly endowed with
+                            archaeological remains as <placeName
+                                ref="https://www.wikidata.org/wiki/Q43">Turkey</placeName>. Nowhere
+                            are ancient monuments and relics so varied, in point of style and epoch,
+                            as those hidden beneath the soil of the Otto man Empire, and more
+                            particularly in its Asiatic dominions. Assyria, <placeName
+                                ref="https://www.wikidata.org/wiki/Q41">Greece</placeName>, Rome,
+                            each in turn have bequeathed to their successor treasures which but
+                            await the antiquarian’s spade in order to be properly estimated and
+                            which, valued according to their commercial worth, would, such is the
+                            irony of fate, replenish the proverbially empty coffers of State. But it
+                            has required the introduction of European civilisation to gradually
+                            awaken the Turks to this fact. Not so many years ago archaeological
+                            research was carried on under very restricted if not vexations
+                            conditions, arising out of the rooted dislike of the Turkish official to
+                            foreigners tampering with his sacred soil; he could not understand the
+                            object in digging among ruins which, unless they contained a certain
+                            amount of marble for building purposes were no better than a dung-hill,
+                            a place for owls and bats. But it is no less true that he objected, and
+                            very rightly, to numerous cases of wholesale depredation committed by a
+                            certain sect of the archaeological world who had been brought up in Lord
+                            Elgin's school. Those days are past alike for official objection and
+                            brigand depredation. The status of the archaeologist has been legalised,
+                            and the proper authorities have been appointed to attend to this
+                            department of the State. Pan Athenaic Freizess can no longer be smuggled
+                            out of the country, and the value of archaeology having been
+                            appreciated, the efforts of the provincial authorities are now devoted
+                            to a more perfect mode of preservation than that afforded to antiquities
+                            by a superstratum of earth.</p>
+                        <p>The subject title “Archaeology in <placeName
+                                ref="https://www.wikidata.org/wiki/Q43">Turkey</placeName>" ebraces
+                            too wide a field for general survey, and it will be necessary,
+                            therefore, to deal separately with each district in which explorations
+                            are now in progress. Before so doing, however, it may be well to devote
+                            some attention to an institution which, in the Capital of the Empire, is
+                            directly interested in all that appertains to archaeological research on
+                            either side of the Bosphorus. Moreover, the happy era which bas dawned,
+                            or more correctly speaking the official recognition of archaeology,
+                            dates from the foundation of Tochinili kiosk, or the Stamboul museum, in
+                            1875. The collection preserved in this museum may well rank with that of
+                            any other European capital and the continual addition of
+                            newly-discovered antiquities, amongst others those of the Temple of
+                            Diana at Ephesus, mentioned in the "Times," have increased in like
+                            measure its value. The grounds on which the kiosk and the other
+                            buildings of the museum stand, on the summit of the Acropolis of St.
+                            Demetrius, or Serai Bournou, are, both historically and for pucturesque
+                            scenery, unique in Constantinople.</p>
+                        <p>Half-hidden in groves of cypress and plane the museum stands between the
+                            quaint old Mint and the Church of St Irene whose now silent belfry
+                            crowns the whole scene. It is an enchanting spot, the natural theatre of
+                            many an incident in political and church history, as the strange
+                            appearance of a Christian be fry amidst so much of oriental scenery is
+                            enough to show. The battlefield of Brands, who lost the day on yon
+                            velvet sward, the promenade of the Greek Emperors, these and countless
+                            other scenes of its ancient history crowd the memory as the vision
+                            lingers lovingly on the sacred soil. A worthy shrine for the monuments
+                            of ancient art which are associated with the past.</p>
+                        <p>It was in. 1850 that the nucleus of the present collection was formed by
+                            Fethi Ahmed Pasha, Grand Master of Artillery, within the hall of the
+                            ancient church of St. Irene already named, which, from being being the
+                            chapel royal of Byzantium, has been degraded into an armoury called the
+                            Jeb Heneh. This hall, however, proved inadequate for the continual
+                            additions which now began to be made from the collector from all parts
+                            of the country,and,in 1875 daring the ministry of Subhi Pasha, Minister
+                            of Publio Instruction, and a numismatist of note, an Imperial irade was
+                            promulgated authorising its transfer to Tchinili kiosk. After the
+                            discovery in 1887-1888, by the museum, of twenty one sarcophagi at Saida
+                            (ancient Sidon), of which several may be said to be of the best Greek
+                            sculputre, Tchinili kiosk also became in tarn too small for the
+                            collection, and in virtue of another irade, a new building was erected,
+                            purposely to receive these tombs, opposite Tchinili kiosk.</p>
+                        <p>The new museum was opened in 1892, since when such a number of additions
+                            have been made to it that two wings have had to be erected it.</p>
+                        <p>The character of nearly all the relics preserved in the new musem is
+                            funeral, it having been the intention of Hamdi Bey to give it that
+                            distinctive character.</p>
+                        <p>Entrance to the museum grounds is through one of the lower gates of the
+                            old Seraglio, the tram line from Karakeui bridge landing the visitor at
+                            the threshold. From here a gravel path, lined with antique monuments and
+                            statues wind amid the cypresses as far Tchinili kiosk.</p>
+                        <p>The kiosk was built by Sultan Fatih Mah- opposite it is the new museum,
+                            much larger, and now being added to by a building of about the same
+                            size, which, among other recent arrivals is to receive the antiquities
+                            discovered at Ephesus in the excavation of the seventh temple of
+                            Artemis. Forming the and of the enclosure is a wing containing more
+                            rooms filled with sarcophagi, the offices of the museum, and a library
+                            of 15,000 volumes bequeathed by the late Djevad Pasha, and of these
+                            works 8,000 an Oriental.</p>
                         <p>(To be continued.)</p>
                     </div>
                     <div type="article" scope="letters">
                         <head>MR. MACHELL'S ENGAGEMENT.</head>
                         <head>HIS FUTURE BRIDE</head>
-                        <p>The Countess • Victoria Glpichen, whose engagement to Mr. P. W. Machell has just been announced, is the daughter of H.S.H the late Prince Victor of Hohenlohe Langenbnrg and H.S.H. Princess Victor of Hohenlohe, nee Lady Laura Seymour, and is the niece of H. M. the late Queen Victoria. Her brother, Count Ghleichen, C.M.G. was recently director of Intelligence and Sudan agent to the Egyptian Army and is now military attache at Berlin.</p>
-                        <p>Mr. P. W. Machell. Adviser to the Ministry of the Interior, has shunned all notice in the columns of the Press, not to mention "Who’s Who,” (both the British and the Anglo-African editions) with such success that we would feel a certain diffidence mentioning him, were it not for the fact, that <placeName ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName> owes him so much for the destruction of various pests, from the overthrow of the raiders at Khor Musa in 1888 to the leu dramatic but equally serious campaign against the cotton worm in 1905 Mr. Machell has a few critics, no enemies, and innumerable friends, and on our own behalf and for our readers we congratulate him most heartily.</p>
+                        <p>The Countess • Victoria Glpichen, whose engagement to Mr. P. W. Machell
+                            has just been announced, is the daughter of H.S.H the late Prince Victor
+                            of Hohenlohe Langenbnrg and H.S.H. Princess Victor of Hohenlohe, nee
+                            Lady Laura Seymour, and is the niece of H. M. the late Queen Victoria.
+                            Her brother, Count Ghleichen, C.M.G. was recently director of
+                            Intelligence and Sudan agent to the Egyptian Army and is now military
+                            attache at Berlin.</p>
+                        <p>Mr. P. W. Machell. Adviser to the Ministry of the Interior, has shunned
+                            all notice in the columns of the Press, not to mention "Who’s Who,”
+                            (both the British and the Anglo-African editions) with such success that
+                            we would feel a certain diffidence mentioning him, were it not for the
+                            fact, that <placeName ref="https://www.wikidata.org/wiki/Q79"
+                                >Egypt</placeName> owes him so much for the destruction of various
+                            pests, from the overthrow of the raiders at Khor Musa in 1888 to the leu
+                            dramatic but equally serious campaign against the cotton worm in 1905
+                            Mr. Machell has a few critics, no enemies, and innumerable friends, and
+                            on our own behalf and for our readers we congratulate him most
+                            heartily.</p>
                     </div>
                     <div type="article" scope="letters">
-                        <head>EASTERN EXCHANGE, <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>.</head>
-                        <p>On a recent visit to this well-known and deservedly popular hotel, we were informed by the courteous manager, M. A. de Carli, that extensive alterations were in contemplation, which would, when effected, greatly add to the comfort and convenience of visitors to the hotel. The details of these would not be settled until the arrival of the proprietor, who is expected at an early date ; but we understand that the alterations may include the building of a wide and convenient staircase to the more frequented floors of the building, for the use of those who prefer not to ascend by the lift, and that it is intended to provide an elegant sitting room on the first floor. A garden has recently been laid out ie connection with the bar, and altogether this well-known visitors’ resort shows itself in every way desirous of keeping abreast—if not in advance—of the times. The great height of the buliding should alone form an attraction to those fond of fresh air and fine views, the wide verandahs ran, which entirely round the different floors, enabling the occupants of the various rooms to select the most convenient and sheltered spots in which to enjoy the land or seascape from any point of the compass.</p>
+                        <head>EASTERN EXCHANGE, <placeName
+                                ref="https://www.wikidata.org/wiki/Q134509">Port
+                            Said</placeName>.</head>
+                        <p>On a recent visit to this well-known and deservedly popular hotel, we
+                            were informed by the courteous manager, M. A. de Carli, that extensive
+                            alterations were in contemplation, which would, when effected, greatly
+                            add to the comfort and convenience of visitors to the hotel. The details
+                            of these would not be settled until the arrival of the proprietor, who
+                            is expected at an early date ; but we understand that the alterations
+                            may include the building of a wide and convenient staircase to the more
+                            frequented floors of the building, for the use of those who prefer not
+                            to ascend by the lift, and that it is intended to provide an elegant
+                            sitting room on the first floor. A garden has recently been laid out ie
+                            connection with the bar, and altogether this well-known visitors’ resort
+                            shows itself in every way desirous of keeping abreast—if not in
+                            advance—of the times. The great height of the buliding should alone form
+                            an attraction to those fond of fresh air and fine views, the wide
+                            verandahs ran, which entirely round the different floors, enabling the
+                            occupants of the various rooms to select the most convenient and
+                            sheltered spots in which to enjoy the land or seascape from any point of
+                            the compass.</p>
                     </div>
                 </div>
-                <div type="section" scope="Steamer Movements">
+                <div type="section" scope="maritime">
                     <head>STEAMER MOVEMENTS.</head>
-                    <p>The S.S. Trojan Prince left Manchester on Sunday with passengers and general cargo, and is due to arrive at <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>n, via Tunis and <placeName ref="https://www.wikidata.org/wiki/Q233">Malta</placeName>, on or about October 16.</p>
+                    <p>The S.S. Trojan Prince left Manchester on Sunday with passengers and general
+                        cargo, and is due to arrive at <placeName
+                            ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>n, via
+                        Tunis and <placeName ref="https://www.wikidata.org/wiki/Q233"
+                            >Malta</placeName>, on or about October 16.</p>
                 </div>
                 <div type="section" scope="social">
                     <head>PERSONAL AND SOCIAL</head>
                     <div type="article" scope="social">
-                        <p>Rumours are current that Khalil Pasha Hamdi Hamsda, local director of Customs, will shortly replace Skander Pasha Fehmi on the Railway Board, on the retirement of that official on pension.</p>
+                        <p>Rumours are current that Khalil Pasha Hamdi Hamsda, local director of
+                            Customs, will shortly replace Skander Pasha Fehmi on the Railway Board,
+                            on the retirement of that official on pension.</p>
                     </div>
                     <div type="article" scope="social">
-                        <p>Mr. James Hewat, American Consol, at <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>, arrived this morning by the Messageries Maritime mail boat,</p>
+                        <p>Mr. James Hewat, American Consol, at <placeName
+                                ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>,
+                            arrived this morning by the Messageries Maritime mail boat,</p>
                     </div>
                     <div type="article" scope="social">
-                        <p>A <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>  contemporary announces that Sir Horace Pincing and Dr. Bitter have been delegated to represent <placeName ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName> at the Tuberculosis Congress, which was inaugurated at <placeName ref="https://www.wikidata.org/wiki/Q90">Paris</placeName> yesterday.</p>
+                        <p>A <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>
+                            contemporary announces that Sir Horace Pincing and Dr. Bitter have been
+                            delegated to represent <placeName
+                                ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName> at the
+                            Tuberculosis Congress, which was inaugurated at <placeName
+                                ref="https://www.wikidata.org/wiki/Q90">Paris</placeName>
+                            yesterday.</p>
                     </div>
                     <div type="article" scope="social">
-                        <p>Among the latest arrivals at the Windsor Hotel, <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>, we notice Mr. and Mrs. E. Parser, Mr. and Mrs. Hague, Mr. Hodar, M. Mr. Mrs. Page, Dr Granville, Mrs. Natchigal, M. Dossa,Mr. &amp; Mrs. Holser, Dr Faber,Dr.Beyd Carpenter, Dr. Goldslich, Mr. and Mrs. Antounepoulo, Dr O. J. van Millingen, Mr. Hioka, Mrs. Corbett, Mr. Fishcer, Mr. Pox, Mr. Cokerson, Mr. Kockouk, Mr. Maule, Mr. and Mrs. Agiry, Mr. Bolojian, Mr. Forte, Mr. Raouff, Mr. Angliker, Mr. Sebton. Mr. Rossi, Mr. Bid, Dr. Morogh, Mr. Barnetti, Mrs. Zananiri, Mr. Mr. Cavolo, Mr. Aeroul, Mr. Osborne, Shepherd; Mr. Cuming, Mr. Wilson, Lt G. Grylls, Mr. Rosano, Mr. Camel, Mr. Jones, Mr. Joseph, Mr. and Mrs. Mariatopoulo, Mr. and Mrs. Justiniany, Mr. Moss, Mr. Long, Mr. Bond, Mr. Craig.</p>
+                        <p>Among the latest arrivals at the Windsor Hotel, <placeName
+                                ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>, we
+                            notice Mr. and Mrs. E. Parser, Mr. and Mrs. Hague, Mr. Hodar, M. Mr.
+                            Mrs. Page, Dr Granville, Mrs. Natchigal, M. Dossa,Mr. &amp; Mrs. Holser,
+                            Dr Faber,Dr.Beyd Carpenter, Dr. Goldslich, Mr. and Mrs. Antounepoulo, Dr
+                            O. J. van Millingen, Mr. Hioka, Mrs. Corbett, Mr. Fishcer, Mr. Pox, Mr.
+                            Cokerson, Mr. Kockouk, Mr. Maule, Mr. and Mrs. Agiry, Mr. Bolojian, Mr.
+                            Forte, Mr. Raouff, Mr. Angliker, Mr. Sebton. Mr. Rossi, Mr. Bid, Dr.
+                            Morogh, Mr. Barnetti, Mrs. Zananiri, Mr. Mr. Cavolo, Mr. Aeroul, Mr.
+                            Osborne, Shepherd; Mr. Cuming, Mr. Wilson, Lt G. Grylls, Mr. Rosano, Mr.
+                            Camel, Mr. Jones, Mr. Joseph, Mr. and Mrs. Mariatopoulo, Mr. and Mrs.
+                            Justiniany, Mr. Moss, Mr. Long, Mr. Bond, Mr. Craig.</p>
                     </div>
                     <div type="article" scope="social">
-                        <p>Among the latest arrivals at the Beau-Rivage Hotel, Ramleh, we notice : H. E. Abbate Pasha, Mr. and Mrs. T. H. Davey, Dr. and Mre. Kautsky and family, Mr. G. Metral, Mr. and Mrs. Davacos, Mrs. M. Young, Mr. H. Colie.</p>
+                        <p>Among the latest arrivals at the Beau-Rivage Hotel, Ramleh, we notice :
+                            H. E. Abbate Pasha, Mr. and Mrs. T. H. Davey, Dr. and Mre. Kautsky and
+                            family, Mr. G. Metral, Mr. and Mrs. Davacos, Mrs. M. Young, Mr. H.
+                            Colie.</p>
                     </div>
                     <div type="section" scope="advertisement">
-                        <div type="item" scope="advertisment">
+                        <div type="item" scope="advertisement"><!-- TODO Replace with Ad boilerplate -->
                             <head>RECK &amp; CO’S PILSNER BEER BREMEN.</head>
                             <head>FEARS NO HONEST COMPETITION FOR QUALITY.</head>
-                            <p>B.—Inferior Brands now being offered to Manager of certain good <unclear><ad/></unclear>.</p>
+                            <p>B.—Inferior Brands now being offered to Manager of certain good
+                                    <unclear></unclear>.</p>
                             <p>Beware of evilly disposed competitors running</p>
                         </div>
                         <div type="item" scope="advertisement" xml:id="deg-ad-aan02">
                             <p>Anglo-American Nile Steamer &amp; Hotel Company </p>
-                            <p>River Transport of Good Between <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> &amp; <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> </p>
+                            <p>River Transport of Good Between <placeName
+                                    ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>
+                                &amp; <placeName ref="https://www.wikidata.org/wiki/Q85"
+                                    >Cairo</placeName>
+                            </p>
                             <p>Three Sailings a-Week.</p>
-                            <p>Agents at <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>:</p>
-                            <p><placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> Bonded Warehouse Co. Ld</p>
+                            <p>Agents at <placeName ref="https://www.wikidata.org/wiki/Q87"
+                                    >Alexandria</placeName>:</p>
+                            <p><placeName ref="https://www.wikidata.org/wiki/Q87"
+                                    >Alexandria</placeName> Bonded Warehouse Co. Ld</p>
                             <p>1.10.904</p>
                         </div>
                     </div>
-                    <div type="article" scope="social">
-                        <head><placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> Border Warehouse</head>
+                    <div type="article" scope="maritime">
+                        <head><placeName ref="https://www.wikidata.org/wiki/Q87"
+                                >Alexandria</placeName> Border Warehouse</head>
                         <head type="sub">Passenger List.</head>
-                        <div type="item">
+                        <div type="subsection">
                             <head>ARRIVALS.</head>
-                            <table><!-- TODO Create a proper table representation -->
-                                Le paqubot El Kabira de la Khedivial arrive hier de Constantinople Dardanelles Matelin, Smyrne et Piree avail a bord;
-
-                                M. et Mme S. Riveili, Dr. Franimer et famille, Mmes Stavroulakis, Yoannor, Cokiai, Wakefield, Mmes Maizes, Axelos Cartaliek et famillie, M. M. Pantos, Calvocoronci, Drs, Guilles et Defrigy, Amiradaki, Galanos, C. Risadimios Ap. Apostolidi, Franghiadia A. Perez, J. Yoannidi, Jean Andrioopoulos, M. et Mme Raifsis et famille, M. et Mme Gragorina, M. et Mme D. Harpaki et famille, M. et Mme Georgiadis et famillie, M. et Mme Pandasogaulo
-
-                                M. et Mme Haliadia, Dr. et Mme Gastanos, Mme Volters et famille, C. Exydakis, N. Caloutas, S. Sperer P. Levtaris Christo Stamopaolo, G. Constantinidi. Mme V.ve Bohphidis et famille, M. et Mme N. Papas et famille, Mmes, Polychromidi et famille, Mme S. Macri, Gouvernante Maitre Limgitia, N. Voiclis, G. Carapatis. N. Podaridi, M. et Mme
-
-                                N. Mavros, C. Maliarakis, G. Atassogin, A. Coatzoukis, E. Sakalarios, C. Zapellia. Ibrakimet Hnem et fille, Selmeh et Zekieh Hapem famille S. E. Mohamet Bey Izast J. Vistsi, Attie Hanem, Rew et Mme W. B. Godbay et famille S. El Tarabaki, ainsi que 312 passagers de pont.
-
-                                Le paquebot, italian Vincenzo, Floria de la Cie Florie Rubattino arrive hier da Genesavait a bord :
-
-                                M. et Mme Larrat. Pilotta, Lazzary, R, Savie. V. Oliva et comp., Hag el Fendoli, J, Bramby Cajo, J. Chihib, Eug Graglia, J. Moine, M et
-
-                                Mme Amos, Moh Bey Twefik, Gigaldini, Da Cameripi, Sabbag, Andreolis, Giranda, Reed et fam., Rev. Borgo, S. Lavi, prof. Mariani, M. et Mme R. Rocalie, prof. Farah et comp., prof. Pollardi, prof. Rispoli, Nafal, Livige O. Diacone T. Hemwood, Cap. Art. Levi, M. at Mme Les, A. Mustard, Aloi et fam., Colloridi et fils, M. et Mme G. Porto, A. Riboni, R. Link, J. Jean, L. Parid et 70 passagers de 3e classe.
-
-                                La paqubot Prince Abbas de la Khedivial arrive ce matin da Constatinople, Dardanelles, Metelin, Smyrne et Rhotes avait a bord :
-
-                                Djafer bey Fakhry, Selim bey Faoud et famille, Hassan bey Husni et famille, Mme P, de Pangia et famille, Durrik Hanem. MM. Demetrios Misia, Geo. Armarandos, Houser, E. Evangeli, R. Shezak, M. at Mme M. Derr et famille, Mohamad bey Cheiny et Mma Chainy, Hassan Rassib, CHerif Rianmi, Mme Giro et fils, Herman Mentres, Dr. L. Phillipe, G. Go romilis, Mr. Kenney et compagnon, N. Faz, D. Pulstos, J. Cohen, Evans, Perry, Mme et Mlle Bouteille, N. Holton, Mlle Bent 4 enfants, Ernest Meinert, N. Burbulia ainoi que 98 passagers de pont.
-
-                                Le paquebot Niger des Messageries Marita. mes arrive ce matin da Marseille avait a bords Mlle L. James, Mme Carton de Viapt et
-
-                                Mlle James, M. et Mme Lander, M. N. Smith. M. Ramadan bey, M. H. Morgan, Mlle Girardier, M. Frances, M. Zouffika, M. H. Reboul, M. Mah. Euan, M. Bontaen, M. et Mme Van den Brook d'Obrenean et enfatns, M. et Mme Nousrat Bey, Mme Houst et enftants, M. Jas. Hewat, of Mme Emas, M. Wrakmeyer, M. et Mme Homasen, M. et Mme Dahan, Mme N. Catalan at enfant, Mme A. L Wildig, Mme Slaughter, Mme Sheldrick, Mlle Iuglia M. et Mme Inglis, Mme Fisher, Cap. et Mme Gillson, Conte Zisinis, M. Bimsenstein, M. Aghion et enfant, Moris Bay, M. Stillwell, M. Makand, M. Multado, M. et Mme, Chear Aghion, M. et Mme Pennudjian, M. Malavsi Martino Pacha, M. et Mme St. Chamas, Mme Carusso et 2 enfants, Mme Lefrancois,
-
-                                Mme C. M. Hammann, Mlle Pieanlt, Mme Matsanitz, Mme A. Degiorgio, Mlle Spigh, Mme Hamon, Mlle Martin, M. Fredmann, M. I, D. Jacob, M. H. White et J. Dark, Mrs. J. et A.
-
-                                Santi, Mlle Madasis Mme Schonsemann, M. J.
-
-                                Senes, M. Leferre, Mlle Girard, M. et Mme Gropper, M. O. Giordano,M. et Mme Greppi. Mason, M. et Mme Favre, R.P.P. Forchat et Langivan, M. Gromberg, M. Claus, M. de Salis, Mme Colin Pastour, R.P. Barrean, Mme Giavan, Soer Hatresen, M. Lorrick, M. et Mme Segur, M. Fribourg, Mlle Greenwood, Giles, Dr. Gattino et Lois Disux, M. Dienels, Dr. Tilche, Miss Veisee, Mme Lambert, M. et Mme Arab, M. et Mme Gontier et enfant, Mme Maggiar, Mr. Wedner, Mr. Berzalou, Mr. et Mam Walhroff, M. Vermond, M. Back, Mme Alrpa, M., Mme et Mlle Lakat, M. Pallon, Mrs. Tilcke, M. Aubrey, M. Cambism et 35 passagers de 3me et 9 passagers de 4me classes.
-                            </table>
+                            <!-- TODO Create a proper table representation -->
+                            <p>Le paqubot El Kabira de la Khedivial arrive hier de Constantinople
+                                Dardanelles Matelin, Smyrne et Piree avail a bord;</p>
+                            <p>M. et Mme S. Riveili, Dr. Franimer et famille, Mmes Stavroulakis,
+                                Yoannor, Cokiai, Wakefield, Mmes Maizes, Axelos Cartaliek et
+                                famillie, M. M. Pantos, Calvocoronci, Drs, Guilles et Defrigy,
+                                Amiradaki, Galanos, C. Risadimios Ap. Apostolidi, Franghiadia A.
+                                Perez, J. Yoannidi, Jean Andrioopoulos, M. et Mme Raifsis et
+                                famille, M. et Mme Gragorina, M. et Mme D. Harpaki et famille, M. et
+                                Mme Georgiadis et famillie, M. et Mme Pandasogaulo</p>
+                            <p>M. et Mme Haliadia, Dr. et Mme Gastanos, Mme Volters et famille, C.
+                                Exydakis, N. Caloutas, S. Sperer P. Levtaris Christo Stamopaolo, G.
+                                Constantinidi. Mme V.ve Bohphidis et famille, M. et Mme N. Papas et
+                                famille, Mmes, Polychromidi et famille, Mme S. Macri, Gouvernante
+                                Maitre Limgitia, N. Voiclis, G. Carapatis. N. Podaridi, M. et
+                                Mme</p>
+                            <p>N. Mavros, C. Maliarakis, G. Atassogin, A. Coatzoukis, E. Sakalarios,
+                                C. Zapellia. Ibrakimet Hnem et fille, Selmeh et Zekieh Hapem famille
+                                S. E. Mohamet Bey Izast J. Vistsi, Attie Hanem, Rew et Mme W. B.
+                                Godbay et famille S. El Tarabaki, ainsi que 312 passagers de
+                                pont.</p>
+                            <p>Le paquebot, italian Vincenzo, Floria de la Cie Florie Rubattino
+                                arrive hier da Genesavait a bord :</p>
+                            <p>M. et Mme Larrat. Pilotta, Lazzary, R, Savie. V. Oliva et comp., Hag
+                                el Fendoli, J, Bramby Cajo, J. Chihib, Eug Graglia, J. Moine, M
+                                et</p>
+                            <p>Mme Amos, Moh Bey Twefik, Gigaldini, Da Cameripi, Sabbag, Andreolis,
+                                Giranda, Reed et fam., Rev. Borgo, S. Lavi, prof. Mariani, M. et Mme
+                                R. Rocalie, prof. Farah et comp., prof. Pollardi, prof. Rispoli,
+                                Nafal, Livige O. Diacone T. Hemwood, Cap. Art. Levi, M. at Mme Les,
+                                A. Mustard, Aloi et fam., Colloridi et fils, M. et Mme G. Porto, A.
+                                Riboni, R. Link, J. Jean, L. Parid et 70 passagers de 3e classe.</p>
+                            <p>La paqubot Prince Abbas de la Khedivial arrive ce matin da
+                                Constatinople, Dardanelles, Metelin, Smyrne et Rhotes avait a bord
+                                :</p>
+                            <p>Djafer bey Fakhry, Selim bey Faoud et famille, Hassan bey Husni et
+                                famille, Mme P, de Pangia et famille, Durrik Hanem. MM. Demetrios
+                                Misia, Geo. Armarandos, Houser, E. Evangeli, R. Shezak, M. at Mme M.
+                                Derr et famille, Mohamad bey Cheiny et Mma Chainy, Hassan Rassib,
+                                CHerif Rianmi, Mme Giro et fils, Herman Mentres, Dr. L. Phillipe, G.
+                                Go romilis, Mr. Kenney et compagnon, N. Faz, D. Pulstos, J. Cohen,
+                                Evans, Perry, Mme et Mlle Bouteille, N. Holton, Mlle Bent 4 enfants,
+                                Ernest Meinert, N. Burbulia ainoi que 98 passagers de pont.</p>
+                            <p>Le paquebot Niger des Messageries Marita. mes arrive ce matin da
+                                Marseille avait a bords Mlle L. James, Mme Carton de Viapt et</p>
+                            <p>Mlle James, M. et Mme Lander, M. N. Smith. M. Ramadan bey, M. H.
+                                Morgan, Mlle Girardier, M. Frances, M. Zouffika, M. H. Reboul, M.
+                                Mah. Euan, M. Bontaen, M. et Mme Van den Brook d'Obrenean et
+                                enfatns, M. et Mme Nousrat Bey, Mme Houst et enftants, M. Jas.
+                                Hewat, of Mme Emas, M. Wrakmeyer, M. et Mme Homasen, M. et Mme
+                                Dahan, Mme N. Catalan at enfant, Mme A. L Wildig, Mme Slaughter, Mme
+                                Sheldrick, Mlle Iuglia M. et Mme Inglis, Mme Fisher, Cap. et Mme
+                                Gillson, Conte Zisinis, M. Bimsenstein, M. Aghion et enfant, Moris
+                                Bay, M. Stillwell, M. Makand, M. Multado, M. et Mme, Chear Aghion,
+                                M. et Mme Pennudjian, M. Malavsi Martino Pacha, M. et Mme St.
+                                Chamas, Mme Carusso et 2 enfants, Mme Lefrancois,</p>
+                            <p>Mme C. M. Hammann, Mlle Pieanlt, Mme Matsanitz, Mme A. Degiorgio,
+                                Mlle Spigh, Mme Hamon, Mlle Martin, M. Fredmann, M. I, D. Jacob, M.
+                                H. White et J. Dark, Mrs. J. et A.</p>
+                            <p>Santi, Mlle Madasis Mme Schonsemann, M. J.</p>
+                            <p>Senes, M. Leferre, Mlle Girard, M. et Mme Gropper, M. O. Giordano,M.
+                                et Mme Greppi. Mason, M. et Mme Favre, R.P.P. Forchat et Langivan,
+                                M. Gromberg, M. Claus, M. de Salis, Mme Colin Pastour, R.P. Barrean,
+                                Mme Giavan, Soer Hatresen, M. Lorrick, M. et Mme Segur, M. Fribourg,
+                                Mlle Greenwood, Giles, Dr. Gattino et Lois Disux, M. Dienels, Dr.
+                                Tilche, Miss Veisee, Mme Lambert, M. et Mme Arab, M. et Mme Gontier
+                                et enfant, Mme Maggiar, Mr. Wedner, Mr. Berzalou, Mr. et Mam
+                                Walhroff, M. Vermond, M. Back, Mme Alrpa, M., Mme et Mlle Lakat, M.
+                                Pallon, Mrs. Tilcke, M. Aubrey, M. Cambism et 35 passagers de 3me et
+                                9 passagers de 4me classes.</p>
                         </div>
-                        <div type="item">
+                        <div type="subsection" scope="maritime">
                             <head>DEPARTURES.</head>
-                            <table>
-                                Le paquobot Cleopatra du Lloyd Autrichien parti samedi poor Trieste avait a bord :
-
-                                M. et Mme G. E. Wolf, Rud. Zanke, J. S. Birch Pacha, C. Ferrar, Montrose Clocta, J. Rettie, John Bradburg, A. Laban, K. Alberts, Mme Vve. V. Orvieto, Paolo Discone, Eroole Diacono, Wolfdorf, Mlle O. Thiel, M. et Mme B. K. Bamika, Hugo Rosenbaum et 17 passagers de 3mee classe.
-                            </table>
+                            <p>Le paquobot Cleopatra du Lloyd Autrichien parti samedi poor Trieste
+                                avait a bord :</p>
+                            <p>M. et Mme G. E. Wolf, Rud. Zanke, J. S. Birch Pacha, C. Ferrar,
+                                Montrose Clocta, J. Rettie, John Bradburg, A. Laban, K. Alberts, Mme
+                                Vve. V. Orvieto, Paolo Discone, Eroole Diacono, Wolfdorf, Mlle O.
+                                Thiel, M. et Mme B. K. Bamika, Hugo Rosenbaum et 17 passagers de
+                                3mee classe.</p>
                         </div>
                     </div>
-                    <div type="section" scope="advertisment">
+                    <div type="section" scope="advertisement">
                         <div type="item" scope="advertisement" xml:id="deg-ad-whr01"><!-- TODO Replace with Add boilerplate -->
                             <head>WINDSOR HOTEL</head>
                             <p>Table d’Heta Luncheons &amp; Dinners Served on the Terrace</p>
@@ -2092,11 +2898,12 @@
                         </div>
                         <div type="item" scope="advertisement"><!-- TODO Replace with Add boilerplate -->
                             <head>AMERICAN REFRIGERATORS</head>
-                            <p>₤4 to ₤20--DRESS, £5 to £25 TYPEWRITERS ₤5 to ₤20 SEWING MACHINES ₤5 TO ₤15</p>
+                            <p>₤4 to ₤20--DRESS, £5 to £25 TYPEWRITERS ₤5 to ₤20 SEWING MACHINES ₤5
+                                TO ₤15</p>
                         </div>
                         <div type="item" scope="advertisement"><!-- TODO Replace with Add boilerplate -->
                             <head>THE AMERICAN Manufacturers </head>
-                            <unclear/><ad/>
+                            <p><unclear></unclear></p>
                         </div>
                     </div>
                 </div>

--- a/1905-10-03.xml
+++ b/1905-10-03.xml
@@ -30,36 +30,17 @@
         <body>
             <div type="page" n="1">
                 <head>THE EGYPTIAN GAZETTE</head>
-                <head type="sub">No. 7239] <placeName ref="https://www.wikidata.org/wiki/Q87"
-                        >Alexandria</placeName>, Thurdsay, October 5, 1905. [SIX PAGES P.T.
-                    1.</head>
+                <head type="sub">No. 7239] <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>, Thurdsay, October 5, 1905. [SIX PAGES P.T. 1.</head>
                 <div type="section" scope="advertisement">
                     <cb n="1"/>
                     <div type="item" scope="advertisement" xml:id="deg-ad-pos01">
                         <head>Peninsular and Oriental S. N. Company.</head>
                         <p>Summer Rates will be charged from 2 May to 31 October. </p>
-                        <p>For the convenience of families and others, a large portion of each
-                            ship’s accommodation has been reserved for Egypt, so that Berths can be
-                            definitely engaged at once, as if the voyage were commencing at
-                                <placeName ref="https://www.wikidata.org/wiki/Q134509">Port
-                                Said</placeName>. Plans can be seen at the Offices of the Company’s
-                            Agents. </p>
-                        <p>The through Steamers for <placeName
-                                ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName>
-                            and <placeName ref="https://www.wikidata.org/wiki/Q84"
-                                >London</placeName> are intended to leave <placeName
-                                ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>
-                            after the arrival of the 11 a.m. train from <placeName
-                                ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> , every
-                            Tuesday for the present except the MONGOLIA, which is taking passengers
-                            to the Anglo-French Naval Review, and will not wait at <placeName
-                                ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName> on
-                            24/25 July. A steam tender will meet the train to convey passengers to
-                            the ship. </p>
+                        <p>For the convenience of families and others, a large portion of each ship’s accommodation has been reserved for Egypt, so that Berths can be definitely engaged at once, as if the voyage were commencing at <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>. Plans can be seen at the Offices of the Company’s Agents. </p>
+                        <p>The through Steamers for <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName> and <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> are intended to leave <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> after the arrival of the 11 a.m. train from <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> , every Tuesday for the present except the MONGOLIA, which is taking passengers to the Anglo-French Naval Review, and will not wait at <placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName> on 24/25 July. A steam tender will meet the train to convey passengers to the ship. </p>
                         <table>
                             <row>
-                                <cell><placeName ref="https://www.wikidata.org/wiki/Q79"
-                                        >Egypt</placeName></cell>
+                                <cell><placeName ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName></cell>
                                 <cell>4 July</cell>
                                 <cell>Arcadia </cell>
                                 <cell>1 August</cell>
@@ -79,59 +60,36 @@
                                 <cell>18 July</cell>
                                 <cell>Arabia </cell>
                                 <cell>15 August</cell>
-                                <cell><placeName ref="https://www.wikidata.org/wiki/Q79"
-                                        >Egypt</placeName></cell>
+                                <cell><placeName ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName></cell>
                                 <cell>12 Sept.</cell>
                             </row>
                             <row>
                                 <cell>Mongolia</cell>
                                 <cell>25 July</cell>
-                                <cell><placeName ref="https://www.wikidata.org/wiki/Q148"
-                                        >China</placeName></cell>
+                                <cell><placeName ref="https://www.wikidata.org/wiki/Q148">China</placeName></cell>
                                 <cell>22 August</cell>
                                 <cell>Macedonia</cell>
                                 <cell>19 Sept.</cell>
                             </row>
                         </table>
-                        <p>The Brindisi Express Steamers leave <placeName
-                                ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>
-                            directly the Indian Mails arrive. Passengers can go on board the evening
-                            before. The Fare remains as usual. </p>
+                        <p>The Brindisi Express Steamers leave <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> directly the Indian Mails arrive. Passengers can go on board the evening before. The Fare remains as usual. </p>
                         <p>For all further information apply to the Company's Agents, </p>
-                        <p>Messrs. THOS. COOK &amp; SON (Egypt) Ltd. <placeName
-                                ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> . </p>
-                        <p>GEORGE ROYLE, Esq. <placeName ref="https://www.wikidata.org/wiki/Q134509"
-                                >Port-Said</placeName> . </p>
-                        <p>Messrs. HABELDEN &amp; Co. <placeName
-                                ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>. </p>
-                        <p> F. G. DAVIDSON, Superintendent P. &amp; O. S. N. Company in <placeName
-                                ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName><placeName
-                                ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>. </p>
+                        <p>Messrs. THOS. COOK &amp; SON (Egypt) Ltd. <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> . </p>
+                        <p>GEORGE ROYLE, Esq. <placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName> . </p>
+                        <p>Messrs. HABELDEN &amp; Co. <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>. </p>
+                        <p> F. G. DAVIDSON, Superintendent P. &amp; O. S. N. Company in <placeName ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName><placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>. </p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-opl01">
                         <head>Orient-Pacific Line of Royal Mail Steamers.</head>
                         <p>REDUCED SUMMER FARES FROM MAY TO OCTOBER INCLUSIVE.</p>
-                        <p>OUTWARDS to <placeName ref="https://www.wikidata.org/wiki/Q408"
-                                >Australia</placeName>.</p>
-                        <p>R.M.S. “Orotava" will leave <placeName
-                                ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName> about
-                            July 28 | R.M.S "Ormuz" will leave <placeName
-                                ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName> about
-                            August 11. </p>
-                        <p>HOMEWARDS to NAPLES <placeName
-                                ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName>,
-                            GIBRALTAR, PLYMOUTH, <placeName ref="https://www.wikidata.org/wiki/Q84"
-                                >London</placeName>, TILBURY</p>
-                        <p>R.M.S. "Oroya" will leave <placeName
-                                ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>
-                            about July 18 | R.M.S. “Ortona" will leave <placeName
-                                ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>
-                            about August 1</p>
+                        <p>OUTWARDS to <placeName ref="https://www.wikidata.org/wiki/Q408">Australia</placeName>.</p>
+                        <p>R.M.S. “Orotava" will leave <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName> about July 28 | R.M.S "Ormuz" will leave <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName> about August 11. </p>
+                        <p>HOMEWARDS to NAPLES <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName>, GIBRALTAR, PLYMOUTH, <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName>, TILBURY</p>
+                        <p>R.M.S. "Oroya" will leave <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> about July 18 | R.M.S. “Ortona" will leave <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> about August 1</p>
                         <table>
                             <row>
                                 <cell rows="4">Reduced Summer Fares</cell>
-                                <cell><placeName ref="https://www.wikidata.org/wiki/Q134509"
-                                        >Port-Said</placeName> to Naples</cell>
+                                <cell><placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName> to Naples</cell>
                                 <cell>1st Class</cell>
                                 <cell>£ 11</cell>
                                 <cell>2nd Class</cell>
@@ -140,10 +98,7 @@
                                 <cell>£ 4.8</cell>
                             </row>
                             <row>
-                                <cell><placeName ref="https://www.wikidata.org/wiki/Q134509"
-                                        >Port-Said</placeName> to <placeName
-                                        ref="https://www.wikidata.org/wiki/Q579613"
-                                        >Marseilles</placeName></cell>
+                                <cell><placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName> to <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName></cell>
                                 <cell>1st Class</cell>
                                 <cell>£ 12.12</cell>
                                 <cell>2nd Class</cell>
@@ -152,8 +107,7 @@
                                 <cell>£ 5.10</cell>
                             </row>
                             <row>
-                                <cell><placeName ref="https://www.wikidata.org/wiki/Q134509"
-                                        >Port-Said</placeName> to Gibraltar</cell>
+                                <cell><placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName> to Gibraltar</cell>
                                 <cell>1st Class</cell>
                                 <cell>£ 18.0</cell>
                                 <cell>2nd Class</cell>
@@ -162,8 +116,7 @@
                                 <cell>£ 5.10</cell>
                             </row>
                             <row>
-                                <cell><placeName ref="https://www.wikidata.org/wiki/Q134509"
-                                        >Port-Said</placeName> to Plymouth or Tilbury</cell>
+                                <cell><placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName> to Plymouth or Tilbury</cell>
                                 <cell>1st Class</cell>
                                 <cell>£ 16.16</cell>
                                 <cell>2nd Class</cell>
@@ -172,100 +125,42 @@
                                 <cell>£ 8.16</cell>
                             </row>
                         </table>
-                        <p>Egyptian Government Officials allowed a rebate of 15% off the above
-                            fares.</p>
-                        <p>Return tickets no longer issued, but passengers paying full fare in one
-                            direction allowed abatement of 1/3 fare back if return voyage be within
-                            4 months of arrival, or abatement of 20 o/o if return voyage be made
-                            within 8 months of arrival.</p>
-                        <p>Agents. <placeName ref="https://www.wikidata.org/wiki/Q85"
-                                >Cairo</placeName> :—Thos. Cook &amp; Son. <placeName
-                                ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> : —R.
-                            J. Moss &amp; Co.—For all information apply </p>
-                        <p>Wm. STAPLEDON &amp; Sons, <placeName
-                                ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName>
-                            &amp; PORT-TEWFIK (<placeName
-                                ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>)
-                            31-12-904</p>
+                        <p>Egyptian Government Officials allowed a rebate of 15% off the above fares.</p>
+                        <p>Return tickets no longer issued, but passengers paying full fare in one direction allowed abatement of 1/3 fare back if return voyage be within 4 months of arrival, or abatement of 20 o/o if return voyage be made within 8 months of arrival.</p>
+                        <p>Agents. <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> :—Thos. Cook &amp; Son. <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> : —R. J. Moss &amp; Co.—For all information apply </p>
+                        <p>Wm. STAPLEDON &amp; Sons, <placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName> &amp; PORT-TEWFIK (<placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>) 31-12-904</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-blm01">
                         <head>BIBBY LINE MAIL STEAMERS.</head>
                         <p>Special Reduced Rates During Summer Season,</p>
-                        <p>OUTWARDS to COLOMBO, TUTICORIN, etc., and RANGOON. Departures from
-                                <placeName ref="https://www.wikidata.org/wiki/Q134514"
-                                >Suez</placeName>.</p>
+                        <p>OUTWARDS to COLOMBO, TUTICORIN, etc., and RANGOON. Departures from <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>.</p>
                         <p>S.S. Derbyshire 6,635 tons, leaves about July 20.</p>
                         <p>S.S. Lancashire 4,244 tons, leaves about August 3.</p>
-                        <p>HOMEWARDS to <placeName ref="https://www.wikidata.org/wiki/Q579613"
-                                >Marseilles</placeName> and <placeName
-                                ref="https://www.wikidata.org/wiki/Q84">London</placeName>.
-                            Departures from <placeName ref="https://www.wikidata.org/wiki/Q134509"
-                                >Port Said</placeName>.</p>
+                        <p>HOMEWARDS to <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName> and <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName>. Departures from <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>.</p>
                         <p>S.S. Worcestershire 7,160 tons, leaves about July 26.</p>
                         <p>S.S. Yorkshire 4,196 tons leaves about August 9,</p>
-                        <p>FARES from <placeName ref="https://www.wikidata.org/wiki/Q134509">Port
-                                Said</placeName> to <placeName
-                                ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName>
-                            £12.0.0, <placeName ref="https://www.wikidata.org/wiki/Q84"
-                                >London</placeName> £17.0.0, Colombo £32.10.0, Rangoon £37.10.0. </p>
-                        <p>Agents <placeName ref="https://www.wikidata.org/wiki/Q85"
-                                >Cairo</placeName> : THOS. COOK &amp; SON. <placeName
-                                ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName> &amp;
-                                <placeName ref="https://www.wikidata.org/wiki/Q134509">Port
-                                Said</placeName> : WM. STAPLEDON &amp; SONS, 31-12-905</p>
+                        <p>FARES from <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> to <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName> £12.0.0, <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> £17.0.0, Colombo £32.10.0, Rangoon £37.10.0. </p>
+                        <p>Agents <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> : THOS. COOK &amp; SON. <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName> &amp; <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> : WM. STAPLEDON &amp; SONS, 31-12-905</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-kml01">
                         <head>KHEDIVIAL MAIL LINE.</head>
                         <head type="sub">FAST BRITISH PASSENGER STEAMERS</head>
-                        <head type="sub"><placeName ref="https://www.wikidata.org/wiki/Q41"
-                                >Greece</placeName> - <placeName
-                                ref="https://www.wikidata.org/wiki/Q43">Turkey</placeName>
-                            LINE.</head>
-                        <p>Express Steamers leave <placeName ref="https://www.wikidata.org/wiki/Q87"
-                                >Alexandria</placeName> every Wednesday at 4 p.m. for PIRAEUS,
-                            SMYRNA, MITYLENE, and CONSTANTINOPLE, in connection with Orient Express
-                            train-de-luxe for Vienna, <placeName
-                                ref="https://www.wikidata.org/wiki/Q90">Paris</placeName>, and
-                                <placeName ref="https://www.wikidata.org/wiki/Q84"
-                                >London</placeName>.</p>
+                        <head type="sub"><placeName ref="https://www.wikidata.org/wiki/Q41">Greece</placeName> - <placeName ref="https://www.wikidata.org/wiki/Q43">Turkey</placeName> LINE.</head>
+                        <p>Express Steamers leave <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> every Wednesday at 4 p.m. for PIRAEUS, SMYRNA, MITYLENE, and CONSTANTINOPLE, in connection with Orient Express train-de-luxe for Vienna, <placeName ref="https://www.wikidata.org/wiki/Q90">Paris</placeName>, and <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName>.</p>
                         <div type="subsection">
                             <head type="sub">PALESTINE - SYRIA LINE.</head>
-                            <p>Fast steamers leave <placeName
-                                    ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>
-                                every Saturday at 6 p.m., and <placeName
-                                    ref="https://www.wikidata.org/wiki/Q134509">Port
-                                    Said</placeName> every Sunday at 6 p.m., for JAFFA (for
-                                Jerusalem), CAIFFA (for Nazareth), BEYROUT (for Damascus), TRIPOLI,
-                                ALEXANDRETTA, MESSINA, continuing in alternate weeks to LARNACA and
-                                LIMASSOL (Cyprus).</p>
+                            <p>Fast steamers leave <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> every Saturday at 6 p.m., and <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> every Sunday at 6 p.m., for JAFFA (for Jerusalem), CAIFFA (for Nazareth), BEYROUT (for Damascus), TRIPOLI, ALEXANDRETTA, MESSINA, continuing in alternate weeks to LARNACA and LIMASSOL (Cyprus).</p>
                         </div>
                         <div type="subsection">
                             <head type="sub">RED SEA LINE.</head>
-                            <p>Steamers leave <placeName ref="https://www.wikidata.org/wiki/Q134514"
-                                    >Suez</placeName> fortnightly on Wednesday at 6 p.m. for JEDDAH,
-                                SUAKIN, MASSOWAH, HODBIDAH, and ADEN ; and in the intervening weeks
-                                for PORT SUDAN and SUAKIN direct. Calls will be made at TOR (for
-                                Mount Sinai) as required.</p>
-                            <p>N.B.—Deck chairs provided for the use of passengers, excellent
-                                cuisine and table wine free.</p>
-                            <p>Steamer plans may be seen and passages booked at the Company’s
-                                Agencies at <placeName ref="https://www.wikidata.org/wiki/Q87"
-                                    >Alexandria</placeName>, <placeName
-                                    ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> ,
-                                    <placeName ref="https://www.wikidata.org/wiki/Q134509">Port
-                                    Said</placeName>, and <placeName
-                                    ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>, or
-                                at THOS. COOK &amp; SON or other Tourist Agency. 31-12-904</p>
+                            <p>Steamers leave <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName> fortnightly on Wednesday at 6 p.m. for JEDDAH, SUAKIN, MASSOWAH, HODBIDAH, and ADEN ; and in the intervening weeks for PORT SUDAN and SUAKIN direct. Calls will be made at TOR (for Mount Sinai) as required.</p>
+                            <p>N.B.—Deck chairs provided for the use of passengers, excellent cuisine and table wine free.</p>
+                            <p>Steamer plans may be seen and passages booked at the Company’s Agencies at <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>, <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> , <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>, and <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>, or at THOS. COOK &amp; SON or other Tourist Agency. 31-12-904</p>
                         </div>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-mss01">
                         <head>The Moss S.S. Company, Ltd.</head>
-                        <p>For <placeName ref="https://www.wikidata.org/wiki/Q24826"
-                                >Liverpool</placeName> calling at <placeName
-                                ref="https://www.wikidata.org/wiki/Q233">Malta</placeName> (Messrs.
-                            JAMES MOSS &amp; Co. 31, James St, <placeName
-                                ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName>,
-                            Managers.)</p>
+                        <p>For <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName> calling at <placeName ref="https://www.wikidata.org/wiki/Q233">Malta</placeName> (Messrs. JAMES MOSS &amp; Co. 31, James St, <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName>, Managers.)</p>
                         <table rows="3" cols="8">
                             <row>
                                 <cell>*Amasis</cell>
@@ -298,217 +193,101 @@
                                 <cell>(Building)</cell>
                             </row>
                         </table>
-                        <p>*Second class accommodation only, unless specially reserved.—Fares :
-                                <placeName ref="https://www.wikidata.org/wiki/Q87"
-                                >Alexandria</placeName> to <placeName
-                                ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName>,
-                            1st, £14 Single, £25 Return. 2nd, £9 Single, £15 Return.—To <placeName
-                                ref="https://www.wikidata.org/wiki/Q233">Malta</placeName>, 1st, £5
-                            Single, £9 Return, 2nd, £3 Single, £5 Return.—Return tickets available
-                            for six months.</p>
-                        <p>S.S. Seti now on the berth, will sail on or about Monday, July 17, to be
-                            followed by S.S. Menes.</p>
-                        <p>S.S Tabor for Havre via <placeName
-                                ref="https://www.wikidata.org/wiki/Q233">Malta</placeName> to sail
-                            about Saturday l5th inst.</p>
-                        <p>Through freight rates on cotton, etc., to Lancashire inland towns,
-                            Boston, New York and other U.S.A. towns, obtained on application. Cargo
-                            taken by special agreement only. </p>
-                        <p>Passenger Tickets also issued inclusive of Railway fare through to and
-                            from <placeName ref="https://www.wikidata.org/wiki/Q85"
-                                >Cairo</placeName> . Particulars on application to </p>
-                        <p>R. J. MOSS &amp; Co., <placeName ref="https://www.wikidata.org/wiki/Q87"
-                                >Alexandria</placeName>, Agents. 26-12-905</p>
+                        <p>*Second class accommodation only, unless specially reserved.—Fares : <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> to <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName>, 1st, £14 Single, £25 Return. 2nd, £9 Single, £15 Return.—To <placeName ref="https://www.wikidata.org/wiki/Q233">Malta</placeName>, 1st, £5 Single, £9 Return, 2nd, £3 Single, £5 Return.—Return tickets available for six months.</p>
+                        <p>S.S. Seti now on the berth, will sail on or about Monday, July 17, to be followed by S.S. Menes.</p>
+                        <p>S.S Tabor for Havre via <placeName ref="https://www.wikidata.org/wiki/Q233">Malta</placeName> to sail about Saturday l5th inst.</p>
+                        <p>Through freight rates on cotton, etc., to Lancashire inland towns, Boston, New York and other U.S.A. towns, obtained on application. Cargo taken by special agreement only. </p>
+                        <p>Passenger Tickets also issued inclusive of Railway fare through to and from <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> . Particulars on application to </p>
+                        <p>R. J. MOSS &amp; Co., <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>, Agents. 26-12-905</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-mic01">
                         <head>MARINE INSURANCE COMPANY, LIMITED.</head>
                         <p>Established 1836. Capital £1,000,000. Reserve Fund £650,000. </p>
-                        <p>THE IMPERIAL FIRE OFFICE united with THE ALLIANCE ASSURANCE, Co.,
-                            Ltd.</p>
-                        <p>1, Old Broad Street, <placeName ref="https://www.wikidata.org/wiki/Q84"
-                                >London</placeName>—Estabished 1806.—Total Funds exceed
-                            £10,000,000.</p>
-                        <p>31-12-905. Policies issued at <placeName
-                                ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName> by G.
-                            BEYTS &amp; Co., Agents.</p>
+                        <p>THE IMPERIAL FIRE OFFICE united with THE ALLIANCE ASSURANCE, Co., Ltd.</p>
+                        <p>1, Old Broad Street, <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName>—Estabished 1806.—Total Funds exceed £10,000,000.</p>
+                        <p>31-12-905. Policies issued at <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName> by G. BEYTS &amp; Co., Agents.</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-tce01">
                         <head>Telephone Company of Egypt, Limited.</head>
-                        <p><placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>
-                                -<placeName ref="https://www.wikidata.org/wiki/Q87"
-                                >Alexandria</placeName> TELEPHONE.--Rates as follows P.T. 5 for each
-                            3 minutes, or fraction of 3 minutes; P.T. 10 for over 3 up to 8 minutes
-                            communication.</p>
-                        <p>PUBLIC CALL-OFFICES : <placeName ref="https://www.wikidata.org/wiki/Q85"
-                                >Cairo</placeName> , Central Office, Opera Square, and New Bar;
-                            Helouan, Central Office, Maison Purvis ; <placeName
-                                ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>, St
-                            Mark’s Buildings, Egyptian Bar, I. Castelli &amp; Co.; Ramleh, Central
-                            Office. San Stefano Casino 30.4.906</p>
+                        <p><placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> -<placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> TELEPHONE.--Rates as follows P.T. 5 for each 3 minutes, or fraction of 3 minutes; P.T. 10 for over 3 up to 8 minutes communication.</p>
+                        <p>PUBLIC CALL-OFFICES : <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> , Central Office, Opera Square, and New Bar; Helouan, Central Office, Maison Purvis ; <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>, St Mark’s Buildings, Egyptian Bar, I. Castelli &amp; Co.; Ramleh, Central Office. San Stefano Casino 30.4.906</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-hcl01">
                         <head>P. HENDERSON &amp; CO’s LINE.</head>
-                        <p>Steamers leave <placeName ref="https://www.wikidata.org/wiki/Q134514"
-                                >Suez</placeName> and <placeName
-                                ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>
-                            fortnightly for <placeName ref="https://www.wikidata.org/wiki/Q84"
-                                >London</placeName> or <placeName
-                                ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName>
-                            direct.</p>
+                        <p>Steamers leave <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName> and <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> fortnightly for <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> or <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName> direct.</p>
                         <p>(Electric Light.) SALOON (Amidships) FARE £12. (Latest improvements.)</p>
-                        <p>S.S. RANGOON 6000 Tons will leave <placeName
-                                ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>
-                            about July 23 for <placeName ref="https://www.wikidata.org/wiki/Q84"
-                                >London</placeName>.</p>
-                        <p>S.S. BURMA 5600 Tons will leave <placeName
-                                ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>
-                            about August 6 for <placeName ref="https://www.wikidata.org/wiki/Q84"
-                                >London</placeName>.</p>
-                        <p>S.S. ARRACAN 5800 Tons will leave <placeName
-                                ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>
-                            about 20 for <placeName ref="https://www.wikidata.org/wiki/Q24826"
-                                >Liverpool</placeName></p>
-                        <p>Due in <placeName ref="https://www.wikidata.org/wiki/Q84"
-                                >London</placeName> or <placeName
-                                ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName> 12
-                            days thereafter.</p>
-                        <p>Apply WORMS &amp; Co., <placeName
-                                ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>
-                            and <placeName ref="https://www.wikidata.org/wiki/Q134514"
-                                >Suez</placeName>. THOS. COOK &amp; SON, (EGYPT) LD., <placeName
-                                ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> ;</p>
-                        <p>G. J. GRACE &amp; CO., <placeName ref="https://www.wikidata.org/wiki/Q87"
-                                >Alexandria</placeName>.</p>
+                        <p>S.S. RANGOON 6000 Tons will leave <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> about July 23 for <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName>.</p>
+                        <p>S.S. BURMA 5600 Tons will leave <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> about August 6 for <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName>.</p>
+                        <p>S.S. ARRACAN 5800 Tons will leave <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> about 20 for <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName></p>
+                        <p>Due in <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> or <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName> 12 days thereafter.</p>
+                        <p>Apply WORMS &amp; Co., <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> and <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>. THOS. COOK &amp; SON, (EGYPT) LD., <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> ;</p>
+                        <p>G. J. GRACE &amp; CO., <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>.</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-tcs01">
                         <head>Thos. Cook &amp; Son,</head>
-                        <p>(EGYPT), LIMITED, HEAD OFFICE—LUDGATE CIRCUS—<placeName
-                                ref="https://www.wikidata.org/wiki/Q84">London</placeName>.</p>
-                        <p>CHIEF EGYPTIAN OFFICE — <placeName
-                                ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> , near
-                            SHEPHEARD'S HOTEL. </p>
-                        <p><placeName ref="https://www.wikidata.org/wiki/Q87"
-                            >Alexandria</placeName>, <placeName
-                                ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName> ,
-                                <placeName ref="https://www.wikidata.org/wiki/Q134514"
-                                >Suez</placeName>, Luxor, Assuan, Haifa, &amp; Khartum.</p>
+                        <p>(EGYPT), LIMITED, HEAD OFFICE—LUDGATE CIRCUS—<placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName>.</p>
+                        <p>CHIEF EGYPTIAN OFFICE — <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> , near SHEPHEARD'S HOTEL. </p>
+                        <p><placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>, <placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName> , <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>, Luxor, Assuan, Haifa, &amp; Khartum.</p>
                         <p>GENERAL RAILWAY AND STEAMSHIP AGENTS. BANKERS.</p>
                         <p>BAGGAGE AND FORWARDING AGENTS.</p>
-                        <p>Officially appointed &amp; Sole Agents in <placeName
-                                ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> to the
-                            P.&amp;O. S.N. Co.</p>
-                        <p>RESIDENTS IN <placeName ref="https://www.wikidata.org/wiki/Q79"
-                                >Egypt</placeName>proceeding to Europe for the summer are requested
-                            to apply to our offices for information respecting their Passages, where
-                            steamer plans may be consulted and Berths secured by all Lines of
-                            Steamers to all parts of the Globe; arrangements can also be made for
-                            the collection and forwarding of their baggage and clearance at port of
-                            arrival.</p>
-                        <p>CIRCULAR NOTES issued payable at the current rate of exchange in all the
-                            principal cities of Europe. Cook’s Interpreters in uniform are present
-                            at the principal Railway stations and Landing-places in Europe to assist
-                            passengers holding their travelling tickets.</p>
-                        <p>Large and splendidly appointed steamers belonging to the Co. leave
-                                <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>
-                            thrice weekly, between November and March, for Luxor, Assouan and
-                            Wady-Halfa in connection with trains de luxe to Khartoum. Moderate
-                            fares. </p>
-                        <p>FREIGHT SERVICE, Steamers leave <placeName
-                                ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> every
-                            Saturday and Tuesday for Assouan and Halfa.</p>
+                        <p>Officially appointed &amp; Sole Agents in <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> to the P.&amp;O. S.N. Co.</p>
+                        <p>RESIDENTS IN <placeName ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName>proceeding to Europe for the summer are requested to apply to our offices for information respecting their Passages, where steamer plans may be consulted and Berths secured by all Lines of Steamers to all parts of the Globe; arrangements can also be made for the collection and forwarding of their baggage and clearance at port of arrival.</p>
+                        <p>CIRCULAR NOTES issued payable at the current rate of exchange in all the principal cities of Europe. Cook’s Interpreters in uniform are present at the principal Railway stations and Landing-places in Europe to assist passengers holding their travelling tickets.</p>
+                        <p>Large and splendidly appointed steamers belonging to the Co. leave <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> thrice weekly, between November and March, for Luxor, Assouan and Wady-Halfa in connection with trains de luxe to Khartoum. Moderate fares. </p>
+                        <p>FREIGHT SERVICE, Steamers leave <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> every Saturday and Tuesday for Assouan and Halfa.</p>
                         <p>Special Steamers and Dahabeahs for private parties.</p>
-                        <p>Special arrangements for tour in PALESTINE, SYRIA and the DESERT, Lowest
-                            Rates.</p>
+                        <p>Special arrangements for tour in PALESTINE, SYRIA and the DESERT, Lowest Rates.</p>
                         <p>Best camp equipment in the country! 10 12-904 </p>
                     </div>
                     <cb n="2"/>
                     <div type="item" scope="advertisement" xml:id="deg-ad-bis01">
-                        <head>British <placeName ref="https://www.wikidata.org/wiki/Q668"
-                                >India</placeName> S. N. Company, Limited.</head>
+                        <head>British <placeName ref="https://www.wikidata.org/wiki/Q668">India</placeName> S. N. Company, Limited.</head>
                         <p>MAIL AND PASSENGER STEAM SHIPS.</p>
-                        <p>SAILINGS FROM <placeName ref="https://www.wikidata.org/wiki/Q134514"
-                                >Suez</placeName>, <placeName
-                                ref="https://www.wikidata.org/wiki/Q84">London</placeName> and
-                            CALCUTTA LINE.</p>
-                        <p>Calling at ADEN, COLOMBO and MADRAS Outward, and <placeName
-                                ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName>
-                            (GENOA and PLYMOUTH optional) Homeward. </p>
-                        <p>Fortnightly Service in connection with the Co's Indian Mail Lines and
-                            monthly with the East African Mail Line between ADEN, MOMBASSA and
-                            Zanzibar. </p>
+                        <p>SAILINGS FROM <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>, <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> and CALCUTTA LINE.</p>
+                        <p>Calling at ADEN, COLOMBO and MADRAS Outward, and <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName> (GENOA and PLYMOUTH optional) Homeward. </p>
+                        <p>Fortnightly Service in connection with the Co's Indian Mail Lines and monthly with the East African Mail Line between ADEN, MOMBASSA and Zanzibar. </p>
                         <p>OUTWARD.—S.S. Fazilka ... July 22 | HOMEWARD.—S.S. Mombassa ... July 21 </p>
-                        <p>Queensland Line of Steamers Between <placeName
-                                ref="https://www.wikidata.org/wiki/Q84">London</placeName> and
-                            Brisbane.</p>
+                        <p>Queensland Line of Steamers Between <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> and Brisbane.</p>
                         <p>Calling at Colombo, Batavia, Cooktown, Townsville, and Rockhamptom.</p>
-                        <p>The S.S. .................. will sail from <placeName
-                                ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName> on
-                            about ..................</p>
+                        <p>The S.S. .................. will sail from <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName> on about ..................</p>
                         <table rows="2" cols="9">
                             <row>
-                                <cell>First Class Fares from <placeName
-                                        ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>
-                                    to</cell>
+                                <cell>First Class Fares from <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName> to</cell>
                                 <cell>Aden</cell>
                                 <cell>£11. 8</cell>
                                 <cell>Colombo</cell>
                                 <cell>£14.14</cell>
                                 <cell>Calcutta</cell>
                                 <cell>£31. 0</cell>
-                                <cell><placeName ref="https://www.wikidata.org/wiki/Q579613"
-                                        >Marseilles</placeName></cell>
+                                <cell><placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName></cell>
                                 <cell>£15.12</cell>
                             </row>
                             <row>
                                 <cell/>
-                                <cell><placeName ref="https://www.wikidata.org/wiki/Q1156"
-                                        >Bombay</placeName></cell>
+                                <cell><placeName ref="https://www.wikidata.org/wiki/Q1156">Bombay</placeName></cell>
                                 <cell>£31.10</cell>
                                 <cell>Madras</cell>
                                 <cell>£xx.11</cell>
                                 <cell>Genoa</cell>
                                 <cell>£13.10</cell>
-                                <cell><placeName ref="https://www.wikidata.org/wiki/Q84"
-                                        >London</placeName></cell>
+                                <cell><placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName></cell>
                                 <cell>£19. 0</cell>
                             </row>
                         </table>
-                        <p>From <placeName ref="https://www.wikidata.org/wiki/Q134509"
-                                >Port-Said</placeName> £2 less Homeward, and £2 more Outward. Second
-                            class, two thirds of 1st Class Fares.</p>
-                        <p>Agents at <placeName ref="https://www.wikidata.org/wiki/Q134509">Port
-                                Said</placeName>, for the <placeName
-                                ref="https://www.wikidata.org/wiki/Q84">London</placeName>, Calcutta
-                            and Persian Gulf Lines, Messrs. Worms &amp; Co.</p>
-                        <p>Agents at <placeName ref="https://www.wikidata.org/wiki/Q134509">Port
-                                Said</placeName>, for the <placeName
-                                ref="https://www.wikidata.org/wiki/Q84">London</placeName> and
-                            Queensland Line, Messrs. Wills &amp; Co., Limited.</p>
-                        <p>Messrs. Thos. Cook &amp; Son and the Anglo-American Hotel &amp; Steamer
-                            Company, <placeName ref="https://www.wikidata.org/wiki/Q85"
-                                >Cairo</placeName> &amp; <placeName
-                                ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>.</p>
-                        <p>For further particulars. Freight and Passage apply to G. BEYTS &amp; Co.
-                            Agents, <placeName ref="https://www.wikidata.org/wiki/Q134514"
-                                >Suez</placeName>. 31-12-905</p>
+                        <p>From <placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName> £2 less Homeward, and £2 more Outward. Second class, two thirds of 1st Class Fares.</p>
+                        <p>Agents at <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>, for the <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName>, Calcutta and Persian Gulf Lines, Messrs. Worms &amp; Co.</p>
+                        <p>Agents at <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>, for the <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> and Queensland Line, Messrs. Wills &amp; Co., Limited.</p>
+                        <p>Messrs. Thos. Cook &amp; Son and the Anglo-American Hotel &amp; Steamer Company, <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> &amp; <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>.</p>
+                        <p>For further particulars. Freight and Passage apply to G. BEYTS &amp; Co. Agents, <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>. 31-12-905</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-all01">
                         <head>ANCHOR LINE, LIMITED.</head>
-                        <p>(HENDERSON BROTHERS,) <placeName ref="https://www.wikidata.org/wiki/Q84"
-                                >London</placeName>, <placeName
-                                ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName> AND
-                            GLASGOW.</p>
-                        <p>Booking Passengers and Cargo through to Ports in <placeName
-                                ref="https://www.wikidata.org/wiki/Q668">India</placeName>, Europe
-                            &amp; America</p>
-                        <p>First class passengers steamers. Sailing fortnightly from <placeName
-                                ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>.</p>
+                        <p>(HENDERSON BROTHERS,) <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName>, <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName> AND GLASGOW.</p>
+                        <p>Booking Passengers and Cargo through to Ports in <placeName ref="https://www.wikidata.org/wiki/Q668">India</placeName>, Europe &amp; America</p>
+                        <p>First class passengers steamers. Sailing fortnightly from <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>.</p>
                         <table rows="2" cols="6">
                             <row>
-                                <cell>For <placeName ref="https://www.wikidata.org/wiki/Q579613"
-                                        >Marseilles</placeName> &amp; <placeName
-                                        ref="https://www.wikidata.org/wiki/Q24826"
-                                        >Liverpool</placeName></cell>
+                                <cell>For <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName> &amp; <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName></cell>
                                 <cell>S.S. “Bohemia”</cell>
                                 <cell>July 26</cell>
                                 <cell>For CALCUTTA</cell>
@@ -516,73 +295,36 @@
                                 <cell>August 3</cell>
                             </row>
                             <row>
-                                <cell>For <placeName ref="https://www.wikidata.org/wiki/Q84"
-                                        >London</placeName></cell>
+                                <cell>For <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName></cell>
                                 <cell>S.S. “Persia"</cell>
                                 <cell>July 28</cell>
-                                <cell>For <placeName ref="https://www.wikidata.org/wiki/Q1156"
-                                        >Bombay</placeName></cell>
-                                <cell>S.S. "<placeName ref="https://www.wikidata.org/wiki/Q408"
-                                        >Australia</placeName>"</cell>
+                                <cell>For <placeName ref="https://www.wikidata.org/wiki/Q1156">Bombay</placeName></cell>
+                                <cell>S.S. "<placeName ref="https://www.wikidata.org/wiki/Q408">Australia</placeName>"</cell>
                                 <cell>July 23</cell>
                             </row>
                         </table>
-                        <p>Saloon Fares: from <placeName ref="https://www.wikidata.org/wiki/Q134509"
-                                >Port-Said</placeName> , to Gibraltar £9; <placeName
-                                ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName>
-                            £9: <placeName ref="https://www.wikidata.org/wiki/Q24826"
-                                >Liverpool</placeName> (all sea route) £15; <placeName
-                                ref="https://www.wikidata.org/wiki/Q84">London</placeName> (all sea
-                            route) £ 12 <placeName ref="https://www.wikidata.org/wiki/Q84"
-                                >London</placeName> via <placeName
-                                ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName>
-                            £15.5.0. Passengers embarking at <placeName
-                                ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName> £2
-                            more, 10 % reduction for officers of army of Occupation and Government
-                            employés. Through tickets issued to New-York (via Glasgow). Fares on
-                            application. </p>
-                        <p> Agents in <placeName ref="https://www.wikidata.org/wiki/Q85"
-                                >Cairo</placeName> , Messrs. Thos. Cook &amp; Son. <placeName
-                                ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName> ,
-                            Messrs. Cory Brothers &amp; Co., Ltd.</p>
-                        <p>For further partienlan of Freight or Passage apply to G. BEYTS &amp; Co.,
-                                <placeName ref="https://www.wikidata.org/wiki/Q134514"
-                                >Suez</placeName>. 31-12-905</p>
+                        <p>Saloon Fares: from <placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName> , to Gibraltar £9; <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName> £9: <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName> (all sea route) £15; <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> (all sea route) £ 12 <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> via <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName> £15.5.0. Passengers embarking at <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName> £2 more, 10 % reduction for officers of army of Occupation and Government employés. Through tickets issued to New-York (via Glasgow). Fares on application. </p>
+                        <p> Agents in <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> , Messrs. Thos. Cook &amp; Son. <placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName> , Messrs. Cory Brothers &amp; Co., Ltd.</p>
+                        <p>For further partienlan of Freight or Passage apply to G. BEYTS &amp; Co., <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>. 31-12-905</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-dll01">
                         <head>Deutsche Levante-Linie.</head>
-                        <p>Mail and Passenger Steamships. Regular three-weekly Service from <lb/>
-                            HAMBURG, via ANTWERP &amp; <placeName
-                                ref="https://www.wikidata.org/wiki/Q233">Malta</placeName>, to
-                                <placeName ref="https://www.wikidata.org/wiki/Q87"
-                                >Alexandria</placeName> and vice-versa, admitting<lb/> goods from
-                            all chief German Railway Stations on direct Bill of Landing to<lb/>
-                            <placeName ref="https://www.wikidata.org/wiki/Q87"
-                                >Alexandria</placeName> and all chief ports of Egypt, Syria, etc.,
-                            at favourable through<lb/> rates of DEUTSCHE <lb/> VERKEHR
-                            (traffic).</p>
-                        <p>EXPECTED AT <placeName ref="https://www.wikidata.org/wiki/Q87"
-                                >Alexandria</placeName>.</p>
+                        <p>Mail and Passenger Steamships. Regular three-weekly Service from <lb/> HAMBURG, via ANTWERP &amp; <placeName ref="https://www.wikidata.org/wiki/Q233">Malta</placeName>, to <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> and vice-versa, admitting<lb/> goods from all chief German Railway Stations on direct Bill of Landing to<lb/>
+                            <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> and all chief ports of Egypt, Syria, etc., at favourable through<lb/> rates of DEUTSCHE <lb/> VERKEHR (traffic).</p>
+                        <p>EXPECTED AT <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>.</p>
                         <p>S.S. Lesbos July 20 from Antwerp.</p>
                         <p>S.S. Androos July 20 from Hamburg bound for Beyrout.</p>
                         <p>S.S. Lemnos July 31 from Hamburg bound for Beyrout.</p>
-                        <p>For tariff and particulars apply to ADOLPHE STROSS, <placeName
-                                ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>,
-                            Agent. </p>
+                        <p>For tariff and particulars apply to ADOLPHE STROSS, <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>, Agent. </p>
                         <p>15-2-905 </p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-mma01">
                         <head>Messageries Maritimes.</head>
-                        <p>From <placeName ref="https://www.wikidata.org/wiki/Q87"
-                                >Alexandria</placeName></p>
+                        <p>From <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName></p>
                         <table rows="12" cols="6">
-                            <head><hi rend="bold">Sailing from <placeName
-                                        ref="https://www.wikidata.org/wiki/Q87"
-                                        >Alexandria</placeName> in July, 1905.</hi></head>
+                            <head><hi rend="bold">Sailing from <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> in July, 1905.</hi></head>
                             <row>
-                                <cell cols="6"><hi rend="bold">For <placeName
-                                            ref="https://www.wikidata.org/wiki/Q579613"
-                                            >Marseilles</placeName> direct</hi></cell>
+                                <cell cols="6"><hi rend="bold">For <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName> direct</hi></cell>
                             </row>
                             <row>
                                 <cell>Friday</cell>
@@ -625,9 +367,7 @@
                                 <cell>Capt. Vincenti</cell>
                             </row>
                             <row>
-                                <cell cols="6"><hi rend="bold">For <placeName
-                                            ref="https://www.wikidata.org/wiki/Q134509">Port
-                                            Said</placeName> and Beyrouth</hi></cell>
+                                <cell cols="6"><hi rend="bold">For <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> and Beyrouth</hi></cell>
                             </row>
                             <row>
                                 <cell>Thursday</cell>
@@ -646,9 +386,7 @@
                                 <cell>Capt. Aillaud</cell>
                             </row>
                             <row>
-                                <cell cols="6"><hi rend="bold">For <placeName
-                                            ref="https://www.wikidata.org/wiki/Q134509">Port
-                                            Said</placeName>, Jaffa and Beyrouth</hi></cell>
+                                <cell cols="6"><hi rend="bold">For <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>, Jaffa and Beyrouth</hi></cell>
                             </row>
                             <row>
                                 <cell>Thursday</cell>
@@ -676,97 +414,57 @@
                                 <cell>2nd Class</cell>
                             </row>
                             <row>
-                                <cell>From <placeName ref="https://www.wikidata.org/wiki/Q87"
-                                        >Alexandria</placeName> or <placeName
-                                        ref="https://www.wikidata.org/wiki/Q134509">Port
-                                        Said</placeName> (directly or via <placeName
-                                        ref="https://www.wikidata.org/wiki/Q87"
-                                        >Alexandria</placeName>) To <placeName
-                                        ref="https://www.wikidata.org/wiki/Q579613"
-                                        >Marseilles</placeName></cell>
+                                <cell>From <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> or <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> (directly or via <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>) To <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName></cell>
                                 <cell>£12.9.8 </cell>
                                 <cell>£9.10.3</cell>
                             </row>
                             <row>
-                                <cell>From <placeName ref="https://www.wikidata.org/wiki/Q87"
-                                        >Alexandria</placeName> To <placeName
-                                        ref="https://www.wikidata.org/wiki/Q134509">Port
-                                        Said</placeName></cell>
+                                <cell>From <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> To <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName></cell>
                                 <cell>£1.15.10</cell>
                                 <cell>£1.7.10</cell>
                             </row>
                             <row>
-                                <cell>From <placeName ref="https://www.wikidata.org/wiki/Q87"
-                                        >Alexandria</placeName> to Jaffa</cell>
+                                <cell>From <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> to Jaffa</cell>
                                 <cell>£3.3.5</cell>
                                 <cell>£2.2.5</cell>
                             </row>
                             <row>
-                                <cell>From <placeName ref="https://www.wikidata.org/wiki/Q87"
-                                        >Alexandria</placeName> to Beyrouth</cell>
+                                <cell>From <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> to Beyrouth</cell>
                                 <cell>£4.7.2</cell>
                                 <cell>£3.3.2.</cell>
                             </row>
                             <row>
-                                <cell>Through tickets for <placeName
-                                        ref="https://www.wikidata.org/wiki/Q90">Paris</placeName>
-                                    (via <placeName ref="https://www.wikidata.org/wiki/Q579613"
-                                        >Marseilles</placeName> from <placeName
-                                        ref="https://www.wikidata.org/wiki/Q87"
-                                        >Alexandria</placeName>) </cell>
+                                <cell>Through tickets for <placeName ref="https://www.wikidata.org/wiki/Q90">Paris</placeName> (via <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName> from <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>) </cell>
                                 <cell>£15.12.1</cell>
                                 <cell>£10.12.5</cell>
                             </row>
                             <row>
-                                <cell>Through tickets for <placeName
-                                        ref="https://www.wikidata.org/wiki/Q90">Paris</placeName>
-                                    (via <placeName ref="https://www.wikidata.org/wiki/Q579613"
-                                        >Marseilles</placeName>) from <placeName
-                                        ref="https://www.wikidata.org/wiki/Q134509">Port
-                                        Said</placeName> (directly or via <placeName
-                                        ref="https://www.wikidata.org/wiki/Q87"
-                                        >Alexandria</placeName>) </cell>
+                                <cell>Through tickets for <placeName ref="https://www.wikidata.org/wiki/Q90">Paris</placeName> (via <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName>) from <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> (directly or via <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>) </cell>
                                 <cell>£16.5.11</cell>
                                 <cell>£12.1.5</cell>
                             </row>
                             <row>
-                                <cell>Through tickets for <placeName
-                                        ref="https://www.wikidata.org/wiki/Q84">London</placeName>
-                                    (via <placeName ref="https://www.wikidata.org/wiki/Q579613"
-                                        >Marseilles</placeName>) (Calais-Douvree) from <placeName
-                                        ref="https://www.wikidata.org/wiki/Q87"
-                                        >Alexandria</placeName> or <placeName
-                                        ref="https://www.wikidata.org/wiki/Q134509">Port
-                                        Said</placeName> (directly or via <placeName
-                                        ref="https://www.wikidata.org/wiki/Q87"
-                                        >Alexandria</placeName>)</cell>
+                                <cell>Through tickets for <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> (via <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName>) (Calais-Douvree) from <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> or <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> (directly or via <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>)</cell>
                                 <cell>£16.12.10</cell>
                                 <cell>£12.9.8</cell>
                             </row>
                             <row>
-                                <cell>Interchangeable return tickets with the Austrian Lloyd Cy.
-                                    (available one way by Messageries</cell>
+                                <cell>Interchangeable return tickets with the Austrian Lloyd Cy. (available one way by Messageries</cell>
                                 <cell>£21.11.10</cell>
                                 <cell>£15.11.2</cell>
                             </row>
                         </table>
                         <table rend="frame" xml:id="SailingfromPortSaid">
-                            <head><hi rend="bold">Sailing from <placeName
-                                        ref="https://www.wikidata.org/wiki/Q134509">Port
-                                        Said</placeName> in July, 1905</hi></head>
+                            <head><hi rend="bold">Sailing from <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> in July, 1905</hi></head>
                             <row>
-                                <cell rows="5">For <placeName
-                                        ref="https://www.wikidata.org/wiki/Q579613"
-                                        >Marseilles</placeName> Direct</cell>
+                                <cell rows="5">For <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName> Direct</cell>
                                 <cell>Probably on</cell>
                                 <cell>Thursday</cell>
                                 <cell>6</cell>
                                 <cell>July</cell>
                                 <cell>Polynesien</cell>
                                 <cell>Capt. Broc</cell>
-                                <cell>returning from <placeName
-                                        ref="https://www.wikidata.org/wiki/Q1239">Indian
-                                        Ocean</placeName></cell>
+                                <cell>returning from <placeName ref="https://www.wikidata.org/wiki/Q1239">Indian Ocean</placeName></cell>
                             </row>
                             <row>
                                 <cell>Probably on</cell>
@@ -775,9 +473,7 @@
                                 <cell>July</cell>
                                 <cell>Iraouaddy</cell>
                                 <cell>Capt. Riquier</cell>
-                                <cell>returning from <placeName
-                                        ref="https://www.wikidata.org/wiki/Q148"
-                                    >China</placeName></cell>
+                                <cell>returning from <placeName ref="https://www.wikidata.org/wiki/Q148">China</placeName></cell>
                             </row>
                             <row>
                                 <cell>Probably on</cell>
@@ -786,9 +482,7 @@
                                 <cell>July</cell>
                                 <cell>Caledonian</cell>
                                 <cell>Capt. Grégory</cell>
-                                <cell>returning from <placeName
-                                        ref="https://www.wikidata.org/wiki/Q1239">Indian
-                                        Ocean</placeName></cell>
+                                <cell>returning from <placeName ref="https://www.wikidata.org/wiki/Q1239">Indian Ocean</placeName></cell>
                             </row>
                             <row>
                                 <cell>Probably on</cell>
@@ -797,9 +491,7 @@
                                 <cell>July</cell>
                                 <cell>Natal</cell>
                                 <cell>Capt. Fabre</cell>
-                                <cell>returning from <placeName
-                                        ref="https://www.wikidata.org/wiki/Q148"
-                                    >China</placeName></cell>
+                                <cell>returning from <placeName ref="https://www.wikidata.org/wiki/Q148">China</placeName></cell>
                             </row>
                             <row>
                                 <cell>Probably on</cell>
@@ -808,18 +500,13 @@
                                 <cell>July</cell>
                                 <cell>Ville de la Ciatat</cell>
                                 <cell>Capt. Etienne</cell>
-                                <cell>returning from <placeName
-                                        ref="https://www.wikidata.org/wiki/Q408"
-                                        >Australia</placeName></cell>
+                                <cell>returning from <placeName ref="https://www.wikidata.org/wiki/Q408">Australia</placeName></cell>
                             </row>
                         </table>
                         <table rend="frame" xml:id="SailingfromSuez">
-                            <head><hi rend="bold">Sailing from <placeName
-                                        ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>
-                                    in July, 1905</hi></head>
+                            <head><hi rend="bold">Sailing from <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName> in July, 1905</hi></head>
                             <row>
-                                <cell rows="2">For Aden, Colombo, Singapore, Saigon, Hong-Kong,
-                                    Shanghai, Kobe and Yokohama</cell>
+                                <cell rows="2">For Aden, Colombo, Singapore, Saigon, Hong-Kong, Shanghai, Kobe and Yokohama</cell>
                                 <cell>Saturday</cell>
                                 <cell>1</cell>
                                 <cell>July</cell>
@@ -834,8 +521,7 @@
                                 <cell>Capt. Bourdon</cell>
                             </row>
                             <row>
-                                <cell>For Djibouti, Colombo, Singapore, Saigon, Hong-Kong, Shanghai,
-                                    Kobe and Yokohama</cell>
+                                <cell>For Djibouti, Colombo, Singapore, Saigon, Hong-Kong, Shanghai, Kobe and Yokohama</cell>
                                 <cell>Saturday</cell>
                                 <cell>15</cell>
                                 <cell>July</cell>
@@ -843,8 +529,7 @@
                                 <cell>Capt. Guionnet</cell>
                             </row>
                             <row>
-                                <cell>For Djibouti, Zanzibar, Mutsamudu, Mayotte, Majunga, Nossi-Bé,
-                                    D. Suares, Tamatave, La Réunion and Maurice</cell>
+                                <cell>For Djibouti, Zanzibar, Mutsamudu, Mayotte, Majunga, Nossi-Bé, D. Suares, Tamatave, La Réunion and Maurice</cell>
                                 <cell>Sunday</cell>
                                 <cell>16</cell>
                                 <cell>July</cell>
@@ -852,8 +537,7 @@
                                 <cell>Capt. Jourdan</cell>
                             </row>
                             <row>
-                                <cell rows="2">For Djibouti, Aden, Mabé Diego-Suares, Ste. Marie,
-                                    Tamatave, La Réunion and Maurice</cell>
+                                <cell rows="2">For Djibouti, Aden, Mabé Diego-Suares, Ste. Marie, Tamatave, La Réunion and Maurice</cell>
                                 <cell>Saturday</cell>
                                 <cell>1</cell>
                                 <cell>July</cell>
@@ -868,9 +552,7 @@
                                 <cell>Capt. Riquier</cell>
                             </row>
                             <row>
-                                <cell>For Aden, <placeName ref="https://www.wikidata.org/wiki/Q1156"
-                                        >Bombay</placeName>, Colombo, Freemantle, Adelaide,
-                                    Melbourne, Sidney, and Noumes</cell>
+                                <cell>For Aden, <placeName ref="https://www.wikidata.org/wiki/Q1156">Bombay</placeName>, Colombo, Freemantle, Adelaide, Melbourne, Sidney, and Noumes</cell>
                                 <cell>Monday</cell>
                                 <cell>10</cell>
                                 <cell>July</cell>
@@ -878,8 +560,7 @@
                                 <cell>Capt. Boyer</cell>
                             </row>
                         </table>
-                        <p><placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>
-                            Agency (Shepheard's Hotel) 28-2-905</p>
+                        <p><placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> Agency (Shepheard's Hotel) 28-2-905</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-pri01">
                         <head>Prince Line.</head>
@@ -1014,13 +695,7 @@
                             </row>
                         </table>
                         <p>Good Accommodation for Passengers.</p>
-                        <p>Sailings every 10 days from Manchester and <placeName
-                                ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName> and
-                            fortnightly from Antwerp and <placeName
-                                ref="https://www.wikidata.org/wiki/Q84">London</placeName> to
-                                <placeName ref="https://www.wikidata.org/wiki/Q87"
-                                >Alexandria</placeName> and Syrian Coast. The dates are
-                            approximate</p>
+                        <p>Sailings every 10 days from Manchester and <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName> and fortnightly from Antwerp and <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> to <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> and Syrian Coast. The dates are approximate</p>
                         <table rows="4" cols="8">
                             <row>
                                 <cell>OCEAN PRINCE</cell>
@@ -1035,15 +710,11 @@
                             <row>
                                 <cell>PERSIAN PRINCE</cell>
                                 <cell>due from</cell>
-                                <cell>Antwerp &amp; <placeName
-                                        ref="https://www.wikidata.org/wiki/Q84"
-                                    >London</placeName></cell>
+                                <cell>Antwerp &amp; <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName></cell>
                                 <cell>July 23</cell>
                                 <cell>CARIB PRINCE</cell>
                                 <cell>due from</cell>
-                                <cell>Antwerp &amp; <placeName
-                                        ref="https://www.wikidata.org/wiki/Q84"
-                                    >London</placeName></cell>
+                                <cell>Antwerp &amp; <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName></cell>
                                 <cell>August 15</cell>
                             </row>
                             <row>
@@ -1059,23 +730,16 @@
                             <row>
                                 <cell>TROJAN PRINCE</cell>
                                 <cell>due from</cell>
-                                <cell>Antwerp &amp; <placeName
-                                        ref="https://www.wikidata.org/wiki/Q84"
-                                    >London</placeName></cell>
+                                <cell>Antwerp &amp; <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName></cell>
                                 <cell>July 31</cell>
                                 <cell>CREOLE PRINCE</cell>
                                 <cell>due from</cell>
-                                <cell>Antwerp &amp; <placeName
-                                        ref="https://www.wikidata.org/wiki/Q84"
-                                    >London</placeName></cell>
+                                <cell>Antwerp &amp; <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName></cell>
                                 <cell>August 29</cell>
                             </row>
                         </table>
-                        <p>HOMEWARD SAILINGS: -- The S.S. SPARTAN PRINCE is now loading for
-                            Manchester.</p>
-                        <p>For terms of freight or passage apply to C. J. Grace &amp; Co.,
-                                <placeName ref="https://www.wikidata.org/wiki/Q87"
-                                >Alexandria</placeName>, Agents. 31-12-904</p>
+                        <p>HOMEWARD SAILINGS: -- The S.S. SPARTAN PRINCE is now loading for Manchester.</p>
+                        <p>For terms of freight or passage apply to C. J. Grace &amp; Co., <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>, Agents. 31-12-904</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-nml01">
                         <head>THE NATIONAL MUTUAL LIFE ASSOCIATION OF AUSTRALASIA, LIMITED.</head>
@@ -1083,8 +747,7 @@
                         <p>With Profits Distributed every 3 Years. </p>
                         <p>Nearest Age 30.-Sun Assured £1,000.-Payable at age 50.</p>
                         <p>ANNUAL PREMIUM £47:18:4 TOTAL COST £958:6:8</p>
-                        <p>Minimum Return Over Cost exclusive of Bonuses £41:13:4. Several options
-                            at the end of 20 years. Guaranteed benefits during 20 years.</p>
+                        <p>Minimum Return Over Cost exclusive of Bonuses £41:13:4. Several options at the end of 20 years. Guaranteed benefits during 20 years.</p>
                         <table rend="frame">
                             <row>
                                 <cell/>
@@ -1123,8 +786,7 @@
                             </row>
                         </table>
                         <p>Full particulars on application to</p>
-                        <p>AGENTS IN <placeName ref="https://www.wikidata.org/wiki/Q85"
-                                >Cairo</placeName> :</p>
+                        <p>AGENTS IN <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> :</p>
                         <p>S. &amp; A. DE BILINSKI,</p>
                         <p>Khedivial Bourse Court.</p>
                         <p>LOW RATES. LIBERAL CONTRACTS. LARGE BONUSES.</p>
@@ -1132,56 +794,29 @@
                     <div type="item" scope="advertisement" xml:id="deg-ad-bal01">
                         <head>BANK OF ATHENS, LIMITED.</head>
                         <p><hi rend="bold">Capital 20,000,000 (Fully paid up).</hi></p>
-                        <p>BRANCHES: <placeName ref="https://www.wikidata.org/wiki/Q84"
-                                >London</placeName> 55-56 Bishops gate-street Within-<placeName
-                                ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>,
-                                <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>
-                            , Constantinople, Smyrna, At Candia and throughout <placeName
-                                ref="https://www.wikidata.org/wiki/Q41">Greece</placeName>.</p>
-                        <p>The Bank undertakes all banking business in Egypt, <placeName
-                                ref="https://www.wikidata.org/wiki/Q41">Greece</placeName>,<lb/>
-                            etc. Interest, on cash deposits: 3 0/0 per ann. at sight; 3 1/2 0/0
-                            <lb/> per ann. for 6 months ; 4 0/0 per ann. for 12 months ; 5 0/0
-                            per<lb/> ann. for 3 years and over. Savings Bank Branch receives
-                            de-<lb/>posits at 3 1/2 0/0 per ann., from P.T. 30 to P.T. 10,000.
-                            23538-19-1.905</p>
+                        <p>BRANCHES: <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> 55-56 Bishops gate-street Within-<placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>, <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> , Constantinople, Smyrna, At Candia and throughout <placeName ref="https://www.wikidata.org/wiki/Q41">Greece</placeName>.</p>
+                        <p>The Bank undertakes all banking business in Egypt, <placeName ref="https://www.wikidata.org/wiki/Q41">Greece</placeName>,<lb/> etc. Interest, on cash deposits: 3 0/0 per ann. at sight; 3 1/2 0/0 <lb/> per ann. for 6 months ; 4 0/0 per ann. for 12 months ; 5 0/0 per<lb/> ann. for 3 years and over. Savings Bank Branch receives de-<lb/>posits at 3 1/2 0/0 per ann., from P.T. 30 to P.T. 10,000. 23538-19-1.905</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-iob01">
                         <head>IMPERIAL OTTOMAN BANK.</head>
                         <p>CAPITAL: £10,000,000.</p>
-                        <p>HEAD OFFIOE IN CONSTANTINOPLE. CHIEF AGENCIES: <placeName
-                                ref="https://www.wikidata.org/wiki/Q84">London</placeName> &amp;
-                                <placeName ref="https://www.wikidata.org/wiki/Q90"
-                            >Paris</placeName>.</p>
-                        <p>BRANCHES IN ALL THE PRINCIPAL TOWNS IN <placeName
-                                ref="https://www.wikidata.org/wiki/Q43">Turkey</placeName>.</p>
-                        <p>Agencies in <placeName ref="https://www.wikidata.org/wiki/Q79"
-                                >Egypt</placeName>: <placeName
-                                ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>,
-                                <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>
-                            , &amp; <placeName ref="https://www.wikidata.org/wiki/Q134509">Port
-                                Said</placeName>.</p>
-                        <p>Advances on Merchandise and Securities in current account and for fixed
-                            periods. Purchase and sale of stocks and Shares on the <placeName
-                                ref="https://www.wikidata.org/wiki/Q84">London</placeName> and
-                            Continental exchanges, letters of credit issued, valuables reoeived in
-                            safe custody. Drafts, cheques and telegraphic transfers issued on the
-                            principal towns of the world. Foreign exchange purchased, bills
-                            discounted, bills, invoices, annuities and dividends collected and every
-                            description of banking business transacted. 18-4-906</p>
+                        <p>HEAD OFFIOE IN CONSTANTINOPLE. CHIEF AGENCIES: <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> &amp; <placeName ref="https://www.wikidata.org/wiki/Q90">Paris</placeName>.</p>
+                        <p>BRANCHES IN ALL THE PRINCIPAL TOWNS IN <placeName ref="https://www.wikidata.org/wiki/Q43">Turkey</placeName>.</p>
+                        <p>Agencies in <placeName ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName>: <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>, <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> , &amp; <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>.</p>
+                        <p>Advances on Merchandise and Securities in current account and for fixed periods. Purchase and sale of stocks and Shares on the <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> and Continental exchanges, letters of credit issued, valuables reoeived in safe custody. Drafts, cheques and telegraphic transfers issued on the principal towns of the world. Foreign exchange purchased, bills discounted, bills, invoices, annuities and dividends collected and every description of banking business transacted. 18-4-906</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-sgr01">
                         <head>SUDAN GOVERNMENT RAILWAYS.</head>
-                        <p><placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>
-                            -KHARTOUM SUMMER MAIL SERVICE.</p>
+                        <p><placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> -KHARTOUM SUMMER MAIL SERVICE.</p>
+
+
 
                         <table rows="3" cols="7">
                             <row>
                                 <cell>Wednesday and *Saturday</cell>
                                 <cell>8 p.m.</cell>
                                 <cell>depart</cell>
-                                <cell><placeName ref="https://www.wikidata.org/wiki/Q85"
-                                        >Cairo</placeName>
+                                <cell><placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>
                                 </cell>
                                 <cell>arrive</cell>
                                 <cell>*Monday and *Friday</cell>
@@ -1215,62 +850,30 @@
                                 <cell>12 noon</cell>
                             </row>
                         </table>
-                        <p>Mail delivered Khartoum, Sun. and Wednesday evening, and <placeName
-                                ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> , Mon. and
-                            Friday evening. *Dining and Sleeping Cars.</p>
+                        <p>Mail delivered Khartoum, Sun. and Wednesday evening, and <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> , Mon. and Friday evening. *Dining and Sleeping Cars.</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-sde01">
                         <head>SUDAN DEVELOPMENT &amp; EXPLORATION COMPANY, LIMITED</head>
-                        <p>KHARTOUM: <placeName ref="https://www.wikidata.org/wiki/Q85"
-                                >Cairo</placeName> Office, Sharia Kasr-el-Nil.</p>
-                        <p>TRANSPORT DEPARTMENT. Six days White Nile Tourist Trip dep. Khartoum
-                            Tuesdays. Steamer plans may be seen and passages booked at all
-                                <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>
-                            Tourist Agents. - Special Steamers for private charter. - Trips arranged
-                            and transport of goods undertaken to all places on White and Blue Niles
-                            within navigation limits.</p>
-                        <p>ENGINEERING DEPARTMENT. Shipyard for construction of sternwheel steamers,
-                            barges, stream, motor launches, etc. Contractors for supply and erection
-                            of all classes of machinery, buildings, irrigation pumps, etc.</p>
-                        <p>SOLE AGENTS FOR Dudbridges Oil Engines from 1 to 25 B.H.P. as supplied to
-                            Sudan Government. Seamless xxxxxxxxxxxxxxxxxxxxx</p>
+                        <p>KHARTOUM: <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> Office, Sharia Kasr-el-Nil.</p>
+                        <p>TRANSPORT DEPARTMENT. Six days White Nile Tourist Trip dep. Khartoum Tuesdays. Steamer plans may be seen and passages booked at all <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> Tourist Agents. - Special Steamers for private charter. - Trips arranged and transport of goods undertaken to all places on White and Blue Niles within navigation limits.</p>
+                        <p>ENGINEERING DEPARTMENT. Shipyard for construction of sternwheel steamers, barges, stream, motor launches, etc. Contractors for supply and erection of all classes of machinery, buildings, irrigation pumps, etc.</p>
+                        <p>SOLE AGENTS FOR Dudbridges Oil Engines from 1 to 25 B.H.P. as supplied to Sudan Government. Seamless xxxxxxxxxxxxxxxxxxxxx</p>
                     </div>
                     <cb n="3"/>
                     <div type="item" scope="advertisement" xml:id="deg-ad-aan01">
                         <head>Anglo-American Nile Steamer &amp; Hotel Coy.</head>
-                        <p>Weekly departure during Winter Season by the<lb/> Luxurious First Class
-                            Tourist Steamers VICTORIA, PURITAN &amp; MAYFLOWER.<lb/> Regular weekly
-                            Departures to the SECOND CATARACT by the S.S. IndianA.<lb/> THROUGH
-                            BOOKINGS TO KHARTOUM, GONDOKORO AND THE WHITE NILE.<lb/> Steamers and
-                            Dahabeahs for private charter. Steam Tugs and Steam Launches for
-                            hire.<lb/> FREIGHT SERVICE BY STEAM BARGES BETWEEN <placeName
-                                ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> AND
-                                <placeName ref="https://www.wikidata.org/wiki/Q87"
-                                >Alexandria</placeName>.<lb/> Working in conjunction and under
-                            special arrangement with the<lb/> “Upper <placeName
-                                ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName>Hotels
-                            Company."</p>
-                        <p>For details and illustrated programmes apply to "THE ANGLO-AMERICAN NILE
-                            STEAMER and<lb/> HOTEL COMPANY."</p>
-                        <p> OFFICES IN <placeName ref="https://www.wikidata.org/wiki/Q85"
-                                >Cairo</placeName> : Sharia Boulac, "Grand Continental Hotel
-                            Buildings.” 31-3-06</p>
+                        <p>Weekly departure during Winter Season by the<lb/> Luxurious First Class Tourist Steamers VICTORIA, PURITAN &amp; MAYFLOWER.<lb/> Regular weekly Departures to the SECOND CATARACT by the S.S. IndianA.<lb/> THROUGH BOOKINGS TO KHARTOUM, GONDOKORO AND THE WHITE NILE.<lb/> Steamers and Dahabeahs for private charter. Steam Tugs and Steam Launches for hire.<lb/> FREIGHT SERVICE BY STEAM BARGES BETWEEN <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> AND <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>.<lb/> Working in conjunction and under special arrangement with the<lb/> “Upper <placeName ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName>Hotels Company."</p>
+                        <p>For details and illustrated programmes apply to "THE ANGLO-AMERICAN NILE STEAMER and<lb/> HOTEL COMPANY."</p>
+                        <p> OFFICES IN <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> : Sharia Boulac, "Grand Continental Hotel Buildings.” 31-3-06</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-nll01">
                         <head>NORDDEUTSCHER LLOYD.</head>
-                        <p>Regular Service from <placeName ref="https://www.wikidata.org/wiki/Q87"
-                                >Alexandria</placeName> (Passenger and Freight) to NAPLES-<placeName
-                                ref="https://www.wikidata.org/wiki/Q579613"
-                            >Marseilles</placeName>.</p>
-                        <p> SCHLESWIG will leave <placeName ref="https://www.wikidata.org/wiki/Q87"
-                                >Alexandria</placeName> at 4 p.m. July 26, August 30, September 20,
-                            etc. </p>
-                        <p>The following steamers are intended to leave <placeName
-                                ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName> : </p>
+                        <p>Regular Service from <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> (Passenger and Freight) to NAPLES-<placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName>.</p>
+                        <p> SCHLESWIG will leave <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> at 4 p.m. July 26, August 30, September 20, etc. </p>
+                        <p>The following steamers are intended to leave <placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName> : </p>
                         <table rows="14" cols="3">
                             <row>
-                                <cell cols="3">HOMEWARD : for Bremen Hamburg via Naples, Genoa,
-                                    (Gibraltar), Southampton, Antwerp.</cell>
+                                <cell cols="3">HOMEWARD : for Bremen Hamburg via Naples, Genoa, (Gibraltar), Southampton, Antwerp.</cell>
                             </row>
                             <row>
                                 <cell>Zieten</cell>
@@ -1298,11 +901,7 @@
                                 <cell>about 28 August</cell>
                             </row>
                             <row>
-                                <cell cols="3">OUTWARD: for <placeName
-                                        ref="https://www.wikidata.org/wiki/Q148">China</placeName>
-                                    and JAPAN via <placeName
-                                        ref="https://www.wikidata.org/wiki/Q134514"
-                                    >Suez</placeName>, ADEN, COLOMBO, PENANG, SINGAPORE.</cell>
+                                <cell cols="3">OUTWARD: for <placeName ref="https://www.wikidata.org/wiki/Q148">China</placeName> and JAPAN via <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>, ADEN, COLOMBO, PENANG, SINGAPORE.</cell>
                             </row>
                             <row>
                                 <cell>Prinz E. Friedrich</cell>
@@ -1320,11 +919,7 @@
                                 <cell>about 7 August</cell>
                             </row>
                             <row>
-                                <cell cols="3">For <placeName
-                                        ref="https://www.wikidata.org/wiki/Q408"
-                                        >Australia</placeName> via <placeName
-                                        ref="https://www.wikidata.org/wiki/Q134514"
-                                    >Suez</placeName>, ADEN, COLOMBO.</cell>
+                                <cell cols="3">For <placeName ref="https://www.wikidata.org/wiki/Q408">Australia</placeName> via <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>, ADEN, COLOMBO.</cell>
                             </row>
                             <row>
                                 <cell>Seydlitz</cell>
@@ -1343,36 +938,15 @@
                             </row>
                         </table>
                         <p>FOR FURTHER PARTICULARS APPLY TO THE AGENTS OF THE </p>
-                        <p>NORDDEUTSCHER LLOYD at <placeName ref="https://www.wikidata.org/wiki/Q85"
-                                >Cairo</placeName> , <placeName
-                                ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>,
-                                <placeName ref="https://www.wikidata.org/wiki/Q134509"
-                                >Port-Said</placeName> and <placeName
-                                ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>. </p>
-                        <p>OTTO STERZING, Agent In <placeName
-                                ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> , Opera
-                            Square. </p>
-                        <p>C. H. SCHOELLER, Agent In <placeName
-                                ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>,
-                            Cleopatra Lane.</p>
-                        <p>Messrs. THOS. COOK &amp; SON (Egypt) LTD., and CARL STANGENS REISEBUREAN
-                            are anthorised to sell tickets in <placeName
-                                ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> and
-                                <placeName ref="https://www.wikidata.org/wiki/Q87"
-                                >Alexandria</placeName>, 31-8-905</p>
+                        <p>NORDDEUTSCHER LLOYD at <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> , <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>, <placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName> and <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>. </p>
+                        <p>OTTO STERZING, Agent In <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> , Opera Square. </p>
+                        <p>C. H. SCHOELLER, Agent In <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>, Cleopatra Lane.</p>
+                        <p>Messrs. THOS. COOK &amp; SON (Egypt) LTD., and CARL STANGENS REISEBUREAN are anthorised to sell tickets in <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> and <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>, 31-8-905</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-als01">
                         <head>Austrian Lloyd’s Steam Navigation</head>
-                        <p><placeName ref="https://www.wikidata.org/wiki/Q87"
-                            >Alexandria</placeName>-Brindisi-Venice-Trieste.</p>
-                        <p>Weekly Express Mail Service. Steamers leave <placeName
-                                ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> every
-                            Saturday at 4 p.m. arrive at Brindisi, Tuesday a.m. in time for express
-                            to <placeName ref="https://www.wikidata.org/wiki/Q90">Paris</placeName>,
-                                <placeName ref="https://www.wikidata.org/wiki/Q84"
-                                >London</placeName>, Naples, Rome. Arrival Trieste Wednesday noon
-                            connecting with Vienna Express (Trieste-Ostende through carriage) and
-                            expresses to Italy and Germany.</p>
+                        <p><placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>-Brindisi-Venice-Trieste.</p>
+                        <p>Weekly Express Mail Service. Steamers leave <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> every Saturday at 4 p.m. arrive at Brindisi, Tuesday a.m. in time for express to <placeName ref="https://www.wikidata.org/wiki/Q90">Paris</placeName>, <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName>, Naples, Rome. Arrival Trieste Wednesday noon connecting with Vienna Express (Trieste-Ostende through carriage) and expresses to Italy and Germany.</p>
                         <table rows="3" cols="8">
                             <row>
                                 <cell>July 8</cell>
@@ -1405,8 +979,7 @@
                                 <cell/>
                             </row>
                         </table>
-                        <p>Fortnightly Service: <placeName ref="https://www.wikidata.org/wiki/Q87"
-                                >Alexandria</placeName>-Brindisi-Venice-Trieste </p>
+                        <p>Fortnightly Service: <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>-Brindisi-Venice-Trieste </p>
                         <table rows="1" cols="8">
                             <row>
                                 <cell>June 21</cell>
@@ -1419,47 +992,21 @@
                                 <cell>Capt. Knezevich</cell>
                             </row>
                         </table>
-                        <p>(Departures from <placeName ref="https://www.wikidata.org/wiki/Q134514"
-                                >Suez</placeName>) To Aden, <placeName
-                                ref="https://www.wikidata.org/wiki/Q1156">Bombay</placeName>,
-                            Colombo, Penang, Singapore, Hong-Kong, Shanghai, Yokohama, Kobé about
-                            July 5 and August 4. To Aden, Karachi, and <placeName
-                                ref="https://www.wikidata.org/wiki/Q1156">Bombay</placeName>
-                            accelerated service about August 18. To Aden, Karachi, <placeName
-                                ref="https://www.wikidata.org/wiki/Q1156">Bombay</placeName>,
-                            Colombo, Madras, Rangoon, and Calcutta about July 20.</p>
+                        <p>(Departures from <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>) To Aden, <placeName ref="https://www.wikidata.org/wiki/Q1156">Bombay</placeName>, Colombo, Penang, Singapore, Hong-Kong, Shanghai, Yokohama, Kobé about July 5 and August 4. To Aden, Karachi, and <placeName ref="https://www.wikidata.org/wiki/Q1156">Bombay</placeName> accelerated service about August 18. To Aden, Karachi, <placeName ref="https://www.wikidata.org/wiki/Q1156">Bombay</placeName>, Colombo, Madras, Rangoon, and Calcutta about July 20.</p>
                         <p>East African Line.</p>
-                        <p>To Aden, Mombassa, Zanzibar, Beira, Delagoa Bay, Durban, about July 4 and
-                            August 3.</p>
+                        <p>To Aden, Mombassa, Zanzibar, Beira, Delagoa Bay, Durban, about July 4 and August 3.</p>
                         <p>Syrian-Cyprus-Caramanian Line.</p>
-                        <p>Steamers leaves <placeName ref="https://www.wikidata.org/wiki/Q87"
-                                >Alexandria</placeName> on or about July 3, 17 and 31.</p>
-                        <p>For information apply to the Agents, <placeName
-                                ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>,
-                                <placeName ref="https://www.wikidata.org/wiki/Q134509">Port
-                                Said</placeName> and <placeName
-                                ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>, Thos.
-                            Cook &amp; Son, Ld., Leon Heller, <placeName
-                                ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> Agent, 4,
-                            Sharia Maghraby, (Telephone 192), <placeName
-                                ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> ; F.
-                            Tedeschi, Helouan.</p>
-                        <p>Special passage rates granted to Egyptian Government officials, members
-                            of the Army of Occupation and their families. </p>
+                        <p>Steamers leaves <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> on or about July 3, 17 and 31.</p>
+                        <p>For information apply to the Agents, <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>, <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> and <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>, Thos. Cook &amp; Son, Ld., Leon Heller, <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> Agent, 4, Sharia Maghraby, (Telephone 192), <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> ; F. Tedeschi, Helouan.</p>
+                        <p>Special passage rates granted to Egyptian Government officials, members of the Army of Occupation and their families. </p>
                         <p>31-12-905</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-cun01">
                         <head>Cunard Line.</head>
                         <table rows="4" cols="6">
-                            <head><placeName ref="https://www.wikidata.org/wiki/Q87"
-                                    >Alexandria</placeName> to New-York and Boston via the Continent
-                                and <placeName ref="https://www.wikidata.org/wiki/Q24826"
-                                    >Liverpool</placeName></head>
+                            <head><placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> to New-York and Boston via the Continent and <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName></head>
                             <row>
-                                <cell cols="6">Sailings from <placeName
-                                        ref="https://www.wikidata.org/wiki/Q24826"
-                                        >Liverpool</placeName> on Saturdays and Tuesdays. Royal Mail
-                                    Steamers:</cell>
+                                <cell cols="6">Sailings from <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName> on Saturdays and Tuesdays. Royal Mail Steamers:</cell>
                             </row>
                             <row>
                                 <cell>Caronia</cell>
@@ -1487,12 +1034,9 @@
                             </row>
                         </table>
                         <table rows="3" cols="4">
-                            <head><placeName ref="https://www.wikidata.org/wiki/Q87"
-                                    >Alexandria</placeName> to New-York via Trieste, Fiume or
-                                Palermo</head>
+                            <head><placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> to New-York via Trieste, Fiume or Palermo</head>
                             <row>
-                                <cell cols="4">Regular twin-screw Passenger Service from the
-                                    Adriatic. Excellent accommodation.</cell>
+                                <cell cols="4">Regular twin-screw Passenger Service from the Adriatic. Excellent accommodation.</cell>
                             </row>
                             <row>
                                 <cell>Carpathia</cell>
@@ -1507,73 +1051,36 @@
                                 <cell>10,402 tons</cell>
                             </row>
                         </table>
-                        <p>All steamers fitted with Marconi's wireless telegraphy. For through
-                            tickets from Egypt, and particulars aply to the Agents Rodacanachi &amp;
-                            Co., <placeName ref="https://www.wikidata.org/wiki/Q87"
-                                >Alexandria</placeName>; Nic. Kerzis, <placeName
-                                ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> ; R.
-                            Broadbent, <placeName ref="https://www.wikidata.org/wiki/Q134509">Port
-                                Said</placeName>. 19-1-905</p>
+                        <p>All steamers fitted with Marconi's wireless telegraphy. For through tickets from Egypt, and particulars aply to the Agents Rodacanachi &amp; Co., <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>; Nic. Kerzis, <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> ; R. Broadbent, <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>. 19-1-905</p>
                     </div>
                     <!-- TODO Russian Steam Navigation -->
                     <div type="item" scope="advertisement" xml:id="deg-ad-pap01">
                         <head>THE PAPAYANNI LINE.</head>
                         <head type="sub">(The Ellerman Lines, Ltd.)</head>
-                        <p>Frequent Sailings from <placeName ref="https://www.wikidata.org/wiki/Q87"
-                                >Alexandria</placeName> to <placeName
-                                ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName>,
-                            also Regular Services from <placeName
-                                ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName> to
-                                <placeName ref="https://www.wikidata.org/wiki/Q87"
-                                >Alexandria</placeName> and to ALGERIA, <placeName
-                                ref="https://www.wikidata.org/wiki/Q233">Malta</placeName>, LEVANT,
-                            BLACK SEA, and other Mediterranean Ports.</p>
-                        <p>Excellent Passenger Accommodation. Stewardess carried. Liberal table and
-                            Moderate Fares for single and retnrn tickets. </p>
-                        <p>The S S. SARDINIA will sail for <placeName
-                                ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName>
-                            (via Bona) on Friday, the 7th inst. at 4 p.m.</p>
-                        <p>CARGO taken by special agreement only. Through Freights quoted for the
-                            UNITED STATES and INLAND TOWNS in GREAT BRITAIN.</p>
-                        <p>For passage or freight apply to the Agents, BARKER &amp; Co., <placeName
-                                ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>.
-                            2061-17-10-905 </p>
+                        <p>Frequent Sailings from <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> to <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName>, also Regular Services from <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName> to <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> and to ALGERIA, <placeName ref="https://www.wikidata.org/wiki/Q233">Malta</placeName>, LEVANT, BLACK SEA, and other Mediterranean Ports.</p>
+                        <p>Excellent Passenger Accommodation. Stewardess carried. Liberal table and Moderate Fares for single and retnrn tickets. </p>
+                        <p>The S S. SARDINIA will sail for <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName> (via Bona) on Friday, the 7th inst. at 4 p.m.</p>
+                        <p>CARGO taken by special agreement only. Through Freights quoted for the UNITED STATES and INLAND TOWNS in GREAT BRITAIN.</p>
+                        <p>For passage or freight apply to the Agents, BARKER &amp; Co., <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>. 2061-17-10-905 </p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-ell01">
                         <head>Ellerman Lines, Limited.</head>
                         <table rows="3" cols="6">
                             <row>
-                                <cell cols="3">CITY LINE to <placeName
-                                        ref="https://www.wikidata.org/wiki/Q233">Malta</placeName>,
-                                        <placeName ref="https://www.wikidata.org/wiki/Q84"
-                                        >London</placeName>, COLOMBO &amp; CALCUTTA.</cell>
+                                <cell cols="3">CITY LINE to <placeName ref="https://www.wikidata.org/wiki/Q233">Malta</placeName>, <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName>, COLOMBO &amp; CALCUTTA.</cell>
                                 <cell cols="3">
-                                    <p>CITY &amp; HALL LINES. Joint Service to <placeName
-                                            ref="https://www.wikidata.org/wiki/Q579613"
-                                            >Marseilles</placeName>, <placeName
-                                            ref="https://www.wikidata.org/wiki/Q24826"
-                                            >Liverpool</placeName>, <placeName
-                                            ref="https://www.wikidata.org/wiki/Q1156"
-                                            >Bombay</placeName> &amp; KARACHI.</p>
+                                    <p>CITY &amp; HALL LINES. Joint Service to <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName>, <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName>, <placeName ref="https://www.wikidata.org/wiki/Q1156">Bombay</placeName> &amp; KARACHI.</p>
                                 </cell>
                             </row>
                             <row>
-                                <cell cols="6">The undermentioned First Class Passenger Steamers
-                                    will be dispatched from <placeName
-                                        ref="https://www.wikidata.org/wiki/Q134509">Port
-                                        Said</placeName> on or about the following dates for </cell>
+                                <cell cols="6">The undermentioned First Class Passenger Steamers will be dispatched from <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> on or about the following dates for </cell>
                             </row>
                             <row>
-                                <cell><placeName ref="https://www.wikidata.org/wiki/Q233"
-                                        >Malta</placeName> and <placeName
-                                        ref="https://www.wikidata.org/wiki/Q84">London</placeName>
+                                <cell><placeName ref="https://www.wikidata.org/wiki/Q233">Malta</placeName> and <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName>
                                 </cell>
                                 <cell>S.S. City of Corinth </cell>
                                 <cell>July 26</cell>
-                                <cell><placeName ref="https://www.wikidata.org/wiki/Q579613"
-                                        >Marseilles</placeName> and <placeName
-                                        ref="https://www.wikidata.org/wiki/Q24826"
-                                        >Liverpool</placeName></cell>
+                                <cell><placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName> and <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName></cell>
                                 <cell/>
                                 <cell/>
                             </row>
@@ -1581,94 +1088,54 @@
                                 <cell>Colombo and Calcutta</cell>
                                 <cell>S.S. City of Manchester</cell>
                                 <cell>July 12</cell>
-                                <cell><placeName ref="https://www.wikidata.org/wiki/Q1156"
-                                        >Bombay</placeName></cell>
+                                <cell><placeName ref="https://www.wikidata.org/wiki/Q1156">Bombay</placeName></cell>
                                 <cell>S.S. Anton Hall</cell>
                                 <cell>July 13</cell>
                             </row>
                         </table>
-                        <p>SALOON FARES:—<placeName ref="https://www.wikidata.org/wiki/Q134509">Port
-                                Said</placeName> to <placeName
-                                ref="https://www.wikidata.org/wiki/Q233">Malta</placeName> £4.10.0.
-                                <placeName ref="https://www.wikidata.org/wiki/Q579613"
-                                >Marseilles</placeName>. £8.0.0. <placeName
-                                ref="https://www.wikidata.org/wiki/Q84">London</placeName> or
-                                <placeName ref="https://www.wikidata.org/wiki/Q24826"
-                                >Liverpool</placeName>, £l2.l0.0. Colombo, Calcutta, <placeName
-                                ref="https://www.wikidata.org/wiki/Q1156">Bombay</placeName> or
-                            Karachi, £35.0.0. Special rates for steamers not carrying Doctor or
-                            Stewardess. For further particulars apply to </p>
-                        <p>CORY BROS. &amp; Co., Ltd., Agents for CITY Line, <placeName
-                                ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>:
-                            W. STAPLEDON &amp; SON, Agents for Hall Line, <placeName
-                                ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> ;
-                            or COOK &amp; SON (Egypt), Ltd., <placeName
-                                ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> .
-                            23788-28-8-905 </p>
+                        <p>SALOON FARES:—<placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> to <placeName ref="https://www.wikidata.org/wiki/Q233">Malta</placeName> £4.10.0. <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName>. £8.0.0. <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> or <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName>, £l2.l0.0. Colombo, Calcutta, <placeName ref="https://www.wikidata.org/wiki/Q1156">Bombay</placeName> or Karachi, £35.0.0. Special rates for steamers not carrying Doctor or Stewardess. For further particulars apply to </p>
+                        <p>CORY BROS. &amp; Co., Ltd., Agents for CITY Line, <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>: W. STAPLEDON &amp; SON, Agents for Hall Line, <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> ; or COOK &amp; SON (Egypt), Ltd., <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> . 23788-28-8-905 </p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-ell02">
                         <head>The Ellerman Lines, Limited.</head>
                         <head type="sub">(Including Westcott &amp; Laurance Line.)</head>
-                        <p>Regular sailings from <placeName
-                                ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName>,
-                            Glasgow, Antwerp and <placeName ref="https://www.wikidata.org/wiki/Q84"
-                                >London</placeName> to <placeName
-                                ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>.
-                            Frequent sailings from <placeName
-                                ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> to
-                                <placeName ref="https://www.wikidata.org/wiki/Q24826"
-                                >Liverpool</placeName> and <placeName
-                                ref="https://www.wikidata.org/wiki/Q84">London</placeName>. Through
-                            freight rates to Inland towns in Great Britain also to the U.S.A</p>
+                        <p>Regular sailings from <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName>, Glasgow, Antwerp and <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> to <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>. Frequent sailings from <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> to <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName> and <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName>. Through freight rates to Inland towns in Great Britain also to the U.S.A</p>
                         <table rows="4" cols="5">
                             <row>
                                 <cell>Westcott S.S. Joshua Nicholson</cell>
                                 <cell>expected from</cell>
-                                <cell>Antwerp, <placeName ref="https://www.wikidata.org/wiki/Q84"
-                                        >London</placeName> &amp; <placeName
-                                        ref="https://www.wikidata.org/wiki/Q233"
-                                    >Malta</placeName></cell>
+                                <cell>Antwerp, <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> &amp; <placeName ref="https://www.wikidata.org/wiki/Q233">Malta</placeName></cell>
                                 <cell>is due on or about</cell>
                                 <cell>July 16</cell>
                             </row>
                             <row>
                                 <cell>Ellerman S.S. City of Dundee</cell>
                                 <cell>expected from</cell>
-                                <cell>Glasgow, Gibraltar &amp; <placeName
-                                        ref="https://www.wikidata.org/wiki/Q233"
-                                    >Malta</placeName></cell>
+                                <cell>Glasgow, Gibraltar &amp; <placeName ref="https://www.wikidata.org/wiki/Q233">Malta</placeName></cell>
                                 <cell>is due on or about</cell>
                                 <cell>July 25</cell>
                             </row>
                             <row>
                                 <cell>Westcott S.S. Plymothian</cell>
                                 <cell>expected from</cell>
-                                <cell>Antwerp, <placeName ref="https://www.wikidata.org/wiki/Q84"
-                                        >London</placeName> &amp; <placeName
-                                        ref="https://www.wikidata.org/wiki/Q233"
-                                    >Malta</placeName></cell>
+                                <cell>Antwerp, <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> &amp; <placeName ref="https://www.wikidata.org/wiki/Q233">Malta</placeName></cell>
                                 <cell>is due on or about</cell>
                                 <cell>July 25</cell>
                             </row>
                             <row>
                                 <cell>Ellerman S.S. City of Oxford</cell>
                                 <cell>expected from</cell>
-                                <cell><placeName ref="https://www.wikidata.org/wiki/Q24826"
-                                        >Liverpool</placeName> &amp; Melta</cell>
+                                <cell><placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName> &amp; Melta</cell>
                                 <cell>is due on or about</cell>
                                 <cell>July 30</cell>
                             </row>
                         </table>
-                        <p>Ellerman S.S. Britannia now on the berth for <placeName
-                                ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName> is
-                            expected to sail about the 25th inst.</p>
-                        <p>N. E. TAMVACO <placeName ref="https://www.wikidata.org/wiki/Q87"
-                                >Alexandria</placeName> agents 23186-20-3-3</p>
+                        <p>Ellerman S.S. Britannia now on the berth for <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName> is expected to sail about the 25th inst.</p>
+                        <p>N. E. TAMVACO <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> agents 23186-20-3-3</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-ngi01">
                         <head>Navigation Générale Italienne.</head>
-                        <p>Societes Reunies Florio-Rubattino. - Services Postaux. - Departs de
-                            Juillet.</p>
+                        <p>Societes Reunies Florio-Rubattino. - Services Postaux. - Departs de Juillet.</p>
                         <table rows="5" cols="4">
                             <row>
                                 <cell>Les Jeudis</cell>
@@ -1692,9 +1159,7 @@
                                 <cell>Le Lundi</cell>
                                 <cell>24</cell>
                                 <cell>à 4 h. p.m.</cell>
-                                <cell>pour Port-Saïd, <placeName
-                                        ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>
-                                    et Massawah.</cell>
+                                <cell>pour Port-Saïd, <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName> et Massawah.</cell>
                             </row>
                             <row>
                                 <cell>Le Vendredi</cell>
@@ -1727,50 +1192,39 @@
                         <p>Soda Water. Lemonade, Ginger Ale, Ginger Beer. Tonic Water</p>
                         <p>Pomegranade, Orangeaade, Pineapple, Champagne, Cider, etc., etc.</p>
                         <p> Water guaranteed by Chamberlain’s Filter (Pasteur’s System).</p>
-                        <p>Inventor of WHISKY &amp; SODA and BRANDY &amp; SODA, bottled ready for
-                            use.</p>
+                        <p>Inventor of WHISKY &amp; SODA and BRANDY &amp; SODA, bottled ready for use.</p>
                         <p> Sole Agents in Egypt and Soudan for</p>
                         <p> J. Calvet &amp; Co. Bordeaux. Wine &amp; Cognacs.</p>
                         <p>Louis Roederer. Rheims. Champagnes.</p>
                         <p>August Engel. Wiesbaden. Rhine and Moselle Wines.</p>
-                        <p>Mackie &amp; Co. Glasgow. Lagavulin, White Horse Cellar &amp; other
-                            Whiskies.</p>
+                        <p>Mackie &amp; Co. Glasgow. Lagavulin, White Horse Cellar &amp; other Whiskies.</p>
                         <p>Dunville &amp; Co, Ltd. Belfast. Old Irish Whiskies.</p>
                         <p>Wm. Lanahan &amp; Son. Baltimore. Monongshels XXXX Whiskey.</p>
-                        <p>The Cook &amp; Bernheimer Co. New York. Old Valley Whiskey and Gold Lion
-                            Cocktails.</p>
+                        <p>The Cook &amp; Bernheimer Co. New York. Old Valley Whiskey and Gold Lion Cocktails.</p>
                         <p>Stone &amp; Son. London. Guinness' Stout &amp; Bass' Pale Ale.</p>
                         <p>Freund Ballor &amp; Co. Tornio. Vermouth.</p>
                         <p>Pierre Bisset. Cette. Vermouth &amp; Aperitives.</p>
                         <p>Terrabonatea Company, Ld. Teas.</p>
-                        <p>Depot for Prince Metternich's "Richardsquelle," the best mineral table
-                            water in the world.</p>
-                        <p>Great assortment of Wines, Spirits, Liqueurs, of the finest Brands,
-                            etc</p>
+                        <p>Depot for Prince Metternich's "Richardsquelle," the best mineral table water in the world.</p>
+                        <p>Great assortment of Wines, Spirits, Liqueurs, of the finest Brands, etc</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-abp01">
                         <head>THE ARTESIAN BORING AND PROSPECTING COMPANY.</head>
                         <p>(SOCIÉTÉ ANONYME)</p>
                         <p>CAIRO, 28, SHARIA-EL-MANAKH,<lb/> (OPPOSITE IMPERIAL OTTOMAN BANK).</p>
-                        <p>I. —Installation of complete Water supplies for drinking, agricultural,
-                            and<lb/> industrial purposes by means of artesian wells.</p>
-                        <p>II. - Deep borings for prospecting purposes in all conditions of soil by
-                            means of the<lb/> “Express Boring System."</p>
+                        <p>I. —Installation of complete Water supplies for drinking, agricultural, and<lb/> industrial purposes by means of artesian wells.</p>
+                        <p>II. - Deep borings for prospecting purposes in all conditions of soil by means of the<lb/> “Express Boring System."</p>
                         <p>24,437-12-1-905</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-hom01">
                         <head>"Homocea" "Touches The Spot"</head>
-                        <p>In all cases of cuts, burns, bruises, chafes, sores, ulcers, open Wounds,
-                            and cimilar ills of the flesh, anoint with Homocea on linen or lint.</p>
-                        <p>Homocea for bruises, bites stings, swellings, sore throat, face-ache
-                            etc., gently rob and cover with Homocea on linen</p>
+                        <p>In all cases of cuts, burns, bruises, chafes, sores, ulcers, open Wounds, and cimilar ills of the flesh, anoint with Homocea on linen or lint.</p>
+                        <p>Homocea for bruises, bites stings, swellings, sore throat, face-ache etc., gently rob and cover with Homocea on linen</p>
                         <p>Homocea is antiseptic, soothing, and healing,</p>
                         <p>Homocea allays inaflamtive, initature &amp;c.</p>
                         <p>Homocea is the most wonderful relief and cure for piles known.</p>
-                        <p>Homocea Embrocation is for rubbing of in pains of all kinds, rheumatic
-                            pains, strains, stiff joints neuralgia, etc.</p>
-                        <p>Hippacea does in the kennel, stable, and farm, for all animals what
-                            Homocea does in the Household.</p>
+                        <p>Homocea Embrocation is for rubbing of in pains of all kinds, rheumatic pains, strains, stiff joints neuralgia, etc.</p>
+                        <p>Hippacea does in the kennel, stable, and farm, for all animals what Homocea does in the Household.</p>
                         <p>Sold by Druggists and Chemists</p>
                         <p>The wholesale trade supplied by: MAX FISCHER, Cairo.</p>
                         <p>24203-52-6</p>
@@ -1783,8 +1237,7 @@
                         <p>de provenance directe et de toutes les meilleures marques</p>
                         <p>Nicolas G Sabbag</p>
                         <p>IMPORTATEUR GENERAL</p>
-                        <p>FOURNISSIUR DE S A LE KHEDIVE et de tous les grands Clubs et Hôtels
-                            d'Egypte.</p>
+                        <p>FOURNISSIUR DE S A LE KHEDIVE et de tous les grands Clubs et Hôtels d'Egypte.</p>
                         <p>2—Rue de la Gare du Caire—2 ALEXANDRIE</p>
                         <p> Adresse Télégraphique : SABBAG Alexandrie</p>
                         <p> Téléphone No 559.</p>
@@ -1813,35 +1266,19 @@
                         <head>Hall's Sanitary Washable Distemper</head>
                         <p>Made in 70 Colors</p>
                         <p>An artistic wall covering.</p>
-                        <p>This celebrated water paint is made in two qualities for Inside and
-                            Outside work</p>
-                        <p>HALL’S SANITARY WASHABLE DISTEMPER is rapidly superseding wall papers in
-                            all tastefully furnished homes. It is made in 70 artistic tints, and
-                            only requires the addition of water to make it ready for use. It is
-                            quickly and easily applied with a whitewash brush, with half the labour
-                            and at one third the cost of paint. HALL’S DISTEMPER ensures
-                            cleanliness, and is pleasing to the eye. It appeals alike to artistic
-                            and practical house decoration. HALL’S DISTEMPER is of special value in
-                            hot climates. Owing to its cool, pleasing colours, great
-                            weather-resisting and germ-destroying properties, it lends itself to
-                            every kind of wall, wood, brick or stone coating, possessing all the
-                            advantages of paint, colour- wash, and disinfectant at one third the
-                            cost of oil paint. It never blisters in the hottest sun, and the fact
-                            that it can be washed adds greatly to its sanitary advantages.</p>
+                        <p>This celebrated water paint is made in two qualities for Inside and Outside work</p>
+                        <p>HALL’S SANITARY WASHABLE DISTEMPER is rapidly superseding wall papers in all tastefully furnished homes. It is made in 70 artistic tints, and only requires the addition of water to make it ready for use. It is quickly and easily applied with a whitewash brush, with half the labour and at one third the cost of paint. HALL’S DISTEMPER ensures cleanliness, and is pleasing to the eye. It appeals alike to artistic and practical house decoration. HALL’S DISTEMPER is of special value in hot climates. Owing to its cool, pleasing colours, great weather-resisting and germ-destroying properties, it lends itself to every kind of wall, wood, brick or stone coating, possessing all the advantages of paint, colour- wash, and disinfectant at one third the cost of oil paint. It never blisters in the hottest sun, and the fact that it can be washed adds greatly to its sanitary advantages.</p>
                         <p>Supplied in Tins and Iron Kegs.</p>
                         <p>Sole Manufacturers :</p>
                         <p>SISSONS BROTHERS &amp; Co., Ltd., HULL.</p>
-                        <p>Stocks are held In Cairo by FRANK RATCLIFFE, Sanitary Contractor and
-                            Engineer, Sharia Saptieh.</p>
+                        <p>Stocks are held In Cairo by FRANK RATCLIFFE, Sanitary Contractor and Engineer, Sharia Saptieh.</p>
                         <p>In Alexandria by RAMADAN YOUSSEF, Sanitary Contractor, Rue Sesostris.</p>
                         <p>General Agents: GEORGE MORRIS &amp; Co.. Alexandria &amp; Cairo.</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-bla01">
                         <head>Beetham's "Larola"</head>
                         <p>Prevents the attack of mosquitoes.</p>
-                        <p>Will entirely Remove all ROUGHNESS, REDNESS, HEAT, IRRITATION, &amp;c.,
-                            in a very short time. IT KEEPS THE SKIN SOFT, SMOOTH, AND WHITE at all
-                            seasons, and is DELIGHTFULLY COOLING and REFRESHING.</p>
+                        <p>Will entirely Remove all ROUGHNESS, REDNESS, HEAT, IRRITATION, &amp;c., in a very short time. IT KEEPS THE SKIN SOFT, SMOOTH, AND WHITE at all seasons, and is DELIGHTFULLY COOLING and REFRESHING.</p>
                         <p>Agent:--MAX FISCHER, CAIRO AND ALEXANDRIA.</p>
                         <p>Sole Makers--M. BEETHAM &amp; SON, CHELTENHAM, ENGLAND.</p>
                     </div>
@@ -1855,10 +1292,8 @@
                         <p>DIRECT IMPORTER OF BRITISH AND IRISH TEXTILE MANUFACTURES.</p>
                         <p>LADIES’ SUMMER STOCKINGS.</p>
                         <p> IN SPUN SILK at P.T. 20 per pair.</p>
-                        <p>LISLE THREAD, in plain and lace open-work, in black, white, tan and usual
-                            shades, to suit boots worn in Egypt, frpm P.T. 5 per pair.</p>
-                        <p>Every pair is marked “Au De Rouge" which is a guarantee that the Color is
-                            absolutely fast and stainless.</p>
+                        <p>LISLE THREAD, in plain and lace open-work, in black, white, tan and usual shades, to suit boots worn in Egypt, frpm P.T. 5 per pair.</p>
+                        <p>Every pair is marked “Au De Rouge" which is a guarantee that the Color is absolutely fast and stainless.</p>
                         <p>24916-15-11-905</p>
                     </div>
                     <!-- TODO Lancaster House, Cairo -->
@@ -1877,11 +1312,9 @@
                                 <cell>
                                     <p>E.T.C. Cricket Match. Seniors v.<lb/>Juniors. 1.30 p.m.</p>
                                     <p>Mex Casino. Reunion des Familles.<lb/>9.30 p.m.</p>
-                                    <p>Mex. Prineaas' Restaurant des Bisins<lb/>Roumanian orchestra,
-                                        every afternoon<lb/>Sundays, morning.</p>
+                                    <p>Mex. Prineaas' Restaurant des Bisins<lb/>Roumanian orchestra, every afternoon<lb/>Sundays, morning.</p>
                                     <p>Windsor Hotel. Orchestra. 6 to<lb/>11:30 p.m. every day.</p>
-                                    <p>Alhambra -- Italian company --<lb/>I fourchambault. 9.15
-                                        p.m.</p>
+                                    <p>Alhambra -- Italian company --<lb/>I fourchambault. 9.15 p.m.</p>
                                     <p>Crouwn Casino. Ibrahhimieh. 9.30 p.m.</p>
                                     <p>Tour Eiffel. Calabrian Benefit performance<lb/>9 p.m.</p>
                                 </cell>
@@ -1890,18 +1323,15 @@
                                 <cell>Sat.</cell>
                                 <cell>7</cell>
                                 <cell>
-                                    <p>Alex. Swimming Club. 3rd Annual<lb/>Aquatic Sports. New
-                                        Graving<lb/>Dock, Gabbari. 3 p.m.</p>
+                                    <p>Alex. Swimming Club. 3rd Annual<lb/>Aquatic Sports. New Graving<lb/>Dock, Gabbari. 3 p.m.</p>
                                 </cell>
                             </row>
                             <row>
                                 <cell>Sat.</cell>
                                 <cell>14</cell>
                                 <cell>
-                                    <p>Alex. Swimming Club. 60yds Juniors'<lb/>100yds. Seniors'
-                                        Chapmpionships.<lb/>Customs Gate 23. 4 p.m.</p>
-                                    <p>B.R.C. Mustapha Pasha Range.<lb/>Practice and Cup
-                                        Compeittion.<lb/>3 p.m.</p>
+                                    <p>Alex. Swimming Club. 60yds Juniors'<lb/>100yds. Seniors' Chapmpionships.<lb/>Customs Gate 23. 4 p.m.</p>
+                                    <p>B.R.C. Mustapha Pasha Range.<lb/>Practice and Cup Compeittion.<lb/>3 p.m.</p>
                                 </cell>
                             </row>
                         </table>
@@ -1914,8 +1344,7 @@
                                 <cell>Tues.</cell>
                                 <cell>3</cell>
                                 <cell>
-                                    <p>Esbekieh Gardens. Performances by<lb/>British Military Band.
-                                        9 to 11 p.m.</p>
+                                    <p>Esbekieh Gardens. Performances by<lb/>British Military Band. 9 to 11 p.m.</p>
                                     <p>Esbekieh Theater. French Operetta<lb/>Company. 9.15 p.m.</p>
                                     <p>Tehatre des Nouvesutes. 9.30 p.m.</p>
                                     <p>Aloazar Parisien. 9.30 p.m.</p>
@@ -1925,15 +1354,13 @@
                                 <cell>Fri.</cell>
                                 <cell>6</cell>
                                 <cell>
-                                    <p>Esbekieh Gardens. Performances by<lb/>British Military Band.
-                                        9 to 11 p.m.</p>
+                                    <p>Esbekieh Gardens. Performances by<lb/>British Military Band. 9 to 11 p.m.</p>
                                 </cell>
                             </row>
                             <row>
                                 <cell>Mon.</cell>
                                 <cell>16</cell>
-                                <cell>Cairo Musical and Dramatic Society.<lb/>Concert in aid of
-                                    Calabrian Victims.<lb/>Distinguished Patronage.</cell>
+                                <cell>Cairo Musical and Dramatic Society.<lb/>Concert in aid of Calabrian Victims.<lb/>Distinguished Patronage.</cell>
                             </row>
                         </table>
                     </div>
@@ -1979,8 +1406,7 @@
                     </div>
                     <div type="subsection">
                         <head>REMARKS.</head>
-                        <p>The weather continues uncahnged, with the exception of an<lb/>increased
-                            degree of humidity. The barometer is fallling.</p>
+                        <p>The weather continues uncahnged, with the exception of an<lb/>increased degree of humidity. The barometer is fallling.</p>
                     </div>
                     <div type="subsection">
                         <table cols="3" xml:id="OtherStations">
@@ -2146,40 +1572,23 @@
                         </table>
                         <div type="item">
                             <head>The Planets,</head>
-                            <p>Mercury is invisible at the beginning of the month but becomes an
-                                evening star by the 15th.</p>
+                            <p>Mercury is invisible at the beginning of the month but becomes an evening star by the 15th.</p>
                             <p>Venus is a morning star.</p>
                             <p>Mars sets abou 10 p.m. throughout the month.</p>
-                            <p>Jupiter rises at 9 p.m. at the beginning of the month, and becoems
-                                into opposition at the end.</p>
-                            <p>Saturn sets at 3 a.m. at the beginning of the month and 1 a.m. at the
-                                end.</p>
-                            <p>The cheif constelations in the South at 9 p.m. are Pegasus (cheif
-                                star Merkab) near the zenith, Aquarius about <measure unit="deg"
-                                    >60</measure> and Capricornus about <measure unit="deg"
-                                    >40</measure> above the horizon.</p>
+                            <p>Jupiter rises at 9 p.m. at the beginning of the month, and becoems into opposition at the end.</p>
+                            <p>Saturn sets at 3 a.m. at the beginning of the month and 1 a.m. at the end.</p>
+                            <p>The cheif constelations in the South at 9 p.m. are Pegasus (cheif star Merkab) near the zenith, Aquarius about <measure unit="deg">60</measure> and Capricornus about <measure unit="deg">40</measure> above the horizon.</p>
                         </div>
                     </div>
                 </div>
                 <div type="item" scope="newspaper">
                     <head>THE EGYPTIAN GAZETTE.</head>
-                    <p>SUBSCRIPTIONS.—Alexandria, Cairo, and the Interior of Egypt (including
-                        delivery in Alexandria or postage to subscriber’s address) P.T. 231½ per
-                        annum, P.T. 116 for six months, P.T. 80 for three months. To other countries
-                        in the Postal Union P.T. 273 (£2.16s.) per annum. Six months P.T. 136½
-                        (£1.8s.), three months P.T. 92 (£0.19s.) N.B.—Subscriptions commence from
-                        the 1st or 16th of any month. </p>
-                    <p>ADVERTISEMENTS.—P.T. 4 per line. Minimum charge P.T. 20. Births, Marriages,
-                        or Deaths, not exceeding three lines, P.T. 20. Every additional line P.T.
-                        10. Notices in news column P.T. 20 per line. Contracts entered into for
-                        standing advertisements. </p>
-                    <p>SUBSCRIPTIONS and ADVERTISEMENTS are due in advance. P.O. Orders and Cheques
-                        to be made payable to the Editor and Manager, Rowland Snelling, Alexandria. </p>
+                    <p>SUBSCRIPTIONS.—Alexandria, Cairo, and the Interior of Egypt (including delivery in Alexandria or postage to subscriber’s address) P.T. 231½ per annum, P.T. 116 for six months, P.T. 80 for three months. To other countries in the Postal Union P.T. 273 (£2.16s.) per annum. Six months P.T. 136½ (£1.8s.), three months P.T. 92 (£0.19s.) N.B.—Subscriptions commence from the 1st or 16th of any month. </p>
+                    <p>ADVERTISEMENTS.—P.T. 4 per line. Minimum charge P.T. 20. Births, Marriages, or Deaths, not exceeding three lines, P.T. 20. Every additional line P.T. 10. Notices in news column P.T. 20 per line. Contracts entered into for standing advertisements. </p>
+                    <p>SUBSCRIPTIONS and ADVERTISEMENTS are due in advance. P.O. Orders and Cheques to be made payable to the Editor and Manager, Rowland Snelling, Alexandria. </p>
                     <p>London Offices : 36, New Broad-street. B.C. </p>
-                    <p>THE EGYPTIAN GAZETTE can be obtained in London at our office, 36, New Broad
-                        Street, E.C., and also at Messrs. May &amp; Williams 160, Piccadilly, W. </p>
-                    <p>THE “EGYPTIAN GAZETTE” IS PRINTED ON PAPER MANUFACTURED AND SUPPLIED BY THE
-                        LONDON PAPER MILLS Co., LIMITED (SALES OFFICE: 27, CANNON STREET, E.C.) </p>
+                    <p>THE EGYPTIAN GAZETTE can be obtained in London at our office, 36, New Broad Street, E.C., and also at Messrs. May &amp; Williams 160, Piccadilly, W. </p>
+                    <p>THE “EGYPTIAN GAZETTE” IS PRINTED ON PAPER MANUFACTURED AND SUPPLIED BY THE LONDON PAPER MILLS Co., LIMITED (SALES OFFICE: 27, CANNON STREET, E.C.) </p>
                 </div>
                 <div type="item" scope="newspaper">
                     <p>The Egyptian Gazette </p>
@@ -2201,9 +1610,7 @@
                 <div type="item" scope="advertisement" xml:id="deg-ad-cah01">
                     <head>CARLTON HOTEL</head>
                     <p>Bulkeley, Ramleh.</p>
-                    <p>Ten minutes from Alexandria. First-Class in every respect Very moderate
-                        charges. Bulkeley is the fashionable English quarter. Visitors fron Cairo
-                        alight at Sidi Gaber Station.</p>
+                    <p>Ten minutes from Alexandria. First-Class in every respect Very moderate charges. Bulkeley is the fashionable English quarter. Visitors fron Cairo alight at Sidi Gaber Station.</p>
                     <p>24480-24-5-905</p>
                     <p>G. AQUILINA, Proprieter.</p>
                 </div>
@@ -2215,108 +1622,72 @@
                     <head>RANTS FOR RAILWAY EXTENSION.</head>
                     <head>DEVELOPMENT OF NORTHERN RUSSIA.</head>
                     <dateline><placeName>St. Petersburg</placeName>, October 2.</dateline>
-                    <p>The budget for 1905 provies for extensive railway construction especially for
-                        the devel nt of Northern Russia and the construction of a direct line from
-                        here to Omsk, it is understood that it has also been decided to doubling the
-                        Siberian line (Reuter)</p>
+                    <p>The budget for 1905 provies for extensive railway construction especially for the devel nt of Northern Russia and the construction of a direct line from here to Omsk, it is understood that it has also been decided to doubling the Siberian line (Reuter)</p>
                 </div>
                 <div type="article" scope="international">
                     <head>IMMENSE FIRE IN JAPAN</head>
                     <head>MY STORE BUILDINGS DESTROYED</head>
                     <dateline><placeName>Tokyo</placeName> October 2.</dateline>
-                    <p>Twenty seven army store buildings have been destroyed by fire at Hiroshima
-                        The buildings are still blazing and it is believed this is the work of an
-                        incendiary. The damage is from five to ten millions of yen.</p>
+                    <p>Twenty seven army store buildings have been destroyed by fire at Hiroshima The buildings are still blazing and it is believed this is the work of an incendiary. The damage is from five to ten millions of yen.</p>
                     <byline>(Reuter)</byline>
                 </div>
                 <div type="article" scope="international">
                     <head>JAPANESE STEAMER SUNK.</head>
                     <dateline><placeName>Tokio</placeName>, October 2</dateline>
-                    <p>The Hstehho, a brand new steamer ofhcered foreigners, was sunk by a mine in
-                        the Yellow Sea on Saturday. Fifteen men were drowned.</p>
+                    <p>The Hstehho, a brand new steamer ofhcered foreigners, was sunk by a mine in the Yellow Sea on Saturday. Fifteen men were drowned.</p>
                 </div>
                 <div type="article" scope="international">
                     <head>FINANCIAL CONTROL IN MACEDONIA</head>
                     <head>FORTE RENEWS Objection</head>
-                    <p>In answer to collective note from the ambassadors, the Forte renews its
-                        objections i international nationalist control in Macedonia.</p>
+                    <p>In answer to collective note from the ambassadors, the Forte renews its objections i international nationalist control in Macedonia.</p>
                 </div>
                 <div type="article" scope="international">
                     <head>THE TUBERCULOSIS CONGRESS INAUGURATION WELL SUPPORTED</head>
                     <div type="item">
-                        <dateline><placeName><placeName ref="https://www.wikidata.org/wiki/Q90"
-                                    >Paris</placeName></placeName>, October 2</dateline>
-                        <p>President Loubet has opened a most important Congress of tuberculosis
-                            specialists. Sixty seven foreign delegations, comprising three thousand
-                            doctors and scientists, will sit</p>
+                        <dateline><placeName><placeName ref="https://www.wikidata.org/wiki/Q90">Paris</placeName></placeName>, October 2</dateline>
+                        <p>President Loubet has opened a most important Congress of tuberculosis specialists. Sixty seven foreign delegations, comprising three thousand doctors and scientists, will sit</p>
                     </div>
                     <div type="item">
-                        <dateline><placeName ref="https://www.wikidata.org/wiki/Q90"
-                                >Paris</placeName>, October 2.</dateline>
-                        <p>M Loubet has inaugurated the tuberculosis congress at which 3,500 people
-                            were present.</p>
+                        <dateline><placeName ref="https://www.wikidata.org/wiki/Q90">Paris</placeName>, October 2.</dateline>
+                        <p>M Loubet has inaugurated the tuberculosis congress at which 3,500 people were present.</p>
                     </div>
                 </div>
                 <div type="article" scope="international">
                     <head>THE AMERICAN COTTON CROP LARGE AREA RUINED BY STORMS.</head>
                     <dateline>New Orleans October 2.</dateline>
-                    <p>A terrific storm on the coast of the Gulf of Mexico has devastated the cotton
-                        crops in a large area. (Reuter)</p>
+                    <p>A terrific storm on the coast of the Gulf of Mexico has devastated the cotton crops in a large area. (Reuter)</p>
                 </div>
                 <div type="wireReport" scope="international">
                     <head>A FRENCH CRUISER BREAKS Saigon, October 2.</head>
                     <div type="item">
-                        <p>The armoured cruiser Sully has sank, her armoured deck has broken in two.
-                            ( Havas)</p>
+                        <p>The armoured cruiser Sully has sank, her armoured deck has broken in two. ( Havas)</p>
                         <dateline><placeName>Saigon</placeName>, October 2.</dateline>
                     </div>
                     <div type="item">
-                        <p>The French armoured cruiser Sully, which cost a million sterling, has
-                            broken in two. (R.)</p>
+                        <p>The French armoured cruiser Sully, which cost a million sterling, has broken in two. (R.)</p>
                     </div>
                     <div type="item">
-                        <p>The armoured cruiser Sully displaced about 10,000 tons, and her engines
-                            developed 20.000 horse power, giving her a speed of 21 knots She was
-                            built by the Forges et Chantiers do la Mediterrancee et La Seyne, being
-                            laid down in 1900 and launched on June 1 1901. She was well armoured for
-                            a cruiser, having a 6 in. belt with armoured casemates, turrets and
-                            conning tower, and carried two 7.6 in., eight 6.4 in , and six 4 in.
-                            quickfirers with twenty-four smaller guns and five 17.7 in. tubes, two
-                            armoured and one unarmoured above water, and two submerged. Her
-                            complement numbered 600 men. The Sully ran on an uncharted rock at
-                            Haiphong Bay, Tonquin, in February 1905, but it was hoped that she might
-                            be refloated with the aid of a large caisson recently completed at Hong
-                            Kong, which has evidently arrived too late. The Sully cost close on a
-                            million pounds.</p>
+                        <p>The armoured cruiser Sully displaced about 10,000 tons, and her engines developed 20.000 horse power, giving her a speed of 21 knots She was built by the Forges et Chantiers do la Mediterrancee et La Seyne, being laid down in 1900 and launched on June 1 1901. She was well armoured for a cruiser, having a 6 in. belt with armoured casemates, turrets and conning tower, and carried two 7.6 in., eight 6.4 in , and six 4 in. quickfirers with twenty-four smaller guns and five 17.7 in. tubes, two armoured and one unarmoured above water, and two submerged. Her complement numbered 600 men. The Sully ran on an uncharted rock at Haiphong Bay, Tonquin, in February 1905, but it was hoped that she might be refloated with the aid of a large caisson recently completed at Hong Kong, which has evidently arrived too late. The Sully cost close on a million pounds.</p>
                     </div>
                 </div>
                 <div type="wireReport" scope="international">
                     <head>RIOTING AT BRUNN</head>
                     <dateline><placeName>Brunn</placeName>, October 2.</dateline>
-                    <p>Two hundred persons have been injured in rioting between Germans and Czechs
-                        here.</p>
+                    <p>Two hundred persons have been injured in rioting between Germans and Czechs here.</p>
                 </div>
                 <div type="wireReport" scope="international">
-                    <head>BARON ROSEN IN <placeName ref="https://www.wikidata.org/wiki/Q90"
-                            >Paris</placeName>.</head>
-                    <dateline><placeName><placeName ref="https://www.wikidata.org/wiki/Q90"
-                                >Paris</placeName></placeName>, October 2.</dateline>
-                    <p>Baron Rosen visited M. Loubet and then attended a theatrical representation
-                        at the Opera House, where be occupied the President's box with Prince von
-                        Radolin. (Havas)</p>
+                    <head>BARON ROSEN IN <placeName ref="https://www.wikidata.org/wiki/Q90">Paris</placeName>.</head>
+                    <dateline><placeName><placeName ref="https://www.wikidata.org/wiki/Q90">Paris</placeName></placeName>, October 2.</dateline>
+                    <p>Baron Rosen visited M. Loubet and then attended a theatrical representation at the Opera House, where be occupied the President's box with Prince von Radolin. (Havas)</p>
                 </div>
                 <div type="wireReport" scope="international">
                     <head>THE HOMEWARD MAILS</head>
-                    <dateline><placeName><placeName ref="https://www.wikidata.org/wiki/Q134514"
-                                >Suez</placeName></placeName>October 2.</dateline>
-                    <p>The mails from nearly thirty ships have been rent to <placeName
-                            ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> by
-                        tog. (Reuter)</p>
+                    <dateline><placeName><placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName></placeName>October 2.</dateline>
+                    <p>The mails from nearly thirty ships have been rent to <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> by tog. (Reuter)</p>
                 </div>
                 <div type="wireReport" scope="international">
                     <head>MR MACHELL ENGAGED</head>
-                    <dateline><placeName><placeName ref="https://www.wikidata.org/wiki/Q84"
-                                >London</placeName></placeName>, October 2.</dateline>
+                    <dateline><placeName><placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName></placeName>, October 2.</dateline>
                     <p>Mr P W Macbell is engaged to Countess Vistoria Glsichen.</p>
                     <byline>(Reuter)</byline>
                 </div>
@@ -2324,77 +1695,30 @@
                     <head>LOCAL AND GENERAL</head>
                     <div type="article" scope="local">
                         <head>Esbekieh Gardens.</head>
-                        <p>We are requested to mention that the last concert of the season by the
-                            British military bands will be given on Friday the 13th instant.</p>
+                        <p>We are requested to mention that the last concert of the season by the British military bands will be given on Friday the 13th instant.</p>
                     </div>
                     <div type="article" scope="local">
                         <head>Concert at Kasr En-Nil</head>
-                        <p>An open-air vocal and instrumental concert, the last of the season, will
-                            be given this evening, commencing at 9 o'clock, at Karen-Nil
-                            barracks</p>
+                        <p>An open-air vocal and instrumental concert, the last of the season, will be given this evening, commencing at 9 o'clock, at Karen-Nil barracks</p>
                     </div>
                     <div type="article" scope="local">
-                        <p>A New Weekly under the title of "Arte e Sport", a new Italian illustrated
-                            weekly will appear in the near future The subjects treated will be those
-                            mentioned in the title.</p>
-                        <p>We hope that M G E Brandt, the editor of " Arte e Sport" will meet with
-                            the success he deserves in this new and interesting departure.</p>
+                        <p>A New Weekly under the title of "Arte e Sport", a new Italian illustrated weekly will appear in the near future The subjects treated will be those mentioned in the title.</p>
+                        <p>We hope that M G E Brandt, the editor of " Arte e Sport" will meet with the success he deserves in this new and interesting departure.</p>
                     </div>
                     <div type="article" scope="local">
-                        <p>T <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>
-                            Steamers Owing to the Post office having failed to inform that no postal
-                            van is attached to the train leaving <placeName
-                                ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> at 4
-                            25 p.m our issue of yesterday was not delivered in <placeName
-                                ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> until this
-                            morning We have, however, made arrangements by which the "Egyptian
-                            Gazette" will henceforth be delivered in <placeName
-                                ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> on the
-                            evening of the day ot issue, as hitherto.</p>
+                        <p>T <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> Steamers Owing to the Post office having failed to inform that no postal van is attached to the train leaving <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> at 4 25 p.m our issue of yesterday was not delivered in <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> until this morning We have, however, made arrangements by which the "Egyptian Gazette" will henceforth be delivered in <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> on the evening of the day ot issue, as hitherto.</p>
                     </div>
                     <div type="article" scope="local">
                         <head>The Charity Fete At Ghezireh</head>
-                        <p>The charity bazaar and fete, organised by some of the leading members of
-                            the Italian colony at the Capital in aid of the victims of the Calabrian
-                            earthquake, which took place at the Theatre des Ambassadeurs at Ghezireh
-                            on Sunday afternoon, was an unqualified success, and, considering the
-                            time of year, was largely attended by the eltie of society. It is
-                            expected that more than ₤300 will be realised from the bazar after
-                            deduction of expenses. The band of the Royal lnai-killing Fusiliers and
-                            the orchestra from the Theatre des Ninveantes played alternately during
-                            the fete which was kept up until the dinner hour.</p>
+                        <p>The charity bazaar and fete, organised by some of the leading members of the Italian colony at the Capital in aid of the victims of the Calabrian earthquake, which took place at the Theatre des Ambassadeurs at Ghezireh on Sunday afternoon, was an unqualified success, and, considering the time of year, was largely attended by the eltie of society. It is expected that more than ₤300 will be realised from the bazar after deduction of expenses. The band of the Royal lnai-killing Fusiliers and the orchestra from the Theatre des Ninveantes played alternately during the fete which was kept up until the dinner hour.</p>
                     </div>
                     <div type="article" scope="local">
                         <head>Crown Casino Iorahimieh</head>
-                        <p>The duettists, M Gaspard and Mde Neva, have, said farewell to the patrons
-                            of the music hall in connection with the Crown Brewery at Iorahimieh,
-                            after a short spell during which they were mos popular, but the
-                            management continue to provide a good programme. The debut of the
-                            musical clowns, the Prices, is billed for tonight, and Mlle Pulette
-                            d'lcles will also appear this evening for the first time at this
-                            theatre, though she is a well-known artiste both in <placeName
-                                ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> and
-                                <placeName ref="https://www.wikidata.org/wiki/Q87"
-                                >Alexandria</placeName>. Mlle Marie Fleur continues to attract and
-                            charm large audiences, and amongst others Miles Ivenne Pianette and
-                            Brunette Abdolkader, whose Arabic songs and dances delight the effendi,
-                            are conspicuous successes.</p>
+                        <p>The duettists, M Gaspard and Mde Neva, have, said farewell to the patrons of the music hall in connection with the Crown Brewery at Iorahimieh, after a short spell during which they were mos popular, but the management continue to provide a good programme. The debut of the musical clowns, the Prices, is billed for tonight, and Mlle Pulette d'lcles will also appear this evening for the first time at this theatre, though she is a well-known artiste both in <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> and <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>. Mlle Marie Fleur continues to attract and charm large audiences, and amongst others Miles Ivenne Pianette and Brunette Abdolkader, whose Arabic songs and dances delight the effendi, are conspicuous successes.</p>
                     </div>
                     <div type="article" scope="local">
                         <head>Pro Calabria.</head>
-                        <p>An exceedingly successful "soiree de famille" was held at the Mex casino
-                            on Saturday evening for the benefit of the Calabrian sufferers, and was
-                            attended by a very large number. The entertainment was varied consisting
-                            of a short play, orchestral concert, firework display, and a dance There
-                            was also a lottery, the winning numbers of which will bo found in
-                            another column. A special performance will be given this evening at the
-                            Tour Eiffel with the same object,and the programme, which will include
-                            items in French, Italian, English German, Greek, etc, should be well
-                            received by the large numbers of persons who have bought tickets of
-                            admission. The chief attraction will be provided by the three sisters
-                            d'Orsay, who sing in several languages and are excellent dancers, and
-                            the programme also includes turns by Mlles Orsini, Tina Dumonte,
-                            Valincourt, Borgui, etc., etc.</p>
+                        <p>An exceedingly successful "soiree de famille" was held at the Mex casino on Saturday evening for the benefit of the Calabrian sufferers, and was attended by a very large number. The entertainment was varied consisting of a short play, orchestral concert, firework display, and a dance There was also a lottery, the winning numbers of which will bo found in another column. A special performance will be given this evening at the Tour Eiffel with the same object,and the programme, which will include items in French, Italian, English German, Greek, etc, should be well received by the large numbers of persons who have bought tickets of admission. The chief attraction will be provided by the three sisters d'Orsay, who sing in several languages and are excellent dancers, and the programme also includes turns by Mlles Orsini, Tina Dumonte, Valincourt, Borgui, etc., etc.</p>
                     </div>
                 </div>
                 <div type="section" scope="sporting">
@@ -2460,450 +1784,169 @@
                             </row>
                         </table>
                         <p>Class I. Course C Class II. Course Q</p>
-                        <p>H. H. the Khedive having promised to visit the club, the races for cups
-                            this week will not be sailed but will be postponed until the occaision
-                            of his Highness' visit.</p>
+                        <p>H. H. the Khedive having promised to visit the club, the races for cups this week will not be sailed but will be postponed until the occaision of his Highness' visit.</p>
                     </div>
                 </div>
                 <div type="section" scope="letters">
                     <head>INTERESTING CORRESPONDENCE.</head>
                     <div type="article" scope="letters">
                         <head>THE PRINCES AND THE DAIRA.</head>
-                        <p>The claim brought by the Princess, heirs of the late Ismail Pasha,
-                            against the Egyptian Government tor the return of the surplus accuring
-                            from the sales of the Daira Sanieh properties after the satisfaction of
-                            all the creditors of the Daira Sanieh, is to be heard on the 30th
-                            inst.</p>
-                        <p>The claim of the princes interested was presented to the Khedive early in
-                            February 1905. A letter containing the terms of the demand and
-                            explaining its motives, was forwarded by Prince Ibrahim Pasha, in the
-                            name of the claimants, to Lord Cromer, and gave rise to the following
-                            correspondence, the discussion of which we leave to our readers, as the
-                            affair is sub-judice.</p>
+                        <p>The claim brought by the Princess, heirs of the late Ismail Pasha, against the Egyptian Government tor the return of the surplus accuring from the sales of the Daira Sanieh properties after the satisfaction of all the creditors of the Daira Sanieh, is to be heard on the 30th inst.</p>
+                        <p>The claim of the princes interested was presented to the Khedive early in February 1905. A letter containing the terms of the demand and explaining its motives, was forwarded by Prince Ibrahim Pasha, in the name of the claimants, to Lord Cromer, and gave rise to the following correspondence, the discussion of which we leave to our readers, as the affair is sub-judice.</p>
+                        <!--
                         <quotedLetter>
                             <opener>
                                 <head>The British Agency.</head>
-                                <dateline><placeName ref="https://www.wikidata.org/wiki/Q85"
-                                        >Cairo</placeName> , March 1, 1905.</dateline>
+                                <dateline><placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> , March 1, 1905.</dateline>
                                 <salute>Your Highness,</salute>
                             </opener>
-                            <p>I have the honor to inform you that the Legal Adviser of the Egyptian
-                                Government has given his opinion on the question raised in the note
-                                appended to the letter dated January 29, which your Highness was
-                                good enongh to forward me. After a detailed examination of the
-                                question at issue, the Legal Adviser concludes his summary in the
-                                following terms. "The demand of the heirs of Ismail Pasha has no
-                                chance of being entertained by the tribunals."</p>
-                            <p>It is clear that in virtue of article 40 of the Law of Liquidation
-                                the full entire right over the properties in question are vested in
-                                the State. While I support the view expressed by the Legal Adviser
-                                to the Government, I should like to draw the attention of your
-                                Highness to the opinion I expressed on this subject as a member of
-                                the Commission of Inquiry.</p>
-                            <p>"The domains of the Dairas have been acquired at the expense and to
-                                the detriment of the country. It is therefore only just then the
-                                Khedive should restore a property which has been illegally
-                                acquired."</p>
-                            <p>I am of the same opinion to day. Sir Charles Rivers Wilson, President
-                                of the Commission, also emphasised the fact that the property of the
-                                Dairas had been acquired with the funds of the State Under these
-                                circumstances I regret not only that I cannot support the claim made
-                                by certain members of the Khedivial family hot that, in the highly
-                                improbable case of the Egyptian Government favoring this claim, I
-                                would be obliged to formally oppose it in the interests of the
-                                people and taxpayers of <placeName
-                                    ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName>.</p>
+                            <p>I have the honor to inform you that the Legal Adviser of the Egyptian Government has given his opinion on the question raised in the note appended to the letter dated January 29, which your Highness was good enongh to forward me. After a detailed examination of the question at issue, the Legal Adviser concludes his summary in the following terms. "The demand of the heirs of Ismail Pasha has no chance of being entertained by the tribunals."</p>
+                            <p>It is clear that in virtue of article 40 of the Law of Liquidation the full entire right over the properties in question are vested in the State. While I support the view expressed by the Legal Adviser to the Government, I should like to draw the attention of your Highness to the opinion I expressed on this subject as a member of the Commission of Inquiry.</p>
+                            <p>"The domains of the Dairas have been acquired at the expense and to the detriment of the country. It is therefore only just then the Khedive should restore a property which has been illegally acquired."</p>
+                            <p>I am of the same opinion to day. Sir Charles Rivers Wilson, President of the Commission, also emphasised the fact that the property of the Dairas had been acquired with the funds of the State Under these circumstances I regret not only that I cannot support the claim made by certain members of the Khedivial family hot that, in the highly improbable case of the Egyptian Government favoring this claim, I would be obliged to formally oppose it in the interests of the people and taxpayers of <placeName ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName>.</p>
                             <closer>
                                 <Signed>(Signed) Cromer.</Signed>
                                 <p>To. H H Prince Ibrahim Pasha.</p>
                             </closer>
                         </quotedLetter>
+                        -->
                         <p>To this letter the Prince replied as follows.</p>
+                        <!--
                         <quotedLetter>
                             <opener>
-                                <dateline><placeName ref="https://www.wikidata.org/wiki/Q85"
-                                        >Cairo</placeName> , March 20, 1905.</dateline>
+                                <dateline><placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> , March 20, 1905.</dateline>
                                 <salute>My Lord.</salute>
                             </opener>
-                            <p>I have the honor to acknowledge the receipt of the letter addressed
-                                to me by your Lordship under date of the 1st inst which I have
-                                communicated to the Princes, my brothers. We cannot but regret the
-                                opinion expressed by the Legal Adviser and especially the
-                                declaration that your Lordship has decided, in the interests of the
-                                Egyptian people, to oppose any favorable reception to our demand
-                                that the Government may make. We are reserving our reply to the
-                                government until we receive the reasons adduced by its legal
-                                advisers in support of their contention."</p>
+                            <p>I have the honor to acknowledge the receipt of the letter addressed to me by your Lordship under date of the 1st inst which I have communicated to the Princes, my brothers. We cannot but regret the opinion expressed by the Legal Adviser and especially the declaration that your Lordship has decided, in the interests of the Egyptian people, to oppose any favorable reception to our demand that the Government may make. We are reserving our reply to the government until we receive the reasons adduced by its legal advisers in support of their contention."</p>
                         </quotedLetter>
-                        <p>Prince Ibrahim continues by protesting against Lord Cromer’s view that
-                            the Daira properties wore obtained at the expense and to the detriment
-                            of the country. The properties of the Khedivial house of Mohamed Ali
-                            were acquired by right of conquest and with the consent of the Sultan
-                            from whom the Pasha of <placeName
-                                ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName> derived
-                            his powers. The Seigneurial rights over landed property in Europe had
-                            the same origin. In fact Henry VIII. in England and Cromwell in Ireland
-                            had established domains founded on the same right, viz., conquest and
-                            the consent of the supreme power, and the present possessors of these
-                            domains are not likely to find their titles called in question. The late
-                            Ismail Pasha, who was in possesion of many of the Daira properties by
-                            hereditary right before he became Viceroy of <placeName
-                                ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName>, did much
-                            to improve and benefit these properties, and the expression “illegally
-                            acquired" would never have been employed had the Commision of Enquiry
-                            been able to study the facts. "England in the past prevented Daniel
-                            O’Connell from proclaiming that the owners of large Irish estates were
-                            in possession of properties illegally acquired. Of yon, my Lord, who
-                            personify in <placeName ref="https://www.wikidata.org/wiki/Q79"
-                                >Egypt</placeName> the public opinion of the freest country in the
-                            world, we only ask for an explanation of a statement, revived after
-                            twenty five years’ silence, and based upon incomplete information."
-                            Prince Ibrahim farther states that the fact that an original right is
-                            based on conquest is no bar to its enjoyment bv the heirs of the first
-                            occupant under such a right—in this particular case the late Khedive
-                            Ismail. Farther if hie estates had been taken by force and illegally
-                            from the Egyptian people, the Government would not have disposed of them
-                            to any but the persons dispossessed or their heirs. The fact that it has
-                            disposed of them to others seems to show that it does not consider these
-                            Daira estates to have been illegally acquired.</p>
-                        <p>To this letter Lord Cromer replied as follows under the date of March
-                            25.</p>
+                        -->
+                        <p>Prince Ibrahim continues by protesting against Lord Cromer’s view that the Daira properties wore obtained at the expense and to the detriment of the country. The properties of the Khedivial house of Mohamed Ali were acquired by right of conquest and with the consent of the Sultan from whom the Pasha of <placeName ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName> derived his powers. The Seigneurial rights over landed property in Europe had the same origin. In fact Henry VIII. in England and Cromwell in Ireland had established domains founded on the same right, viz., conquest and the consent of the supreme power, and the present possessors of these domains are not likely to find their titles called in question. The late Ismail Pasha, who was in possesion of many of the Daira properties by hereditary right before he became Viceroy of <placeName ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName>, did much to improve and benefit these properties,
+                            and the expression “illegally acquired" would never have been employed had the Commision of Enquiry been able to study the facts. "England in the past prevented Daniel O’Connell from proclaiming that the owners of large Irish estates were in possession of properties illegally acquired. Of yon, my Lord, who personify in <placeName ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName> the public opinion of the freest country in the world, we only ask for an explanation of a statement, revived after twenty five years’ silence, and based upon incomplete information." Prince Ibrahim farther states that the fact that an original right is based on conquest is no bar to its enjoyment bv the heirs of the first occupant under such a right—in this particular case the late Khedive Ismail. Farther if hie estates had been taken by force and illegally from the Egyptian people, the Government would not have disposed of them to any but the persons dispossessed or their
+                            heirs. The fact that it has disposed of them to others seems to show that it does not consider these Daira estates to have been illegally acquired.</p>
+                        <p>To this letter Lord Cromer replied as follows under the date of March 25.</p>
+                        <!--
                         <quotedLetter>
                             <opener>
                                 <salute>Your Highness,</salute>
                             </opener>
-                            <p>I beg to acknowledge the receipt of the letter which your Highness
-                                was kind enough to address to me under date of the 23rd inst. Since
-                                I see no possibility of altering the opinion I expressed in my
-                                letter of the 1st inst., or of modifying the terms in which I
-                                expressed my opinion, I hope your Highness will recognise with me
-                                that farther correspondence on this subject is of no use. I
-                                therefore beg your Highness to be good enough to excuse me for
-                                refraining to discuss the points raised in your letter. If your
-                                Highness, in agreement with the other Princess of the Khedivial
-                                family, wishes to pursue your claim on the Daira properties, you can
-                                at any time have recourse to the Tribunals, which will decide
-                                whether the claim is or is not well founded, etc., etc.</p>
+                            <p>I beg to acknowledge the receipt of the letter which your Highness was kind enough to address to me under date of the 23rd inst. Since I see no possibility of altering the opinion I expressed in my letter of the 1st inst., or of modifying the terms in which I expressed my opinion, I hope your Highness will recognise with me that farther correspondence on this subject is of no use. I therefore beg your Highness to be good enough to excuse me for refraining to discuss the points raised in your letter. If your Highness, in agreement with the other Princess of the Khedivial family, wishes to pursue your claim on the Daira properties, you can at any time have recourse to the Tribunals, which will decide whether the claim is or is not well founded, etc., etc.</p>
                             <closer>
                                 <signed>(Signed) Cromer.</signed>
                             </closer>
                         </quotedLetter>
+                        -->
                     </div>
                     <div type="article" scope="letters">
-                        <head>ARCHEOLOGY IN <placeName ref="https://www.wikidata.org/wiki/Q43"
-                                >Turkey</placeName>.</head>
+                        <head>ARCHEOLOGY IN <placeName ref="https://www.wikidata.org/wiki/Q43">Turkey</placeName>.</head>
                         <head>A SHORT REVIEW</head>
                         <p>(From a Constantinople Correspondent).</p>
-                        <p>No other country in the world has been so richly endowed with
-                            archaeological remains as <placeName
-                                ref="https://www.wikidata.org/wiki/Q43">Turkey</placeName>. Nowhere
-                            are ancient monuments and relics so varied, in point of style and epoch,
-                            as those hidden beneath the soil of the Otto man Empire, and more
-                            particularly in its Asiatic dominions. Assyria, <placeName
-                                ref="https://www.wikidata.org/wiki/Q41">Greece</placeName>, Rome,
-                            each in turn have bequeathed to their successor treasures which but
-                            await the antiquarian’s spade in order to be properly estimated and
-                            which, valued according to their commercial worth, would, such is the
-                            irony of fate, replenish the proverbially empty coffers of State. But it
-                            has required the introduction of European civilisation to gradually
-                            awaken the Turks to this fact. Not so many years ago archaeological
-                            research was carried on under very restricted if not vexations
-                            conditions, arising out of the rooted dislike of the Turkish official to
-                            foreigners tampering with his sacred soil; he could not understand the
-                            object in digging among ruins which, unless they contained a certain
-                            amount of marble for building purposes were no better than a dung-hill,
-                            a place for owls and bats. But it is no less true that he objected, and
-                            very rightly, to numerous cases of wholesale depredation committed by a
-                            certain sect of the archaeological world who had been brought up in Lord
-                            Elgin's school. Those days are past alike for official objection and
-                            brigand depredation. The status of the archaeologist has been legalised,
-                            and the proper authorities have been appointed to attend to this
-                            department of the State. Pan Athenaic Freizess can no longer be smuggled
-                            out of the country, and the value of archaeology having been
-                            appreciated, the efforts of the provincial authorities are now devoted
-                            to a more perfect mode of preservation than that afforded to antiquities
-                            by a superstratum of earth.</p>
-                        <p>The subject title “Archaeology in <placeName
-                                ref="https://www.wikidata.org/wiki/Q43">Turkey</placeName>" ebraces
-                            too wide a field for general survey, and it will be necessary,
-                            therefore, to deal separately with each district in which explorations
-                            are now in progress. Before so doing, however, it may be well to devote
-                            some attention to an institution which, in the Capital of the Empire, is
-                            directly interested in all that appertains to archaeological research on
-                            either side of the Bosphorus. Moreover, the happy era which bas dawned,
-                            or more correctly speaking the official recognition of archaeology,
-                            dates from the foundation of Tochinili kiosk, or the Stamboul museum, in
-                            1875. The collection preserved in this museum may well rank with that of
-                            any other European capital and the continual addition of
-                            newly-discovered antiquities, amongst others those of the Temple of
-                            Diana at Ephesus, mentioned in the "Times," have increased in like
-                            measure its value. The grounds on which the kiosk and the other
-                            buildings of the museum stand, on the summit of the Acropolis of St.
-                            Demetrius, or Serai Bournou, are, both historically and for pucturesque
-                            scenery, unique in Constantinople.</p>
-                        <p>Half-hidden in groves of cypress and plane the museum stands between the
-                            quaint old Mint and the Church of St Irene whose now silent belfry
-                            crowns the whole scene. It is an enchanting spot, the natural theatre of
-                            many an incident in political and church history, as the strange
-                            appearance of a Christian be fry amidst so much of oriental scenery is
-                            enough to show. The battlefield of Brands, who lost the day on yon
-                            velvet sward, the promenade of the Greek Emperors, these and countless
-                            other scenes of its ancient history crowd the memory as the vision
-                            lingers lovingly on the sacred soil. A worthy shrine for the monuments
-                            of ancient art which are associated with the past.</p>
-                        <p>It was in. 1850 that the nucleus of the present collection was formed by
-                            Fethi Ahmed Pasha, Grand Master of Artillery, within the hall of the
-                            ancient church of St. Irene already named, which, from being being the
-                            chapel royal of Byzantium, has been degraded into an armoury called the
-                            Jeb Heneh. This hall, however, proved inadequate for the continual
-                            additions which now began to be made from the collector from all parts
-                            of the country,and,in 1875 daring the ministry of Subhi Pasha, Minister
-                            of Publio Instruction, and a numismatist of note, an Imperial irade was
-                            promulgated authorising its transfer to Tchinili kiosk. After the
-                            discovery in 1887-1888, by the museum, of twenty one sarcophagi at Saida
-                            (ancient Sidon), of which several may be said to be of the best Greek
-                            sculputre, Tchinili kiosk also became in tarn too small for the
-                            collection, and in virtue of another irade, a new building was erected,
-                            purposely to receive these tombs, opposite Tchinili kiosk.</p>
-                        <p>The new museum was opened in 1892, since when such a number of additions
-                            have been made to it that two wings have had to be erected it.</p>
-                        <p>The character of nearly all the relics preserved in the new musem is
-                            funeral, it having been the intention of Hamdi Bey to give it that
-                            distinctive character.</p>
-                        <p>Entrance to the museum grounds is through one of the lower gates of the
-                            old Seraglio, the tram line from Karakeui bridge landing the visitor at
-                            the threshold. From here a gravel path, lined with antique monuments and
-                            statues wind amid the cypresses as far Tchinili kiosk.</p>
-                        <p>The kiosk was built by Sultan Fatih Mah- opposite it is the new museum,
-                            much larger, and now being added to by a building of about the same
-                            size, which, among other recent arrivals is to receive the antiquities
-                            discovered at Ephesus in the excavation of the seventh temple of
-                            Artemis. Forming the and of the enclosure is a wing containing more
-                            rooms filled with sarcophagi, the offices of the museum, and a library
-                            of 15,000 volumes bequeathed by the late Djevad Pasha, and of these
-                            works 8,000 an Oriental.</p>
+                        <p>No other country in the world has been so richly endowed with archaeological remains as <placeName ref="https://www.wikidata.org/wiki/Q43">Turkey</placeName>. Nowhere are ancient monuments and relics so varied, in point of style and epoch, as those hidden beneath the soil of the Otto man Empire, and more particularly in its Asiatic dominions. Assyria, <placeName ref="https://www.wikidata.org/wiki/Q41">Greece</placeName>, Rome, each in turn have bequeathed to their successor treasures which but await the antiquarian’s spade in order to be properly estimated and which, valued according to their commercial worth, would, such is the irony of fate, replenish the proverbially empty coffers of State. But it has required the introduction of European civilisation to gradually awaken the Turks to this fact. Not so many years ago archaeological research was carried on under very restricted if not vexations conditions, arising out of the rooted dislike of the Turkish
+                            official to foreigners tampering with his sacred soil; he could not understand the object in digging among ruins which, unless they contained a certain amount of marble for building purposes were no better than a dung-hill, a place for owls and bats. But it is no less true that he objected, and very rightly, to numerous cases of wholesale depredation committed by a certain sect of the archaeological world who had been brought up in Lord Elgin's school. Those days are past alike for official objection and brigand depredation. The status of the archaeologist has been legalised, and the proper authorities have been appointed to attend to this department of the State. Pan Athenaic Freizess can no longer be smuggled out of the country, and the value of archaeology having been appreciated, the efforts of the provincial authorities are now devoted to a more perfect mode of preservation than that afforded to antiquities by a superstratum of earth.</p>
+                        <p>The subject title “Archaeology in <placeName ref="https://www.wikidata.org/wiki/Q43">Turkey</placeName>" ebraces too wide a field for general survey, and it will be necessary, therefore, to deal separately with each district in which explorations are now in progress. Before so doing, however, it may be well to devote some attention to an institution which, in the Capital of the Empire, is directly interested in all that appertains to archaeological research on either side of the Bosphorus. Moreover, the happy era which bas dawned, or more correctly speaking the official recognition of archaeology, dates from the foundation of Tochinili kiosk, or the Stamboul museum, in 1875. The collection preserved in this museum may well rank with that of any other European capital and the continual addition of newly-discovered antiquities, amongst others those of the Temple of Diana at Ephesus, mentioned in the "Times," have increased in like measure its value. The grounds
+                            on which the kiosk and the other buildings of the museum stand, on the summit of the Acropolis of St. Demetrius, or Serai Bournou, are, both historically and for pucturesque scenery, unique in Constantinople.</p>
+                        <p>Half-hidden in groves of cypress and plane the museum stands between the quaint old Mint and the Church of St Irene whose now silent belfry crowns the whole scene. It is an enchanting spot, the natural theatre of many an incident in political and church history, as the strange appearance of a Christian be fry amidst so much of oriental scenery is enough to show. The battlefield of Brands, who lost the day on yon velvet sward, the promenade of the Greek Emperors, these and countless other scenes of its ancient history crowd the memory as the vision lingers lovingly on the sacred soil. A worthy shrine for the monuments of ancient art which are associated with the past.</p>
+                        <p>It was in. 1850 that the nucleus of the present collection was formed by Fethi Ahmed Pasha, Grand Master of Artillery, within the hall of the ancient church of St. Irene already named, which, from being being the chapel royal of Byzantium, has been degraded into an armoury called the Jeb Heneh. This hall, however, proved inadequate for the continual additions which now began to be made from the collector from all parts of the country,and,in 1875 daring the ministry of Subhi Pasha, Minister of Publio Instruction, and a numismatist of note, an Imperial irade was promulgated authorising its transfer to Tchinili kiosk. After the discovery in 1887-1888, by the museum, of twenty one sarcophagi at Saida (ancient Sidon), of which several may be said to be of the best Greek sculputre, Tchinili kiosk also became in tarn too small for the collection, and in virtue of another irade, a new building was erected, purposely to receive these tombs, opposite Tchinili
+                            kiosk.</p>
+                        <p>The new museum was opened in 1892, since when such a number of additions have been made to it that two wings have had to be erected it.</p>
+                        <p>The character of nearly all the relics preserved in the new musem is funeral, it having been the intention of Hamdi Bey to give it that distinctive character.</p>
+                        <p>Entrance to the museum grounds is through one of the lower gates of the old Seraglio, the tram line from Karakeui bridge landing the visitor at the threshold. From here a gravel path, lined with antique monuments and statues wind amid the cypresses as far Tchinili kiosk.</p>
+                        <p>The kiosk was built by Sultan Fatih Mah- opposite it is the new museum, much larger, and now being added to by a building of about the same size, which, among other recent arrivals is to receive the antiquities discovered at Ephesus in the excavation of the seventh temple of Artemis. Forming the and of the enclosure is a wing containing more rooms filled with sarcophagi, the offices of the museum, and a library of 15,000 volumes bequeathed by the late Djevad Pasha, and of these works 8,000 an Oriental.</p>
                         <p>(To be continued.)</p>
                     </div>
                     <div type="article" scope="letters">
                         <head>MR. MACHELL'S ENGAGEMENT.</head>
                         <head>HIS FUTURE BRIDE</head>
-                        <p>The Countess • Victoria Glpichen, whose engagement to Mr. P. W. Machell
-                            has just been announced, is the daughter of H.S.H the late Prince Victor
-                            of Hohenlohe Langenbnrg and H.S.H. Princess Victor of Hohenlohe, nee
-                            Lady Laura Seymour, and is the niece of H. M. the late Queen Victoria.
-                            Her brother, Count Ghleichen, C.M.G. was recently director of
-                            Intelligence and Sudan agent to the Egyptian Army and is now military
-                            attache at Berlin.</p>
-                        <p>Mr. P. W. Machell. Adviser to the Ministry of the Interior, has shunned
-                            all notice in the columns of the Press, not to mention "Who’s Who,”
-                            (both the British and the Anglo-African editions) with such success that
-                            we would feel a certain diffidence mentioning him, were it not for the
-                            fact, that <placeName ref="https://www.wikidata.org/wiki/Q79"
-                                >Egypt</placeName> owes him so much for the destruction of various
-                            pests, from the overthrow of the raiders at Khor Musa in 1888 to the leu
-                            dramatic but equally serious campaign against the cotton worm in 1905
-                            Mr. Machell has a few critics, no enemies, and innumerable friends, and
-                            on our own behalf and for our readers we congratulate him most
-                            heartily.</p>
+                        <p>The Countess • Victoria Glpichen, whose engagement to Mr. P. W. Machell has just been announced, is the daughter of H.S.H the late Prince Victor of Hohenlohe Langenbnrg and H.S.H. Princess Victor of Hohenlohe, nee Lady Laura Seymour, and is the niece of H. M. the late Queen Victoria. Her brother, Count Ghleichen, C.M.G. was recently director of Intelligence and Sudan agent to the Egyptian Army and is now military attache at Berlin.</p>
+                        <p>Mr. P. W. Machell. Adviser to the Ministry of the Interior, has shunned all notice in the columns of the Press, not to mention "Who’s Who,” (both the British and the Anglo-African editions) with such success that we would feel a certain diffidence mentioning him, were it not for the fact, that <placeName ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName> owes him so much for the destruction of various pests, from the overthrow of the raiders at Khor Musa in 1888 to the leu dramatic but equally serious campaign against the cotton worm in 1905 Mr. Machell has a few critics, no enemies, and innumerable friends, and on our own behalf and for our readers we congratulate him most heartily.</p>
                     </div>
                     <div type="article" scope="letters">
-                        <head>EASTERN EXCHANGE, <placeName
-                                ref="https://www.wikidata.org/wiki/Q134509">Port
-                            Said</placeName>.</head>
-                        <p>On a recent visit to this well-known and deservedly popular hotel, we
-                            were informed by the courteous manager, M. A. de Carli, that extensive
-                            alterations were in contemplation, which would, when effected, greatly
-                            add to the comfort and convenience of visitors to the hotel. The details
-                            of these would not be settled until the arrival of the proprietor, who
-                            is expected at an early date ; but we understand that the alterations
-                            may include the building of a wide and convenient staircase to the more
-                            frequented floors of the building, for the use of those who prefer not
-                            to ascend by the lift, and that it is intended to provide an elegant
-                            sitting room on the first floor. A garden has recently been laid out ie
-                            connection with the bar, and altogether this well-known visitors’ resort
-                            shows itself in every way desirous of keeping abreast—if not in
-                            advance—of the times. The great height of the buliding should alone form
-                            an attraction to those fond of fresh air and fine views, the wide
-                            verandahs ran, which entirely round the different floors, enabling the
-                            occupants of the various rooms to select the most convenient and
-                            sheltered spots in which to enjoy the land or seascape from any point of
-                            the compass.</p>
+                        <head>EASTERN EXCHANGE, <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>.</head>
+                        <p>On a recent visit to this well-known and deservedly popular hotel, we were informed by the courteous manager, M. A. de Carli, that extensive alterations were in contemplation, which would, when effected, greatly add to the comfort and convenience of visitors to the hotel. The details of these would not be settled until the arrival of the proprietor, who is expected at an early date ; but we understand that the alterations may include the building of a wide and convenient staircase to the more frequented floors of the building, for the use of those who prefer not to ascend by the lift, and that it is intended to provide an elegant sitting room on the first floor. A garden has recently been laid out ie connection with the bar, and altogether this well-known visitors’ resort shows itself in every way desirous of keeping abreast—if not in advance—of the times. The great height of the buliding should alone form an attraction to those fond of fresh air and fine
+                            views, the wide verandahs ran, which entirely round the different floors, enabling the occupants of the various rooms to select the most convenient and sheltered spots in which to enjoy the land or seascape from any point of the compass.</p>
                     </div>
                 </div>
                 <div type="section" scope="maritime">
                     <head>STEAMER MOVEMENTS.</head>
-                    <p>The S.S. Trojan Prince left Manchester on Sunday with passengers and general
-                        cargo, and is due to arrive at <placeName
-                            ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>n, via
-                        Tunis and <placeName ref="https://www.wikidata.org/wiki/Q233"
-                            >Malta</placeName>, on or about October 16.</p>
+                    <p>The S.S. Trojan Prince left Manchester on Sunday with passengers and general cargo, and is due to arrive at <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>n, via Tunis and <placeName ref="https://www.wikidata.org/wiki/Q233">Malta</placeName>, on or about October 16.</p>
                 </div>
                 <div type="section" scope="social">
                     <head>PERSONAL AND SOCIAL</head>
                     <div type="article" scope="social">
-                        <p>Rumours are current that Khalil Pasha Hamdi Hamsda, local director of
-                            Customs, will shortly replace Skander Pasha Fehmi on the Railway Board,
-                            on the retirement of that official on pension.</p>
+                        <p>Rumours are current that Khalil Pasha Hamdi Hamsda, local director of Customs, will shortly replace Skander Pasha Fehmi on the Railway Board, on the retirement of that official on pension.</p>
                     </div>
                     <div type="article" scope="social">
-                        <p>Mr. James Hewat, American Consol, at <placeName
-                                ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>,
-                            arrived this morning by the Messageries Maritime mail boat,</p>
+                        <p>Mr. James Hewat, American Consol, at <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>, arrived this morning by the Messageries Maritime mail boat,</p>
                     </div>
                     <div type="article" scope="social">
-                        <p>A <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>
-                            contemporary announces that Sir Horace Pincing and Dr. Bitter have been
-                            delegated to represent <placeName
-                                ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName> at the
-                            Tuberculosis Congress, which was inaugurated at <placeName
-                                ref="https://www.wikidata.org/wiki/Q90">Paris</placeName>
-                            yesterday.</p>
+                        <p>A <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> contemporary announces that Sir Horace Pincing and Dr. Bitter have been delegated to represent <placeName ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName> at the Tuberculosis Congress, which was inaugurated at <placeName ref="https://www.wikidata.org/wiki/Q90">Paris</placeName> yesterday.</p>
                     </div>
                     <div type="article" scope="social">
-                        <p>Among the latest arrivals at the Windsor Hotel, <placeName
-                                ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>, we
-                            notice Mr. and Mrs. E. Parser, Mr. and Mrs. Hague, Mr. Hodar, M. Mr.
-                            Mrs. Page, Dr Granville, Mrs. Natchigal, M. Dossa,Mr. &amp; Mrs. Holser,
-                            Dr Faber,Dr.Beyd Carpenter, Dr. Goldslich, Mr. and Mrs. Antounepoulo, Dr
-                            O. J. van Millingen, Mr. Hioka, Mrs. Corbett, Mr. Fishcer, Mr. Pox, Mr.
-                            Cokerson, Mr. Kockouk, Mr. Maule, Mr. and Mrs. Agiry, Mr. Bolojian, Mr.
-                            Forte, Mr. Raouff, Mr. Angliker, Mr. Sebton. Mr. Rossi, Mr. Bid, Dr.
-                            Morogh, Mr. Barnetti, Mrs. Zananiri, Mr. Mr. Cavolo, Mr. Aeroul, Mr.
-                            Osborne, Shepherd; Mr. Cuming, Mr. Wilson, Lt G. Grylls, Mr. Rosano, Mr.
-                            Camel, Mr. Jones, Mr. Joseph, Mr. and Mrs. Mariatopoulo, Mr. and Mrs.
-                            Justiniany, Mr. Moss, Mr. Long, Mr. Bond, Mr. Craig.</p>
+                        <p>Among the latest arrivals at the Windsor Hotel, <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>, we notice Mr. and Mrs. E. Parser, Mr. and Mrs. Hague, Mr. Hodar, M. Mr. Mrs. Page, Dr Granville, Mrs. Natchigal, M. Dossa,Mr. &amp; Mrs. Holser, Dr Faber,Dr.Beyd Carpenter, Dr. Goldslich, Mr. and Mrs. Antounepoulo, Dr O. J. van Millingen, Mr. Hioka, Mrs. Corbett, Mr. Fishcer, Mr. Pox, Mr. Cokerson, Mr. Kockouk, Mr. Maule, Mr. and Mrs. Agiry, Mr. Bolojian, Mr. Forte, Mr. Raouff, Mr. Angliker, Mr. Sebton. Mr. Rossi, Mr. Bid, Dr. Morogh, Mr. Barnetti, Mrs. Zananiri, Mr. Mr. Cavolo, Mr. Aeroul, Mr. Osborne, Shepherd; Mr. Cuming, Mr. Wilson, Lt G. Grylls, Mr. Rosano, Mr. Camel, Mr. Jones, Mr. Joseph, Mr. and Mrs. Mariatopoulo, Mr. and Mrs. Justiniany, Mr. Moss, Mr. Long, Mr. Bond, Mr. Craig.</p>
                     </div>
                     <div type="article" scope="social">
-                        <p>Among the latest arrivals at the Beau-Rivage Hotel, Ramleh, we notice :
-                            H. E. Abbate Pasha, Mr. and Mrs. T. H. Davey, Dr. and Mre. Kautsky and
-                            family, Mr. G. Metral, Mr. and Mrs. Davacos, Mrs. M. Young, Mr. H.
-                            Colie.</p>
+                        <p>Among the latest arrivals at the Beau-Rivage Hotel, Ramleh, we notice : H. E. Abbate Pasha, Mr. and Mrs. T. H. Davey, Dr. and Mre. Kautsky and family, Mr. G. Metral, Mr. and Mrs. Davacos, Mrs. M. Young, Mr. H. Colie.</p>
                     </div>
                     <div type="section" scope="advertisement">
-                        <div type="item" scope="advertisement"><!-- TODO Replace with Ad boilerplate -->
+                        <div type="item" scope="advertisement">
+                            <!-- TODO Replace with Ad boilerplate -->
                             <head>RECK &amp; CO’S PILSNER BEER BREMEN.</head>
                             <head>FEARS NO HONEST COMPETITION FOR QUALITY.</head>
-                            <p>B.—Inferior Brands now being offered to Manager of certain good
-                                    <unclear></unclear>.</p>
+                            <p>B.—Inferior Brands now being offered to Manager of certain good <unclear/>.</p>
                             <p>Beware of evilly disposed competitors running</p>
                         </div>
                         <div type="item" scope="advertisement" xml:id="deg-ad-aan02">
                             <p>Anglo-American Nile Steamer &amp; Hotel Company </p>
-                            <p>River Transport of Good Between <placeName
-                                    ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>
-                                &amp; <placeName ref="https://www.wikidata.org/wiki/Q85"
-                                    >Cairo</placeName>
+                            <p>River Transport of Good Between <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> &amp; <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>
                             </p>
                             <p>Three Sailings a-Week.</p>
-                            <p>Agents at <placeName ref="https://www.wikidata.org/wiki/Q87"
-                                    >Alexandria</placeName>:</p>
-                            <p><placeName ref="https://www.wikidata.org/wiki/Q87"
-                                    >Alexandria</placeName> Bonded Warehouse Co. Ld</p>
+                            <p>Agents at <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>:</p>
+                            <p><placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> Bonded Warehouse Co. Ld</p>
                             <p>1.10.904</p>
                         </div>
                     </div>
                     <div type="article" scope="maritime">
-                        <head><placeName ref="https://www.wikidata.org/wiki/Q87"
-                                >Alexandria</placeName> Border Warehouse</head>
+                        <head><placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> Border Warehouse</head>
                         <head type="sub">Passenger List.</head>
                         <div type="subsection">
                             <head>ARRIVALS.</head>
                             <!-- TODO Create a proper table representation -->
-                            <p>Le paqubot El Kabira de la Khedivial arrive hier de Constantinople
-                                Dardanelles Matelin, Smyrne et Piree avail a bord;</p>
-                            <p>M. et Mme S. Riveili, Dr. Franimer et famille, Mmes Stavroulakis,
-                                Yoannor, Cokiai, Wakefield, Mmes Maizes, Axelos Cartaliek et
-                                famillie, M. M. Pantos, Calvocoronci, Drs, Guilles et Defrigy,
-                                Amiradaki, Galanos, C. Risadimios Ap. Apostolidi, Franghiadia A.
-                                Perez, J. Yoannidi, Jean Andrioopoulos, M. et Mme Raifsis et
-                                famille, M. et Mme Gragorina, M. et Mme D. Harpaki et famille, M. et
-                                Mme Georgiadis et famillie, M. et Mme Pandasogaulo</p>
-                            <p>M. et Mme Haliadia, Dr. et Mme Gastanos, Mme Volters et famille, C.
-                                Exydakis, N. Caloutas, S. Sperer P. Levtaris Christo Stamopaolo, G.
-                                Constantinidi. Mme V.ve Bohphidis et famille, M. et Mme N. Papas et
-                                famille, Mmes, Polychromidi et famille, Mme S. Macri, Gouvernante
-                                Maitre Limgitia, N. Voiclis, G. Carapatis. N. Podaridi, M. et
-                                Mme</p>
-                            <p>N. Mavros, C. Maliarakis, G. Atassogin, A. Coatzoukis, E. Sakalarios,
-                                C. Zapellia. Ibrakimet Hnem et fille, Selmeh et Zekieh Hapem famille
-                                S. E. Mohamet Bey Izast J. Vistsi, Attie Hanem, Rew et Mme W. B.
-                                Godbay et famille S. El Tarabaki, ainsi que 312 passagers de
-                                pont.</p>
-                            <p>Le paquebot, italian Vincenzo, Floria de la Cie Florie Rubattino
-                                arrive hier da Genesavait a bord :</p>
-                            <p>M. et Mme Larrat. Pilotta, Lazzary, R, Savie. V. Oliva et comp., Hag
-                                el Fendoli, J, Bramby Cajo, J. Chihib, Eug Graglia, J. Moine, M
-                                et</p>
-                            <p>Mme Amos, Moh Bey Twefik, Gigaldini, Da Cameripi, Sabbag, Andreolis,
-                                Giranda, Reed et fam., Rev. Borgo, S. Lavi, prof. Mariani, M. et Mme
-                                R. Rocalie, prof. Farah et comp., prof. Pollardi, prof. Rispoli,
-                                Nafal, Livige O. Diacone T. Hemwood, Cap. Art. Levi, M. at Mme Les,
-                                A. Mustard, Aloi et fam., Colloridi et fils, M. et Mme G. Porto, A.
-                                Riboni, R. Link, J. Jean, L. Parid et 70 passagers de 3e classe.</p>
-                            <p>La paqubot Prince Abbas de la Khedivial arrive ce matin da
-                                Constatinople, Dardanelles, Metelin, Smyrne et Rhotes avait a bord
-                                :</p>
-                            <p>Djafer bey Fakhry, Selim bey Faoud et famille, Hassan bey Husni et
-                                famille, Mme P, de Pangia et famille, Durrik Hanem. MM. Demetrios
-                                Misia, Geo. Armarandos, Houser, E. Evangeli, R. Shezak, M. at Mme M.
-                                Derr et famille, Mohamad bey Cheiny et Mma Chainy, Hassan Rassib,
-                                CHerif Rianmi, Mme Giro et fils, Herman Mentres, Dr. L. Phillipe, G.
-                                Go romilis, Mr. Kenney et compagnon, N. Faz, D. Pulstos, J. Cohen,
-                                Evans, Perry, Mme et Mlle Bouteille, N. Holton, Mlle Bent 4 enfants,
-                                Ernest Meinert, N. Burbulia ainoi que 98 passagers de pont.</p>
-                            <p>Le paquebot Niger des Messageries Marita. mes arrive ce matin da
-                                Marseille avait a bords Mlle L. James, Mme Carton de Viapt et</p>
-                            <p>Mlle James, M. et Mme Lander, M. N. Smith. M. Ramadan bey, M. H.
-                                Morgan, Mlle Girardier, M. Frances, M. Zouffika, M. H. Reboul, M.
-                                Mah. Euan, M. Bontaen, M. et Mme Van den Brook d'Obrenean et
-                                enfatns, M. et Mme Nousrat Bey, Mme Houst et enftants, M. Jas.
-                                Hewat, of Mme Emas, M. Wrakmeyer, M. et Mme Homasen, M. et Mme
-                                Dahan, Mme N. Catalan at enfant, Mme A. L Wildig, Mme Slaughter, Mme
-                                Sheldrick, Mlle Iuglia M. et Mme Inglis, Mme Fisher, Cap. et Mme
-                                Gillson, Conte Zisinis, M. Bimsenstein, M. Aghion et enfant, Moris
-                                Bay, M. Stillwell, M. Makand, M. Multado, M. et Mme, Chear Aghion,
-                                M. et Mme Pennudjian, M. Malavsi Martino Pacha, M. et Mme St.
-                                Chamas, Mme Carusso et 2 enfants, Mme Lefrancois,</p>
-                            <p>Mme C. M. Hammann, Mlle Pieanlt, Mme Matsanitz, Mme A. Degiorgio,
-                                Mlle Spigh, Mme Hamon, Mlle Martin, M. Fredmann, M. I, D. Jacob, M.
-                                H. White et J. Dark, Mrs. J. et A.</p>
+                            <p>Le paqubot El Kabira de la Khedivial arrive hier de Constantinople Dardanelles Matelin, Smyrne et Piree avail a bord;</p>
+                            <p>M. et Mme S. Riveili, Dr. Franimer et famille, Mmes Stavroulakis, Yoannor, Cokiai, Wakefield, Mmes Maizes, Axelos Cartaliek et famillie, M. M. Pantos, Calvocoronci, Drs, Guilles et Defrigy, Amiradaki, Galanos, C. Risadimios Ap. Apostolidi, Franghiadia A. Perez, J. Yoannidi, Jean Andrioopoulos, M. et Mme Raifsis et famille, M. et Mme Gragorina, M. et Mme D. Harpaki et famille, M. et Mme Georgiadis et famillie, M. et Mme Pandasogaulo</p>
+                            <p>M. et Mme Haliadia, Dr. et Mme Gastanos, Mme Volters et famille, C. Exydakis, N. Caloutas, S. Sperer P. Levtaris Christo Stamopaolo, G. Constantinidi. Mme V.ve Bohphidis et famille, M. et Mme N. Papas et famille, Mmes, Polychromidi et famille, Mme S. Macri, Gouvernante Maitre Limgitia, N. Voiclis, G. Carapatis. N. Podaridi, M. et Mme</p>
+                            <p>N. Mavros, C. Maliarakis, G. Atassogin, A. Coatzoukis, E. Sakalarios, C. Zapellia. Ibrakimet Hnem et fille, Selmeh et Zekieh Hapem famille S. E. Mohamet Bey Izast J. Vistsi, Attie Hanem, Rew et Mme W. B. Godbay et famille S. El Tarabaki, ainsi que 312 passagers de pont.</p>
+                            <p>Le paquebot, italian Vincenzo, Floria de la Cie Florie Rubattino arrive hier da Genesavait a bord :</p>
+                            <p>M. et Mme Larrat. Pilotta, Lazzary, R, Savie. V. Oliva et comp., Hag el Fendoli, J, Bramby Cajo, J. Chihib, Eug Graglia, J. Moine, M et</p>
+                            <p>Mme Amos, Moh Bey Twefik, Gigaldini, Da Cameripi, Sabbag, Andreolis, Giranda, Reed et fam., Rev. Borgo, S. Lavi, prof. Mariani, M. et Mme R. Rocalie, prof. Farah et comp., prof. Pollardi, prof. Rispoli, Nafal, Livige O. Diacone T. Hemwood, Cap. Art. Levi, M. at Mme Les, A. Mustard, Aloi et fam., Colloridi et fils, M. et Mme G. Porto, A. Riboni, R. Link, J. Jean, L. Parid et 70 passagers de 3e classe.</p>
+                            <p>La paqubot Prince Abbas de la Khedivial arrive ce matin da Constatinople, Dardanelles, Metelin, Smyrne et Rhotes avait a bord :</p>
+                            <p>Djafer bey Fakhry, Selim bey Faoud et famille, Hassan bey Husni et famille, Mme P, de Pangia et famille, Durrik Hanem. MM. Demetrios Misia, Geo. Armarandos, Houser, E. Evangeli, R. Shezak, M. at Mme M. Derr et famille, Mohamad bey Cheiny et Mma Chainy, Hassan Rassib, CHerif Rianmi, Mme Giro et fils, Herman Mentres, Dr. L. Phillipe, G. Go romilis, Mr. Kenney et compagnon, N. Faz, D. Pulstos, J. Cohen, Evans, Perry, Mme et Mlle Bouteille, N. Holton, Mlle Bent 4 enfants, Ernest Meinert, N. Burbulia ainoi que 98 passagers de pont.</p>
+                            <p>Le paquebot Niger des Messageries Marita. mes arrive ce matin da Marseille avait a bords Mlle L. James, Mme Carton de Viapt et</p>
+                            <p>Mlle James, M. et Mme Lander, M. N. Smith. M. Ramadan bey, M. H. Morgan, Mlle Girardier, M. Frances, M. Zouffika, M. H. Reboul, M. Mah. Euan, M. Bontaen, M. et Mme Van den Brook d'Obrenean et enfatns, M. et Mme Nousrat Bey, Mme Houst et enftants, M. Jas. Hewat, of Mme Emas, M. Wrakmeyer, M. et Mme Homasen, M. et Mme Dahan, Mme N. Catalan at enfant, Mme A. L Wildig, Mme Slaughter, Mme Sheldrick, Mlle Iuglia M. et Mme Inglis, Mme Fisher, Cap. et Mme Gillson, Conte Zisinis, M. Bimsenstein, M. Aghion et enfant, Moris Bay, M. Stillwell, M. Makand, M. Multado, M. et Mme, Chear Aghion, M. et Mme Pennudjian, M. Malavsi Martino Pacha, M. et Mme St. Chamas, Mme Carusso et 2 enfants, Mme Lefrancois,</p>
+                            <p>Mme C. M. Hammann, Mlle Pieanlt, Mme Matsanitz, Mme A. Degiorgio, Mlle Spigh, Mme Hamon, Mlle Martin, M. Fredmann, M. I, D. Jacob, M. H. White et J. Dark, Mrs. J. et A.</p>
                             <p>Santi, Mlle Madasis Mme Schonsemann, M. J.</p>
-                            <p>Senes, M. Leferre, Mlle Girard, M. et Mme Gropper, M. O. Giordano,M.
-                                et Mme Greppi. Mason, M. et Mme Favre, R.P.P. Forchat et Langivan,
-                                M. Gromberg, M. Claus, M. de Salis, Mme Colin Pastour, R.P. Barrean,
-                                Mme Giavan, Soer Hatresen, M. Lorrick, M. et Mme Segur, M. Fribourg,
-                                Mlle Greenwood, Giles, Dr. Gattino et Lois Disux, M. Dienels, Dr.
-                                Tilche, Miss Veisee, Mme Lambert, M. et Mme Arab, M. et Mme Gontier
-                                et enfant, Mme Maggiar, Mr. Wedner, Mr. Berzalou, Mr. et Mam
-                                Walhroff, M. Vermond, M. Back, Mme Alrpa, M., Mme et Mlle Lakat, M.
-                                Pallon, Mrs. Tilcke, M. Aubrey, M. Cambism et 35 passagers de 3me et
-                                9 passagers de 4me classes.</p>
+                            <p>Senes, M. Leferre, Mlle Girard, M. et Mme Gropper, M. O. Giordano,M. et Mme Greppi. Mason, M. et Mme Favre, R.P.P. Forchat et Langivan, M. Gromberg, M. Claus, M. de Salis, Mme Colin Pastour, R.P. Barrean, Mme Giavan, Soer Hatresen, M. Lorrick, M. et Mme Segur, M. Fribourg, Mlle Greenwood, Giles, Dr. Gattino et Lois Disux, M. Dienels, Dr. Tilche, Miss Veisee, Mme Lambert, M. et Mme Arab, M. et Mme Gontier et enfant, Mme Maggiar, Mr. Wedner, Mr. Berzalou, Mr. et Mam Walhroff, M. Vermond, M. Back, Mme Alrpa, M., Mme et Mlle Lakat, M. Pallon, Mrs. Tilcke, M. Aubrey, M. Cambism et 35 passagers de 3me et 9 passagers de 4me classes.</p>
                         </div>
                         <div type="subsection" scope="maritime">
                             <head>DEPARTURES.</head>
-                            <p>Le paquobot Cleopatra du Lloyd Autrichien parti samedi poor Trieste
-                                avait a bord :</p>
-                            <p>M. et Mme G. E. Wolf, Rud. Zanke, J. S. Birch Pacha, C. Ferrar,
-                                Montrose Clocta, J. Rettie, John Bradburg, A. Laban, K. Alberts, Mme
-                                Vve. V. Orvieto, Paolo Discone, Eroole Diacono, Wolfdorf, Mlle O.
-                                Thiel, M. et Mme B. K. Bamika, Hugo Rosenbaum et 17 passagers de
-                                3mee classe.</p>
+                            <p>Le paquobot Cleopatra du Lloyd Autrichien parti samedi poor Trieste avait a bord :</p>
+                            <p>M. et Mme G. E. Wolf, Rud. Zanke, J. S. Birch Pacha, C. Ferrar, Montrose Clocta, J. Rettie, John Bradburg, A. Laban, K. Alberts, Mme Vve. V. Orvieto, Paolo Discone, Eroole Diacono, Wolfdorf, Mlle O. Thiel, M. et Mme B. K. Bamika, Hugo Rosenbaum et 17 passagers de 3mee classe.</p>
                         </div>
                     </div>
                     <div type="section" scope="advertisement">
-                        <div type="item" scope="advertisement" xml:id="deg-ad-whr01"><!-- TODO Replace with Add boilerplate -->
+                        <div type="item" scope="advertisement" xml:id="deg-ad-whr01">
+                            <!-- TODO Replace with Add boilerplate -->
                             <head>WINDSOR HOTEL</head>
                             <p>Table d’Heta Luncheons &amp; Dinners Served on the Terrace</p>
                             <p>ORCHESTRA PLAYS <unclear>e</unclear> TO 11:30 P.M.</p>
                         </div>
-                        <div type="item" scope="advertisement"><!-- TODO Replace with Add boilerplate -->
+                        <div type="item" scope="advertisement">
+                            <!-- TODO Replace with Add boilerplate -->
                             <head>AMERICAN REFRIGERATORS</head>
-                            <p>₤4 to ₤20--DRESS, £5 to £25 TYPEWRITERS ₤5 to ₤20 SEWING MACHINES ₤5
-                                TO ₤15</p>
+                            <p>₤4 to ₤20--DRESS, £5 to £25 TYPEWRITERS ₤5 to ₤20 SEWING MACHINES ₤5 TO ₤15</p>
                         </div>
-                        <div type="item" scope="advertisement"><!-- TODO Replace with Add boilerplate -->
+                        <div type="item" scope="advertisement">
+                            <!-- TODO Replace with Add boilerplate -->
                             <head>THE AMERICAN Manufacturers </head>
-                            <p><unclear></unclear></p>
+                            <p><unclear/></p>
                         </div>
                     </div>
                 </div>

--- a/1905-10-04.xml
+++ b/1905-10-04.xml
@@ -30,27 +30,17 @@
         <body>
             <div type="page" n="1">
                 <head>THE Egyptian GAZETTE</head>
-                <head type="sub">No. 7239] <placeName ref="https://www.wikidata.org/wiki/Q87"
-                        >Alexandria</placeName>, Wednesday, October 4, 1905. [SIX PAGES P.T.
-                    1.</head>
+                <head type="sub">No. 7239] <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>, Wednesday, October 4, 1905. [SIX PAGES P.T. 1.</head>
                 <div type="section" scope="advertisement">
                     <cb n="1"/>
-                    <div type="item" scope="advertisement" xml:id="deg-ad-pos01">>
+                    <div type="item" scope="advertisement" xml:id="deg-ad-pos01">
                         <head>Peninsular and Oriental S. N. Company.</head>
                         <p>Summer Rates will be charged from 2 May to 31 October. </p>
-                        <p>For the convenience of families and others, a large portion of each ship’s
-                            accommodation has been reserved for <placeName ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName>, so that Berths can be definitely
-                            engaged at once, as if the voyage were commencing at <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>. Plans can be
-                            seen at the Offices of the Company’s Agents. </p>
-                        <p>The through Steamers for <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName> and <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> are intended to leave <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>
-                            after the arrival of the 11 a.m. train from <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> , every Tuesday for the present
-                            except the MONGOLIA, which is taking passengers to the Anglo-French Naval
-                            Review, and will not wait at <placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName>  on 24/25 July. A steam tender will meet
-                            the train to convey passengers to the ship. </p>
+                        <p>For the convenience of families and others, a large portion of each ship’s accommodation has been reserved for <placeName ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName>, so that Berths can be definitely engaged at once, as if the voyage were commencing at <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>. Plans can be seen at the Offices of the Company’s Agents. </p>
+                        <p>The through Steamers for <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName> and <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> are intended to leave <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> after the arrival of the 11 a.m. train from <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> , every Tuesday for the present except the MONGOLIA, which is taking passengers to the Anglo-French Naval Review, and will not wait at <placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName> on 24/25 July. A steam tender will meet the train to convey passengers to the ship. </p>
                         <table>
                             <row>
-                                <cell><placeName ref="https://www.wikidata.org/wiki/Q79"
-                                        >Egypt</placeName>
+                                <cell><placeName ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName>
                                 </cell>
                                 <cell>4 July</cell>
                                 <cell>Arcadia </cell>
@@ -71,46 +61,39 @@
                                 <cell>18 July</cell>
                                 <cell>Arabia </cell>
                                 <cell>15 August</cell>
-                                <cell><placeName ref="https://www.wikidata.org/wiki/Q79"
-                                        >Egypt</placeName>
+                                <cell><placeName ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName>
                                 </cell>
                                 <cell>12 Sept.</cell>
                             </row>
                             <row>
                                 <cell>Mongolia</cell>
                                 <cell>25 July</cell>
-                                <cell><placeName ref="https://www.wikidata.org/wiki/Q148"
-                                        >China</placeName></cell>
+                                <cell><placeName ref="https://www.wikidata.org/wiki/Q148">China</placeName></cell>
                                 <cell>22 August</cell>
                                 <cell>Macedonia</cell>
                                 <cell>19 Sept.</cell>
                             </row>
                         </table>
-                        <p>The Brindisi Express Steamers leave <placeName
-                                ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>
-                            directly the Indian Mails arrive. Passengers can go on board the evening
-                            before. The Fare remains as usual. </p>
+                        <p>The Brindisi Express Steamers leave <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> directly the Indian Mails arrive. Passengers can go on board the evening before. The Fare remains as usual. </p>
                         <p>For all further information apply to the Company's Agents, </p>
                         <p>Messrs. THOS. COOK &amp; SON (<placeName ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName>) Ltd. <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> . </p>
                         <p>GEORGE ROYLE, Esq. <placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName> . </p>
                         <p>Messrs. HABELDEN &amp; Co. <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>. </p>
-                        <p> F. G. DAVIDSON, Superintendent P. &amp; O. S. N. Company in <placeName ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName> <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>. </p>
+                        <p> F. G. DAVIDSON, Superintendent P. &amp; O. S. N. Company in <placeName ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName>
+                            <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>. </p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-opl01">
                         <head>Orient-Pacific Line of Royal Mail Steamers.</head>
                         <p>REDUCED SUMMER FARES FROM MAY TO OCTOBER INCLUSIVE.</p>
                         <p>OUTWARDS to <placeName ref="https://www.wikidata.org/wiki/Q408">Australia</placeName>.</p>
-                        <p>R.M.S. “Orotava" will leave <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName> about July 28 | R.M.S "Ormuz" will leave <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>
-                            about August 11. </p>
-                        <p>HOMEWARDS to <placeName ref="https://www.wikidata.org/wiki/Q2634">Naples</placeName>  <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName>, GIBRALTAR, PLYMOUTH, <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName>, TILBURY</p>
-                        <p>R.M.S. "Oroya" will leave <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> about July 18 | R.M.S. “Ortona" will leave
-                            <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> about August 1</p>
+                        <p>R.M.S. “Orotava" will leave <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName> about July 28 | R.M.S "Ormuz" will leave <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName> about August 11. </p>
+                        <p>HOMEWARDS to <placeName ref="https://www.wikidata.org/wiki/Q2634">Naples</placeName>
+                            <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName>, GIBRALTAR, PLYMOUTH, <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName>, TILBURY</p>
+                        <p>R.M.S. "Oroya" will leave <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> about July 18 | R.M.S. “Ortona" will leave <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> about August 1</p>
                         <table>
                             <row>
                                 <cell rows="4">Reduced Summer Fares</cell>
-                                <cell><placeName ref="https://www.wikidata.org/wiki/Q134509"
-                                        >Port-Said</placeName> to <placeName
-                                        ref="https://www.wikidata.org/wiki/Q2634">Naples</placeName>
+                                <cell><placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName> to <placeName ref="https://www.wikidata.org/wiki/Q2634">Naples</placeName>
                                 </cell>
                                 <cell>1st Class</cell>
                                 <cell>£ 11</cell>
@@ -120,7 +103,7 @@
                                 <cell>£ 4.8</cell>
                             </row>
                             <row>
-                                <cell><placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName>  to <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName></cell>
+                                <cell><placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName> to <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName></cell>
                                 <cell>1st Class</cell>
                                 <cell>£ 12.12</cell>
                                 <cell>2nd Class</cell>
@@ -129,8 +112,7 @@
                                 <cell>£ 5.10</cell>
                             </row>
                             <row>
-                                <cell><placeName ref="https://www.wikidata.org/wiki/Q134509"
-                                        >Port-Said</placeName> to Gibraltar</cell>
+                                <cell><placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName> to Gibraltar</cell>
                                 <cell>1st Class</cell>
                                 <cell>£ 18.0</cell>
                                 <cell>2nd Class</cell>
@@ -139,8 +121,7 @@
                                 <cell>£ 5.10</cell>
                             </row>
                             <row>
-                                <cell><placeName ref="https://www.wikidata.org/wiki/Q134509"
-                                        >Port-Said</placeName> to Plymouth or Tilbury</cell>
+                                <cell><placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName> to Plymouth or Tilbury</cell>
                                 <cell>1st Class</cell>
                                 <cell>£ 16.16</cell>
                                 <cell>2nd Class</cell>
@@ -150,60 +131,41 @@
                             </row>
                         </table>
                         <p>Egyptian Government Officials allowed a rebate of 15% off the above fares.</p>
-                        <p>Return tickets no longer issued, but passengers paying full fare in one direction
-                            allowed abatement of 1/3 fare back if return voyage be within 4 months of
-                            arrival, or abatement of 20 o/o if return voyage be made within 8 months of
-                            arrival.</p>
-                        <p>Agents. <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> :—Thos. Cook &amp; Son. <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> : —R. J. Moss &amp; Co.—For all
-                            information apply </p>
-                        <p>Wm. STAPLEDON &amp; Sons, <placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName>  &amp; PORT-TEWFIK (<placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>) 31-12-904</p>
+                        <p>Return tickets no longer issued, but passengers paying full fare in one direction allowed abatement of 1/3 fare back if return voyage be within 4 months of arrival, or abatement of 20 o/o if return voyage be made within 8 months of arrival.</p>
+                        <p>Agents. <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> :—Thos. Cook &amp; Son. <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> : —R. J. Moss &amp; Co.—For all information apply </p>
+                        <p>Wm. STAPLEDON &amp; Sons, <placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName> &amp; PORT-TEWFIK (<placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>) 31-12-904</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-blm01">
                         <head>BIBBY LINE MAIL STEAMERS.</head>
                         <p>Special Reduced Rates During Summer Season,</p>
-                        <p>OUTWARDS to COLOMBO, TUTICORIN, etc., and RANGOON. Departures from
-                                <placeName ref="https://www.wikidata.org/wiki/Q134514"
-                                >Suez</placeName>.</p>
+                        <p>OUTWARDS to COLOMBO, TUTICORIN, etc., and RANGOON. Departures from <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>.</p>
                         <p>S.S. Derbyshire 6,635 tons, leaves about July 20.</p>
                         <p>S.S. Lancashire 4,244 tons, leaves about August 3.</p>
                         <p>HOMEWARDS to <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName> and <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName>. Departures from <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>.</p>
                         <p>S.S. Worcestershire 7,160 tons, leaves about July 26.</p>
                         <p>S.S. Yorkshire 4,196 tons leaves about August 9,</p>
-                        <p>FARES from <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> to <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName> £12.0.0, <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> £17.0.0, Colombo £32.10.0,
-                            Rangoon £37.10.0. </p>
-                        <p>Agents <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> : THOS. COOK &amp; SON. <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName> &amp; <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> : WM. STAPLEDON &amp; SONS,
-                            31-12-905</p>
+                        <p>FARES from <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> to <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName> £12.0.0, <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> £17.0.0, Colombo £32.10.0, Rangoon £37.10.0. </p>
+                        <p>Agents <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> : THOS. COOK &amp; SON. <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName> &amp; <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> : WM. STAPLEDON &amp; SONS, 31-12-905</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-kml01">
                         <head>KHEDIVIAL MAIL LINE.</head>
                         <head type="sub">FAST BRITISH PASSENGER STEAMERS</head>
                         <head type="sub"><placeName ref="https://www.wikidata.org/wiki/Q41">Greece</placeName> - <placeName ref="https://www.wikidata.org/wiki/Q43">Turkey</placeName> LINE.</head>
-                        <p>Express Steamers leave <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> every Wednesday at 4 p.m. for PIRAEUS, SMYRNA,
-                            MITYLENE, and CONSTANTINOPLE, in connection with Orient Express train-de-luxe
-                            for Vienna, <placeName ref="https://www.wikidata.org/wiki/Q90">Paris</placeName>, and <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName>.</p>
-                        <head type="sub">PALESTINE - SYRIA LINE.</head>
-                        <p>Fast steamers leave <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> every Saturday at 6 p.m., and <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> every
-                            Sunday at 6 p.m., for JAFFA (for Jerusalem), CAIFFA (for Nazareth), BEYROUT (for
-                            Damascus), TRIPOLI, ALEXANDRETTA, MESSINA, continuing in alternate weeks to
-                            LARNACA and LIMASSOL (Cyprus).</p>
-                        <head type="sub">RED SEA LINE.</head>
-                        <p>Steamers leave <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName> fortnightly on Wednesday at 6 p.m. for JEDDAH, SUAKIN,
-                            MASSOWAH, HODBIDAH, and ADEN ; and in the intervening weeks for PORT SUDAN and
-                            SUAKIN direct. Calls will be made at TOR (for Mount Sinai) as required.</p>
-                        <p>N.B.—Deck chairs provided for the use of passengers, excellent cuisine and table
-                            wine free.</p>
-                        <p>Steamer plans may be seen and passages booked at the Company’s Agencies at
-                            <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>, <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> , <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>, and <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>, or at THOS. COOK &amp; SON or other
-                            Tourist Agency. 31-12-904</p>
+                        <p>Express Steamers leave <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> every Wednesday at 4 p.m. for PIRAEUS, SMYRNA, MITYLENE, and CONSTANTINOPLE, in connection with Orient Express train-de-luxe for Vienna, <placeName ref="https://www.wikidata.org/wiki/Q90">Paris</placeName>, and <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName>.</p>
+                        <div type="subsection">
+                            <head type="sub">PALESTINE - SYRIA LINE.</head>
+                            <p>Fast steamers leave <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> every Saturday at 6 p.m., and <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> every Sunday at 6 p.m., for JAFFA (for Jerusalem), CAIFFA (for Nazareth), BEYROUT (for Damascus), TRIPOLI, ALEXANDRETTA, MESSINA, continuing in alternate weeks to LARNACA and LIMASSOL (Cyprus).</p>
+                        </div>
+                        <div type="item">
+                            <head type="sub">RED SEA LINE.</head>
+                            <p>Steamers leave <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName> fortnightly on Wednesday at 6 p.m. for JEDDAH, SUAKIN, MASSOWAH, HODBIDAH, and ADEN ; and in the intervening weeks for PORT SUDAN and SUAKIN direct. Calls will be made at TOR (for Mount Sinai) as required.</p>
+                            <p>N.B.—Deck chairs provided for the use of passengers, excellent cuisine and table wine free.</p>
+                            <p>Steamer plans may be seen and passages booked at the Company’s Agencies at <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>, <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> , <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>, and <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>, or at THOS. COOK &amp; SON or other Tourist Agency. 31-12-904</p>
+                        </div>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-mss01">
                         <head>The Moss S.S. Company, Ltd.</head>
-                        <p>For <placeName ref="https://www.wikidata.org/wiki/Q24826"
-                                >Liverpool</placeName> calling at <placeName
-                                ref="https://www.wikidata.org/wiki/Q233">Malta</placeName> (Messrs.
-                            JAMES MOSS &amp; Co. 31, James St, <placeName
-                                ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName>,
-                            Managers.)</p>
+                        <p>For <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName> calling at <placeName ref="https://www.wikidata.org/wiki/Q233">Malta</placeName> (Messrs. JAMES MOSS &amp; Co. 31, James St, <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName>, Managers.)</p>
                         <table rows="3" cols="8">
                             <row>
                                 <cell>*Amasis</cell>
@@ -236,23 +198,12 @@
                                 <cell>(Building)</cell>
                             </row>
                         </table>
-                        <p>*Second class accommodation only, unless specially reserved.—Fares : <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>
-                            to <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName>, 1st, £14 Single, £25 Return. 2nd, £9 Single, £15 Return.—To <placeName ref="https://www.wikidata.org/wiki/Q233">Malta</placeName>,
-                            1st, £5 Single, £9 Return, 2nd, £3 Single, £5 Return.—Return tickets available
-                            for six months.</p>
-                        <p>S.S. Seti now on the berth, will sail on or about Monday, July 17, to be
-                            followed by S.S. Menes.</p>
-                        <p>S.S Tabor for Havre via <placeName
-                                ref="https://www.wikidata.org/wiki/Q233">Malta</placeName> to sail
-                            about Saturday l5th inst.</p>
-                        <p>Through freight rates on cotton, etc., to Lancashire inland towns,
-                            Boston, New York and other U.S.A. towns, obtained on application. Cargo
-                            taken by special agreement only. </p>
-                        <p>Passenger Tickets also issued inclusive of Railway fare through to and
-                            from <placeName ref="https://www.wikidata.org/wiki/Q85"
-                                >Cairo</placeName> . Particulars on application to </p>
-                        <p>R. J. MOSS &amp; Co., <placeName ref="https://www.wikidata.org/wiki/Q87"
-                                >Alexandria</placeName>, Agents. 26-12-905</p>
+                        <p>*Second class accommodation only, unless specially reserved.—Fares : <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> to <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName>, 1st, £14 Single, £25 Return. 2nd, £9 Single, £15 Return.—To <placeName ref="https://www.wikidata.org/wiki/Q233">Malta</placeName>, 1st, £5 Single, £9 Return, 2nd, £3 Single, £5 Return.—Return tickets available for six months.</p>
+                        <p>S.S. Seti now on the berth, will sail on or about Monday, July 17, to be followed by S.S. Menes.</p>
+                        <p>S.S Tabor for Havre via <placeName ref="https://www.wikidata.org/wiki/Q233">Malta</placeName> to sail about Saturday l5th inst.</p>
+                        <p>Through freight rates on cotton, etc., to Lancashire inland towns, Boston, New York and other U.S.A. towns, obtained on application. Cargo taken by special agreement only. </p>
+                        <p>Passenger Tickets also issued inclusive of Railway fare through to and from <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> . Particulars on application to </p>
+                        <p>R. J. MOSS &amp; Co., <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>, Agents. 26-12-905</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-mic01">
                         <head>MARINE INSURANCE COMPANY, LIMITED.</head>
@@ -263,11 +214,8 @@
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-tce01">
                         <head>Telephone Company of <placeName ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName>, Limited.</head>
-                        <p><placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> -<placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> TELEPHONE.--Rates as follows P.T. 5 for each 3 minutes, or
-                            fraction of 3 minutes; P.T. 10 for over 3 up to 8 minutes communication.</p>
-                        <p>PUBLIC CALL-OFFICES : <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> , Central Office, Opera Square, and New Bar; Helouan,
-                            Central Office, Maison Purvis ; <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>, St Mark’s Buildings, Egyptian Bar,
-                            I. Castelli &amp; Co.; Ramleh, Central Office. San Stefano Casino 30.4.906</p>
+                        <p><placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> -<placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> TELEPHONE.--Rates as follows P.T. 5 for each 3 minutes, or fraction of 3 minutes; P.T. 10 for over 3 up to 8 minutes communication.</p>
+                        <p>PUBLIC CALL-OFFICES : <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> , Central Office, Opera Square, and New Bar; Helouan, Central Office, Maison Purvis ; <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>, St Mark’s Buildings, Egyptian Bar, I. Castelli &amp; Co.; Ramleh, Central Office. San Stefano Casino 30.4.906</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-phc01">
                         <head>P. HENDERSON &amp; CO’s LINE.</head>
@@ -277,8 +225,7 @@
                         <p>S.S. BURMA 5600 Tons will leave <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> about August 6 for <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName>.</p>
                         <p>S.S. ARRACAN 5800 Tons will leave <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> about 20 for <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName></p>
                         <p>Due in <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> or <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName> 12 days thereafter.</p>
-                        <p>Apply WORMS &amp; Co., <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> and <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>. THOS. COOK &amp; SON, (<placeName ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName>) LD.,
-                            <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>  ;</p>
+                        <p>Apply WORMS &amp; Co., <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> and <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>. THOS. COOK &amp; SON, (<placeName ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName>) LD., <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> ;</p>
                         <p>G. J. GRACE &amp; CO., <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>.</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-tcs01">
@@ -288,31 +235,13 @@
                         <p><placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>, <placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName> , <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>, Luxor, Assuan, Haifa, &amp; Khartum.</p>
                         <p>GENERAL RAILWAY AND STEAMSHIP AGENTS. BANKERS.</p>
                         <p>BAGGAGE AND FORWARDING AGENTS.</p>
-                        <p>Officially appointed &amp; Sole Agents in <placeName
-                                ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> to the
-                            P.&amp;O. S.N. Co.</p>
-                        <p>RESIDENTS IN <placeName ref="https://www.wikidata.org/wiki/Q79"
-                                >Egypt</placeName> proceeding to Europe for the summer are requested
-                            to apply to our offices for information respecting their Passages, where
-                            steamer plans may be consulted and Berths secured by all Lines of
-                            Steamers to all parts of the Globe; arrangements can also be made for
-                            the collection and forwarding of their baggage and clearance at port of
-                            arrival.</p>
-                        <p>CIRCULAR NOTES issued payable at the current rate of exchange in all the
-                            principal cities of Europe. Cook’s Interpreters in uniform are present
-                            at the principal Railway stations and Landing-places in Europe to assist
-                            passengers holding their travelling tickets.</p>
-                        <p>Large and splendidly appointed steamers belonging to the Co. leave
-                                <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>
-                            thrice weekly, between November and March, for Luxor, Assouan and
-                            Wady-Halfa in connection with trains de luxe to Khartoum. Moderate
-                            fares. </p>
-                        <p>FREIGHT SERVICE, Steamers leave <placeName
-                                ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> every
-                            Saturday and Tuesday for Assouan and Halfa.</p>
+                        <p>Officially appointed &amp; Sole Agents in <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> to the P.&amp;O. S.N. Co.</p>
+                        <p>RESIDENTS IN <placeName ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName> proceeding to Europe for the summer are requested to apply to our offices for information respecting their Passages, where steamer plans may be consulted and Berths secured by all Lines of Steamers to all parts of the Globe; arrangements can also be made for the collection and forwarding of their baggage and clearance at port of arrival.</p>
+                        <p>CIRCULAR NOTES issued payable at the current rate of exchange in all the principal cities of Europe. Cook’s Interpreters in uniform are present at the principal Railway stations and Landing-places in Europe to assist passengers holding their travelling tickets.</p>
+                        <p>Large and splendidly appointed steamers belonging to the Co. leave <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> thrice weekly, between November and March, for Luxor, Assouan and Wady-Halfa in connection with trains de luxe to Khartoum. Moderate fares. </p>
+                        <p>FREIGHT SERVICE, Steamers leave <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> every Saturday and Tuesday for Assouan and Halfa.</p>
                         <p>Special Steamers and Dahabeahs for private parties.</p>
-                        <p>Special arrangements for tour in PALESTINE, SYRIA and the DESERT, Lowest
-                            Rates.</p>
+                        <p>Special arrangements for tour in PALESTINE, SYRIA and the DESERT, Lowest Rates.</p>
                         <p>Best camp equipment in the country! 10 12-904 </p>
                     </div>
                     <cb n="2"/>
@@ -320,65 +249,41 @@
                         <head>British <placeName ref="https://www.wikidata.org/wiki/Q668">India</placeName> S. N. Company, Limited.</head>
                         <p>MAIL AND PASSENGER STEAM SHIPS.</p>
                         <p>SAILINGS FROM <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>, <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> and CALCUTTA LINE.</p>
-                        <p>Calling at ADEN, COLOMBO and MADRAS Outward, and <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName> (GENOA and PLYMOUTH
-                            optional) Homeward. </p>
-                        <p>Fortnightly Service in connection with the Co's Indian Mail Lines and monthly
-                            with the East African Mail Line between ADEN, MOMBASSA and Zanzibar. </p>
+                        <p>Calling at ADEN, COLOMBO and MADRAS Outward, and <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName> (GENOA and PLYMOUTH optional) Homeward. </p>
+                        <p>Fortnightly Service in connection with the Co's Indian Mail Lines and monthly with the East African Mail Line between ADEN, MOMBASSA and Zanzibar. </p>
                         <p>OUTWARD.—S.S. Fazilka ... July 22 | HOMEWARD.—S.S. Mombassa ... July 21 </p>
-                        <p>Queensland Line of Steamers Between <placeName
-                                ref="https://www.wikidata.org/wiki/Q84">London</placeName> and
-                            Brisbane.</p>
+                        <p>Queensland Line of Steamers Between <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> and Brisbane.</p>
                         <p>Calling at Colombo, Batavia, Cooktown, Townsville, and Rockhamptom.</p>
-                        <p>The S.S. .................. will sail from <placeName
-                                ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName> on
-                            about ..................</p>
+                        <p>The S.S. .................. will sail from <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName> on about ..................</p>
                         <table rows="2" cols="9">
                             <row>
-                                <cell>First Class Fares from <placeName
-                                        ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>
-                                    to</cell>
+                                <cell>First Class Fares from <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName> to</cell>
                                 <cell>Aden</cell>
                                 <cell>£11. 8</cell>
                                 <cell>Colombo</cell>
                                 <cell>£14.14</cell>
                                 <cell>Calcutta</cell>
                                 <cell>£31. 0</cell>
-                                <cell><placeName ref="https://www.wikidata.org/wiki/Q579613"
-                                        >Marseilles</placeName></cell>
+                                <cell><placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName></cell>
                                 <cell>£15.12</cell>
                             </row>
                             <row>
                                 <cell/>
-                                <cell><placeName ref="https://www.wikidata.org/wiki/Q1156"
-                                        >Bombay</placeName></cell>
+                                <cell><placeName ref="https://www.wikidata.org/wiki/Q1156">Bombay</placeName></cell>
                                 <cell>£31.10</cell>
                                 <cell>Madras</cell>
                                 <cell>£xx.11</cell>
                                 <cell>Genoa</cell>
                                 <cell>£13.10</cell>
-                                <cell><placeName ref="https://www.wikidata.org/wiki/Q84"
-                                        >London</placeName></cell>
+                                <cell><placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName></cell>
                                 <cell>£19. 0</cell>
                             </row>
                         </table>
-                        <p>From <placeName ref="https://www.wikidata.org/wiki/Q134509"
-                                >Port-Said</placeName> £2 less Homeward, and £2 more Outward. Second
-                            class, two thirds of 1st Class Fares.</p>
-                        <p>Agents at <placeName ref="https://www.wikidata.org/wiki/Q134509">Port
-                                Said</placeName>, for the <placeName
-                                ref="https://www.wikidata.org/wiki/Q84">London</placeName>, Calcutta
-                            and Persian Gulf Lines, Messrs. Worms &amp; Co.</p>
-                        <p>Agents at <placeName ref="https://www.wikidata.org/wiki/Q134509">Port
-                                Said</placeName>, for the <placeName
-                                ref="https://www.wikidata.org/wiki/Q84">London</placeName> and
-                            Queensland Line, Messrs. Wills &amp; Co., Limited.</p>
-                        <p>Messrs. Thos. Cook &amp; Son and the Anglo-American Hotel &amp; Steamer
-                            Company, <placeName ref="https://www.wikidata.org/wiki/Q85"
-                                >Cairo</placeName> &amp; <placeName
-                                ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>.</p>
-                        <p>For further particulars. Freight and Passage apply to G. BEYTS &amp; Co.
-                            Agents, <placeName ref="https://www.wikidata.org/wiki/Q134514"
-                                >Suez</placeName>. 31-12-905</p>
+                        <p>From <placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName> £2 less Homeward, and £2 more Outward. Second class, two thirds of 1st Class Fares.</p>
+                        <p>Agents at <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>, for the <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName>, Calcutta and Persian Gulf Lines, Messrs. Worms &amp; Co.</p>
+                        <p>Agents at <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>, for the <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> and Queensland Line, Messrs. Wills &amp; Co., Limited.</p>
+                        <p>Messrs. Thos. Cook &amp; Son and the Anglo-American Hotel &amp; Steamer Company, <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> &amp; <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>.</p>
+                        <p>For further particulars. Freight and Passage apply to G. BEYTS &amp; Co. Agents, <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>. 31-12-905</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-all01">
                         <head>ANCHOR LINE, LIMITED.</head>
@@ -387,10 +292,7 @@
                         <p>First class passengers steamers. Sailing fortnightly from <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>.</p>
                         <table rows="2" cols="6">
                             <row>
-                                <cell>For <placeName ref="https://www.wikidata.org/wiki/Q579613"
-                                        >Marseilles</placeName> &amp; <placeName
-                                        ref="https://www.wikidata.org/wiki/Q24826"
-                                        >Liverpool</placeName></cell>
+                                <cell>For <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName> &amp; <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName></cell>
                                 <cell>S.S. “Bohemia”</cell>
                                 <cell>July 26</cell>
                                 <cell>For CALCUTTA</cell>
@@ -398,65 +300,44 @@
                                 <cell>August 3</cell>
                             </row>
                             <row>
-                                <cell>For <placeName ref="https://www.wikidata.org/wiki/Q84"
-                                        >London</placeName></cell>
+                                <cell>For <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName></cell>
                                 <cell>S.S. “Persia"</cell>
                                 <cell>July 28</cell>
-                                <cell>For <placeName ref="https://www.wikidata.org/wiki/Q1156"
-                                        >Bombay</placeName></cell>
-                                <cell>S.S. "<placeName ref="https://www.wikidata.org/wiki/Q408"
-                                        >Australia</placeName>"</cell>
+                                <cell>For <placeName ref="https://www.wikidata.org/wiki/Q1156">Bombay</placeName></cell>
+                                <cell>S.S. "<placeName ref="https://www.wikidata.org/wiki/Q408">Australia</placeName>"</cell>
                                 <cell>July 23</cell>
                             </row>
                         </table>
-                        <p>Saloon Fares: from <placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName> , to Gibraltar £9; <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName> £9: <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName> (all sea
-                            route) £15; <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> (all sea route) £ 12 <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> via <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName> £15.5.0.
-                            Passengers embarking at <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName> £2 more, 10 % reduction for officers of army of
-                            Occupation and Government employés. Through tickets issued to New-York (via
-                            Glasgow). Fares on application. </p>
-                        <p> Agents in <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> , Messrs. Thos. Cook &amp; Son. <placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName> , Messrs. Cory Brothers
-                            &amp; Co., Ltd.</p>
-                        <p>For further partienlan of Freight or Passage apply to G. BEYTS &amp; Co., <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>.
-                            31-12-905</p>
+                        <p>Saloon Fares: from <placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName> , to Gibraltar £9; <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName> £9: <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName> (all sea route) £15; <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> (all sea route) £ 12 <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> via <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName> £15.5.0. Passengers embarking at <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName> £2 more, 10 % reduction for officers of army of Occupation and Government employés. Through tickets issued to New-York (via Glasgow). Fares on application. </p>
+                        <p> Agents in <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> , Messrs. Thos. Cook &amp; Son. <placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName> , Messrs. Cory Brothers &amp; Co., Ltd.</p>
+                        <p>For further partienlan of Freight or Passage apply to G. BEYTS &amp; Co., <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>. 31-12-905</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-dll01">
                         <head>Deutsche Levante-Linie.</head>
-                        <p>Mail and Passenger Steamships. Regular three-weekly Service from <lb/> HAMBURG,
-                            via ANTWERP &amp; <placeName ref="https://www.wikidata.org/wiki/Q233">Malta</placeName>, to <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> and vice-versa, admitting<lb/> goods from
-                            all chief German Railway Stations on direct Bill of Landing to<lb/> <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>
-                            and all chief ports of <placeName ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName>, Syria, etc., at favourable through<lb/> rates of
-                            DEUTSCHE <lb/> VERKEHR (traffic).</p>
+                        <p>Mail and Passenger Steamships. Regular three-weekly Service from <lb/> HAMBURG, via ANTWERP &amp; <placeName ref="https://www.wikidata.org/wiki/Q233">Malta</placeName>, to <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> and vice-versa, admitting<lb/> goods from all chief German Railway Stations on direct Bill of Landing to<lb/>
+                            <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> and all chief ports of <placeName ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName>, Syria, etc., at favourable through<lb/> rates of DEUTSCHE <lb/> VERKEHR (traffic).</p>
                         <p>EXPECTED AT <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>.</p>
                         <p>S.S. Lesbos July 20 from Antwerp.</p>
                         <p>S.S. Androos July 20 from Hamburg bound for Beyrout.</p>
                         <p>S.S. Lemnos July 31 from Hamburg bound for Beyrout.</p>
-                        <p>For tariff and particulars apply to ADOLPHE STROSS, <placeName
-                                ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>,
-                            Agent. </p>
+                        <p>For tariff and particulars apply to ADOLPHE STROSS, <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>, Agent. </p>
                         <p>15-2-905 </p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-doa01">
                         <head>Deutsche Ost-Afrika Linie.</head>
-                        <p>GERMAN EAST-AFRICAN LINE - REGULAR MAIL-SERVICE FROM <placeName
-                                ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName>
+                        <p>GERMAN EAST-AFRICAN LINE - REGULAR MAIL-SERVICE FROM <placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName>
                         </p>
                         <p>OUTWARDS. To ADEN, ZANZIBAR, DURBAN, CAPETOWN and intermediate Ports.</p>
                         <p>HOMEWARDS. To <placeName ref="https://www.wikidata.org/wiki/Q2634">Naples</placeName> , GENOA, <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName>, LISBON, ROTTERDAM, HAMBURG.</p>
-                        <p>Splendid accommodation for passengars of all classes.—First-class steamers,
-                            fitted with all recent improvements. stewardesses and doctor carried—Low passage
-                            rates.</p>
+                        <p>Splendid accommodation for passengars of all classes.—First-class steamers, fitted with all recent improvements. stewardesses and doctor carried—Low passage rates.</p>
                         <p>For all particulars, apply to FIX &amp; DAVID, <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> , Sharia Mansour Pacha</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-nkh01">
                         <head>NEW KHEDIVIAL HOTEL, <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>.</head>
-                        <p>First-class Hotel. Situated in Rosetta Avenue, the finest quarter in the Town.
-                            Two mintes from Railway Station. Close to Conservatory and the Opera House.
-                            Lift. Electric Light Throughout. Perfect Sanitary Arragnements. Magnificent
-                            Ball, Reception, Reading, and Music Rooms. Bar and Smoking Room.</p>
+                        <p>First-class Hotel. Situated in Rosetta Avenue, the finest quarter in the Town. Two mintes from Railway Station. Close to Conservatory and the Opera House. Lift. Electric Light Throughout. Perfect Sanitary Arragnements. Magnificent Ball, Reception, Reading, and Music Rooms. Bar and Smoking Room.</p>
                         <p> HENRI CHAMOULLEAU, Proprietor.</p>
                         <p>45</p>
-                        <p>FINE TERRACE ON THE AVENUE. - SPLENDID GARDEN. - OMNIBUS MEET ALL TRAINS
-                            AND STEAMERS. 28-26 </p>
+                        <p>FINE TERRACE ON THE AVENUE. - SPLENDID GARDEN. - OMNIBUS MEET ALL TRAINS AND STEAMERS. 28-26 </p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-pss01">
                         <head><placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>-SAVOY HOTEL.</head>
@@ -466,25 +347,18 @@
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-hbc01">
                         <head>HOTEL BRISTOL. <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> .</head>
-                        <p>Full South, Electric Light, opposite Esbekieh Gardens, Large Verandahs, Moderate
-                            Charges,</p>
+                        <p>Full South, Electric Light, opposite Esbekieh Gardens, Large Verandahs, Moderate Charges,</p>
                         <p>CHAS. BAUER, Proprietor.</p>
-                        <p>The Hotel is beautifully fitted up and is in the most central part of
-                                <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>
-                            . Terms for pension fare at the rate of ten shillings a day. Special
-                            terms for officers of Army of Occupation. 24,882-31-10-5</p>
+                        <p>The Hotel is beautifully fitted up and is in the most central part of <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> . Terms for pension fare at the rate of ten shillings a day. Special terms for officers of Army of Occupation. 24,882-31-10-5</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-gac01">
                         <head>GUARDIAN ASSURANCE COMPANY, LIMITED,</head>
-                        <p>OF <placeName ref="https://www.wikidata.org/wiki/Q84"
-                            >London</placeName></p>
+                        <p>OF <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName></p>
                         <p>Established 1821.</p>
                         <p>CAPITAL PAID UP AND INVERTED ONE MILLION STERLING.</p>
                         <p>Annual Income . . £895,000.</p>
                         <p>Total Funds . . £5,200,000.</p>
-                        <p>Agents far <placeName ref="https://www.wikidata.org/wiki/Q79"
-                                >Egypt</placeName> and the Sudan - HEWAT &amp; Co., <placeName
-                                ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>.</p>
+                        <p>Agents far <placeName ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName> and the Sudan - HEWAT &amp; Co., <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>.</p>
                         <p>24336--17-6-905</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-lac01">
@@ -493,25 +367,18 @@
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-nfl01">
                         <head>NORTHERN FIRE AND LIFE ASSURANCE Coy.</head>
-                        <p>The undersigned agents are authorised to issue policies on behalf of the above
-                            Company at moderate rates.</p>
-                        <p>IMPERIAL OTTOMAN BANK, <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>. OTTO STERZING, <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> . GEORG. MEINECKE, <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>.
-                            3112905</p>
+                        <p>The undersigned agents are authorised to issue policies on behalf of the above Company at moderate rates.</p>
+                        <p>IMPERIAL OTTOMAN BANK, <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>. OTTO STERZING, <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> . GEORG. MEINECKE, <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>. 3112905</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-sio01">
                         <head>Sun Insurance Office,</head>
-                        <p><placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName>.
-                            Founded 1710.-Total sum insured in 1902 £487,600,000.</p>
-                        <p>Agents : LEON HELLER, <placeName ref="https://www.wikidata.org/wiki/Q85"
-                                >Cairo</placeName> , and BEHREND &amp; Co., <placeName
-                                ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>.
-                            16-1-906</p>
+                        <p><placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName>. Founded 1710.-Total sum insured in 1902 £487,600,000.</p>
+                        <p>Agents : LEON HELLER, <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> , and BEHREND &amp; Co., <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>. 16-1-906</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-rea01">
                         <head>ROYAL EXCHANGE ASSURANCE.</head>
                         <p>Incorporated A. D. 1720.</p>
-                        <p>Chief Office: ROYAL EXCHANGE, <placeName
-                                ref="https://www.wikidata.org/wiki/Q84">London</placeName>, E.C.</p>
+                        <p>Chief Office: ROYAL EXCHANGE, <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName>, E.C.</p>
                         <p>FUNDS IN HAND EXCEED £4,500,000 CLAIMS PAID £40,000,000</p>
                         <table rows="2" cols="2">
                             <row role="label">
@@ -519,13 +386,11 @@
                                 <cell>MARINE</cell>
                             </row>
                             <row>
-                                <cell><placeName ref="https://www.wikidata.org/wiki/Q87"
-                                        >Alexandria</placeName> … ANGLO-Egyptian BANK.</cell>
-                                <cell><placeName ref="https://www.wikidata.org/wiki/Q87"
-                                        >Alexandria</placeName> … Mr. J. B. CAFFARI</cell>
+                                <cell><placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> … ANGLO-Egyptian BANK.</cell>
+                                <cell><placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> … Mr. J. B. CAFFARI</cell>
                             </row>
                             <row>
-                                <cell><placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>  … Mr. J. B. CAFFARI</cell>
+                                <cell><placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> … Mr. J. B. CAFFARI</cell>
                                 <cell><placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName> … Mr. GEO. MEINECKE.</cell>
                             </row>
                         </table>
@@ -535,52 +400,33 @@
                         <head>INTERNATIONAL SLEEPING AND RESTAURANT CARS COMPANY.</head>
                         <table rows="2" cols="4">
                             <row role="label">
-                                <cell cols="4"><hi rend="italic">Restaurant Car runs every day
-                                        between <placeName ref="https://www.wikidata.org/wiki/Q85"
-                                            >Cairo</placeName> &amp; <placeName
-                                            ref="https://www.wikidata.org/wiki/Q87"
-                                            >Alexandria</placeName> &amp; vice-versa</hi>.</cell>
+                                <cell cols="4"><hi rend="italic">Restaurant Car runs every day between <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> &amp; <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> &amp; vice-versa</hi>.</cell>
                             </row>
                             <row>
-                                <cell>Depart. - <placeName ref="https://www.wikidata.org/wiki/Q85"
-                                        >Cairo</placeName>
+                                <cell>Depart. - <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>
                                 </cell>
                                 <cell>6.35 p.m.</cell>
-                                <cell>Arrival - <placeName ref="https://www.wikidata.org/wiki/Q87"
-                                        >Alexandria</placeName></cell>
+                                <cell>Arrival - <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName></cell>
                                 <cell>10.0 p.m.</cell>
                             </row>
                             <row>
-                                <cell>Depart. - <placeName ref="https://www.wikidata.org/wiki/Q87"
-                                        >Alexandria</placeName></cell>
+                                <cell>Depart. - <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName></cell>
                                 <cell>6. 0 p.m.</cell>
-                                <cell>Arrival - <placeName ref="https://www.wikidata.org/wiki/Q85"
-                                        >Cairo</placeName>
+                                <cell>Arrival - <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>
                                 </cell>
                                 <cell>9.20 p.m.</cell>
                             </row>
                         </table>
-                        <p>By the 10.15 p.m. train between <placeName
-                                ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> and
-                                <placeName ref="https://www.wikidata.org/wiki/Q87"
-                                >Alexandria</placeName> and vice-versa a sleeping car is attached
-                            every night. Supplement 30 P.T. </p>
+                        <p>By the 10.15 p.m. train between <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> and <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> and vice-versa a sleeping car is attached every night. Supplement 30 P.T. </p>
                         <table rows="4" cols="4">
                             <row role="label">
-                                <cell cols="4"><hi rend="italic">Daily Restaurant Car Service
-                                        between <placeName ref="https://www.wikidata.org/wiki/Q85"
-                                            >Cairo</placeName> , Ismailia, <placeName
-                                            ref="https://www.wikidata.org/wiki/Q134509">Port
-                                            Said</placeName> &amp; vice-versa</hi>.</cell>
+                                <cell cols="4"><hi rend="italic">Daily Restaurant Car Service between <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> , Ismailia, <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> &amp; vice-versa</hi>.</cell>
                             </row>
                             <row>
-                                <cell>Depart. - <placeName ref="https://www.wikidata.org/wiki/Q85"
-                                        >Cairo</placeName>
+                                <cell>Depart. - <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>
                                 </cell>
                                 <cell>11 a.m. &amp; 6.15 p.m.</cell>
-                                <cell>Depart. - <placeName
-                                        ref="https://www.wikidata.org/wiki/Q134509">Port
-                                        Said</placeName></cell>
+                                <cell>Depart. - <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName></cell>
                                 <cell>11.55 a.m. &amp; 6.30 p.m.</cell>
                             </row>
                             <row>
@@ -596,71 +442,37 @@
                                 <cell>1.35 p.m. &amp; 8.17 p.m.</cell>
                             </row>
                             <row>
-                                <cell>Arriv. - <placeName
-                                        ref="https://www.wikidata.org/wiki/Q134509">Port
-                                        Said</placeName></cell>
+                                <cell>Arriv. - <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName></cell>
                                 <cell>5. 0 p.m. &amp; 11.10 p.m.</cell>
-                                <cell>Arriv. - <placeName ref="https://www.wikidata.org/wiki/Q85"
-                                        >Cairo</placeName>
+                                <cell>Arriv. - <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>
                                 </cell>
                                 <cell>5. 0 p.m. &amp; 11.25 p.m.</cell>
                             </row>
                         </table>
                         <p>Restaurant and Sleeping Cars on Luxor trains:</p>
-                        <p>A Restaurant car and a sleeping car are attached to the 8 p.m. train from
-                                <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>
-                            every Monday, Wednesday and Saturday and to the 5.30 p.m. train from
-                            Luxor every Tuesday, Thursday and Sunday.</p>
-                        <p>Railway and Sleeping Car tickets can be obtained any number of days ahead
-                            at the office of the International Sleeping Car Company in <placeName
-                                ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> Station.
-                            1st class <placeName ref="https://www.wikidata.org/wiki/Q85"
-                                >Cairo</placeName> -Luxor P.T. 200. Sleeping Car supplement P.T.
-                            75.</p>
+                        <p>A Restaurant car and a sleeping car are attached to the 8 p.m. train from <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> every Monday, Wednesday and Saturday and to the 5.30 p.m. train from Luxor every Tuesday, Thursday and Sunday.</p>
+                        <p>Railway and Sleeping Car tickets can be obtained any number of days ahead at the office of the International Sleeping Car Company in <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> Station. 1st class <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> -Luxor P.T. 200. Sleeping Car supplement P.T. 75.</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-ccc01">
                         <p>The Cigarettes Manufactured by</p>
                         <p>The Cleopatra Cigarette Co.</p>
                         <p>G. NUNGOYICH</p>
-                        <p>are on sale at the Company's establishment by Grand Contental Hotel,
-                                <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>
-                            , and at Walker &amp; Meimarschi's, <placeName
-                                ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>.</p>
+                        <p>are on sale at the Company's establishment by Grand Contental Hotel, <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> , and at Walker &amp; Meimarschi's, <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>.</p>
                         <p>Purveyors to H. H. the KHEDIVE.</p>
-                        <p>35750 Patronized by the Duke of Connaught and the Archduke Otto and all
-                            the High Life of <placeName ref="https://www.wikidata.org/wiki/Q79"
-                                >Egypt</placeName>. 18-4-80</p>
+                        <p>35750 Patronized by the Duke of Connaught and the Archduke Otto and all the High Life of <placeName ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName>. 18-4-80</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-ncs01">
                         <head>NILE COLD STORAGE<lb/> COMPANY, LIMITED.</head>
-                        <p>PURVEYORS OF THE FINEST COLONIAL<lb/> MEAT, GAME, POULTRY, BUTTER, FISH,
-                            etc., etc.</p>
-                        <p>The Company have opened a shop in the NEW MARKET, <placeName
-                                ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> , Nos. 39
-                            &amp; 40, where the goods imported by them can be inspected and
-                            purchased.</p>
+                        <p>PURVEYORS OF THE FINEST COLONIAL<lb/> MEAT, GAME, POULTRY, BUTTER, FISH, etc., etc.</p>
+                        <p>The Company have opened a shop in the NEW MARKET, <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> , Nos. 39 &amp; 40, where the goods imported by them can be inspected and purchased.</p>
                         <p>Telephone No. 1. 5. xxx-xx-xx</p>
                     </div>
                     <cb n="3"/>
                     <div type="item" scope="advertisement" xml:id="deg-ad-aan01">
                         <head>Anglo-American Nile Steamer &amp; Hotel Coy.</head>
-                        <p>Weekly departure during Winter Season by the<lb/> Luxurious First Class
-                            Tourist Steamers VICTORIA, PURITAN &amp; MAYFLOWER.<lb/> Regular weekly
-                            Departures to the SECOND CATARACT by the S.S. IndianA.<lb/> THROUGH
-                            BOOKINGS TO KHARTOUM, GONDOKORO AND THE WHITE NILE.<lb/> Steamers and
-                            Dahabeahs for private charter. Steam Tugs and Steam Launches for
-                            hire.<lb/> FREIGHT SERVICE BY STEAM BARGES BETWEEN <placeName
-                                ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> AND
-                                <placeName ref="https://www.wikidata.org/wiki/Q87"
-                                >Alexandria</placeName>.<lb/> Working in conjunction and under
-                            special arrangement with the<lb/> “Upper <placeName
-                                ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName> Hotels
-                            Company."</p>
-                        <p>For details and illustrated programmes apply to "THE ANGLO-AMERICAN NILE
-                            STEAMER and<lb/> HOTEL COMPANY."</p>
-                        <p> OFFICES IN <placeName ref="https://www.wikidata.org/wiki/Q85"
-                                >Cairo</placeName> : Sharia Boulac, "Grand Continental Hotel
-                            Buildings.” 31-3-06</p>
+                        <p>Weekly departure during Winter Season by the<lb/> Luxurious First Class Tourist Steamers VICTORIA, PURITAN &amp; MAYFLOWER.<lb/> Regular weekly Departures to the SECOND CATARACT by the S.S. IndianA.<lb/> THROUGH BOOKINGS TO KHARTOUM, GONDOKORO AND THE WHITE NILE.<lb/> Steamers and Dahabeahs for private charter. Steam Tugs and Steam Launches for hire.<lb/> FREIGHT SERVICE BY STEAM BARGES BETWEEN <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> AND <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>.<lb/> Working in conjunction and under special arrangement with the<lb/> “Upper <placeName ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName> Hotels Company."</p>
+                        <p>For details and illustrated programmes apply to "THE ANGLO-AMERICAN NILE STEAMER and<lb/> HOTEL COMPANY."</p>
+                        <p> OFFICES IN <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> : Sharia Boulac, "Grand Continental Hotel Buildings.” 31-3-06</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-nll02">
                         <head>NORDDEUTSCHER LLOYD.</head>
@@ -669,9 +481,7 @@
                         <p>The following steamers are intended to leave <placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName> : </p>
                         <table rows="14" cols="3">
                             <row>
-                                <cell cols="3">HOMEWARD : for Bremen Hamburg via <placeName
-                                        ref="https://www.wikidata.org/wiki/Q2634">Naples</placeName>
-                                    , Genoa, (Gibraltar), Southampton, Antwerp.</cell>
+                                <cell cols="3">HOMEWARD : for Bremen Hamburg via <placeName ref="https://www.wikidata.org/wiki/Q2634">Naples</placeName> , Genoa, (Gibraltar), Southampton, Antwerp.</cell>
                             </row>
                             <row>
                                 <cell>Zieten</cell>
@@ -699,11 +509,7 @@
                                 <cell>about 28 August</cell>
                             </row>
                             <row>
-                                <cell cols="3">OUTWARD: for <placeName
-                                        ref="https://www.wikidata.org/wiki/Q148">China</placeName>
-                                    and JAPAN via <placeName
-                                        ref="https://www.wikidata.org/wiki/Q134514"
-                                    >Suez</placeName>, ADEN, COLOMBO, PENANG, SINGAPORE.</cell>
+                                <cell cols="3">OUTWARD: for <placeName ref="https://www.wikidata.org/wiki/Q148">China</placeName> and JAPAN via <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>, ADEN, COLOMBO, PENANG, SINGAPORE.</cell>
                             </row>
                             <row>
                                 <cell>Prinz E. Friedrich</cell>
@@ -721,11 +527,7 @@
                                 <cell>about 7 August</cell>
                             </row>
                             <row>
-                                <cell cols="3">For <placeName
-                                        ref="https://www.wikidata.org/wiki/Q408"
-                                        >Australia</placeName> via <placeName
-                                        ref="https://www.wikidata.org/wiki/Q134514"
-                                    >Suez</placeName>, ADEN, COLOMBO.</cell>
+                                <cell cols="3">For <placeName ref="https://www.wikidata.org/wiki/Q408">Australia</placeName> via <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>, ADEN, COLOMBO.</cell>
                             </row>
                             <row>
                                 <cell>Seydlitz</cell>
@@ -744,19 +546,15 @@
                             </row>
                         </table>
                         <p>FOR FURTHER PARTICULARS APPLY TO THE AGENTS OF THE </p>
-                        <p>NORDDEUTSCHER LLOYD at <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> , <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>, <placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName>  and <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>. </p>
+                        <p>NORDDEUTSCHER LLOYD at <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> , <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>, <placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName> and <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>. </p>
                         <p>OTTO STERZING, Agent In <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> , Opera Square. </p>
                         <p>C. H. SCHOELLER, Agent In <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>, Cleopatra Lane.</p>
-                        <p>Messrs. THOS. COOK &amp; SON (<placeName ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName>) LTD., and CARL STANGENS REISEBUREAN are
-                            anthorised to sell tickets in <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>  and <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>, 31-8-905</p>
+                        <p>Messrs. THOS. COOK &amp; SON (<placeName ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName>) LTD., and CARL STANGENS REISEBUREAN are anthorised to sell tickets in <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> and <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>, 31-8-905</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-als01">
                         <head>Austrian Lloyd’s Steam Navigation</head>
                         <p><placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>-Brindisi-Venice-Trieste.</p>
-                        <p>Weekly Express Mail Service. Steamers leave <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> every Saturday at 4 p.m.
-                            arrive at Brindisi, Tuesday a.m. in time for express to <placeName ref="https://www.wikidata.org/wiki/Q90">Paris</placeName>, <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName>, <placeName ref="https://www.wikidata.org/wiki/Q2634">Naples</placeName> ,
-                            Rome. Arrival Trieste Wednesday noon connecting with Vienna Express
-                            (Trieste-Ostende through carriage) and expresses to Italy and Germany.</p>
+                        <p>Weekly Express Mail Service. Steamers leave <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> every Saturday at 4 p.m. arrive at Brindisi, Tuesday a.m. in time for express to <placeName ref="https://www.wikidata.org/wiki/Q90">Paris</placeName>, <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName>, <placeName ref="https://www.wikidata.org/wiki/Q2634">Naples</placeName> , Rome. Arrival Trieste Wednesday noon connecting with Vienna Express (Trieste-Ostende through carriage) and expresses to Italy and Germany.</p>
                         <table rows="3" cols="8">
                             <row>
                                 <cell>July 8</cell>
@@ -789,8 +587,7 @@
                                 <cell/>
                             </row>
                         </table>
-                        <p>Fortnightly Service: <placeName ref="https://www.wikidata.org/wiki/Q87"
-                                >Alexandria</placeName>-Brindisi-Venice-Trieste </p>
+                        <p>Fortnightly Service: <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>-Brindisi-Venice-Trieste </p>
                         <table rows="1" cols="8">
                             <row>
                                 <cell>June 21</cell>
@@ -803,41 +600,23 @@
                                 <cell>Capt. Knezevich</cell>
                             </row>
                         </table>
-                        <p>(Departures from <placeName ref="https://www.wikidata.org/wiki/Q134514"
-                                >Suez</placeName>) To Aden, <placeName
-                                ref="https://www.wikidata.org/wiki/Q1156">Bombay</placeName>,
-                            Colombo, Penang, Singapore, Hong-Kong, Shanghai, Yokohama, Kobé about
-                            July 5 and August 4. To Aden, Karachi, and <placeName
-                                ref="https://www.wikidata.org/wiki/Q1156">Bombay</placeName>
-                            accelerated service about August 18. To Aden, Karachi, <placeName
-                                ref="https://www.wikidata.org/wiki/Q1156">Bombay</placeName>,
-                            Colombo, Madras, Rangoon, and Calcutta about July 20.</p>
+                        <p>(Departures from <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>) To Aden, <placeName ref="https://www.wikidata.org/wiki/Q1156">Bombay</placeName>, Colombo, Penang, Singapore, Hong-Kong, Shanghai, Yokohama, Kobé about July 5 and August 4. To Aden, Karachi, and <placeName ref="https://www.wikidata.org/wiki/Q1156">Bombay</placeName> accelerated service about August 18. To Aden, Karachi, <placeName ref="https://www.wikidata.org/wiki/Q1156">Bombay</placeName>, Colombo, Madras, Rangoon, and Calcutta about July 20.</p>
                         <p>East African Line.</p>
-                        <p>To Aden, Mombassa, Zanzibar, Beira, Delagoa Bay, Durban, about July 4 and
-                            August 3.</p>
+                        <p>To Aden, Mombassa, Zanzibar, Beira, Delagoa Bay, Durban, about July 4 and August 3.</p>
                         <p>Syrian-Cyprus-Caramanian Line.</p>
                         <p>Steamers leaves <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> on or about July 3, 17 and 31.</p>
-                        <p>For information apply to the Agents, <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>, <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> and <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>, Thos. Cook
-                            &amp; Son, Ld., Leon Heller, <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>  Agent, 4, Sharia Maghraby, (Telephone 192),
-                            <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> ; F. Tedeschi, Helouan.</p>
-                        <p>Special passage rates granted to Egyptian Government officials, members of the
-                            Army of Occupation and their families. </p>
+                        <p>For information apply to the Agents, <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>, <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> and <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>, Thos. Cook &amp; Son, Ld., Leon Heller, <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> Agent, 4, Sharia Maghraby, (Telephone 192), <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> ; F. Tedeschi, Helouan.</p>
+                        <p>Special passage rates granted to Egyptian Government officials, members of the Army of Occupation and their families. </p>
                         <p>31-12-905</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-pap01">
                         <head>THE PAPAYANNI LINE.</head>
                         <head type="sub">(The Ellerman Lines, Ltd.)</head>
-                        <p>Frequent Sailings from <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> to <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName>, also Regular Services from
-                            <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName> to <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> and to ALGERIA, <placeName ref="https://www.wikidata.org/wiki/Q233">Malta</placeName>, LEVANT, BLACK SEA, and other
-                            Mediterranean Ports.</p>
-                        <p>Excellent Passenger Accommodation. Stewardess carried. Liberal table and Moderate
-                            Fares for single and retnrn tickets. </p>
-                        <p>The S S. SARDINIA will sail for <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName> (via Bona) on Friday, the 7th inst. at
-                            4 p.m.</p>
-                        <p>CARGO taken by special agreement only. Through Freights quoted for the UNITED
-                            STATES and INLAND TOWNS in GREAT BRITAIN.</p>
-                        <p>For passage or freight apply to the Agents, BARKER &amp; Co., <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>.
-                            2061-17-10-905 </p>
+                        <p>Frequent Sailings from <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> to <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName>, also Regular Services from <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName> to <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> and to ALGERIA, <placeName ref="https://www.wikidata.org/wiki/Q233">Malta</placeName>, LEVANT, BLACK SEA, and other Mediterranean Ports.</p>
+                        <p>Excellent Passenger Accommodation. Stewardess carried. Liberal table and Moderate Fares for single and retnrn tickets. </p>
+                        <p>The S S. SARDINIA will sail for <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName> (via Bona) on Friday, the 7th inst. at 4 p.m.</p>
+                        <p>CARGO taken by special agreement only. Through Freights quoted for the UNITED STATES and INLAND TOWNS in GREAT BRITAIN.</p>
+                        <p>For passage or freight apply to the Agents, BARKER &amp; Co., <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>. 2061-17-10-905 </p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-ell01">
                         <head>Ellerman Lines, Limited.</head>
@@ -845,29 +624,18 @@
                             <row>
                                 <cell cols="3">CITY LINE to <placeName ref="https://www.wikidata.org/wiki/Q233">Malta</placeName>, <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName>, COLOMBO &amp; CALCUTTA.</cell>
                                 <cell cols="3">
-                                    <p>CITY &amp; HALL LINES. Joint Service to <placeName
-                                            ref="https://www.wikidata.org/wiki/Q579613"
-                                            >Marseilles</placeName>, <placeName
-                                            ref="https://www.wikidata.org/wiki/Q24826"
-                                            >Liverpool</placeName>, <placeName
-                                            ref="https://www.wikidata.org/wiki/Q1156"
-                                            >Bombay</placeName> &amp; KARACHI.</p>
+                                    <p>CITY &amp; HALL LINES. Joint Service to <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName>, <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName>, <placeName ref="https://www.wikidata.org/wiki/Q1156">Bombay</placeName> &amp; KARACHI.</p>
                                 </cell>
                             </row>
                             <row>
-                                <cell cols="6">The undermentioned First Class Passenger Steamers
-                                    will be dispatched from <placeName
-                                        ref="https://www.wikidata.org/wiki/Q134509">Port
-                                        Said</placeName> on or about the following dates for </cell>
+                                <cell cols="6">The undermentioned First Class Passenger Steamers will be dispatched from <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> on or about the following dates for </cell>
                             </row>
                             <row>
-                                <cell><placeName ref="https://www.wikidata.org/wiki/Q233">Malta</placeName> and <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> </cell>
+                                <cell><placeName ref="https://www.wikidata.org/wiki/Q233">Malta</placeName> and <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName>
+                                </cell>
                                 <cell>S.S. City of Corinth </cell>
                                 <cell>July 26</cell>
-                                <cell><placeName ref="https://www.wikidata.org/wiki/Q579613"
-                                        >Marseilles</placeName> and <placeName
-                                        ref="https://www.wikidata.org/wiki/Q24826"
-                                        >Liverpool</placeName></cell>
+                                <cell><placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName> and <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName></cell>
                                 <cell/>
                                 <cell/>
                             </row>
@@ -875,32 +643,23 @@
                                 <cell>Colombo and Calcutta</cell>
                                 <cell>S.S. City of Manchester</cell>
                                 <cell>July 12</cell>
-                                <cell><placeName ref="https://www.wikidata.org/wiki/Q1156"
-                                        >Bombay</placeName></cell>
+                                <cell><placeName ref="https://www.wikidata.org/wiki/Q1156">Bombay</placeName></cell>
                                 <cell>S.S. Anton Hall</cell>
                                 <cell>July 13</cell>
                             </row>
                         </table>
-                        <p>SALOON FARES:—<placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> to <placeName ref="https://www.wikidata.org/wiki/Q233">Malta</placeName> £4.10.0. <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName>. £8.0.0. <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> or
-                            <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName>, £l2.l0.0. Colombo, Calcutta, <placeName ref="https://www.wikidata.org/wiki/Q1156">Bombay</placeName> or Karachi, £35.0.0. Special
-                            rates for steamers not carrying Doctor or Stewardess. For further particulars
-                            apply to </p>
-                        <p>CORY BROS. &amp; Co., Ltd., Agents for CITY Line, <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>: W. STAPLEDON &amp;
-                            SON, Agents for Hall Line, <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> ; or COOK &amp; SON (<placeName ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName>), Ltd., <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> .
-                            23788-28-8-905 </p>
+                        <p>SALOON FARES:—<placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> to <placeName ref="https://www.wikidata.org/wiki/Q233">Malta</placeName> £4.10.0. <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName>. £8.0.0. <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> or <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName>, £l2.l0.0. Colombo, Calcutta, <placeName ref="https://www.wikidata.org/wiki/Q1156">Bombay</placeName> or Karachi, £35.0.0. Special rates for steamers not carrying Doctor or Stewardess. For further particulars apply to </p>
+                        <p>CORY BROS. &amp; Co., Ltd., Agents for CITY Line, <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>: W. STAPLEDON &amp; SON, Agents for Hall Line, <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> ; or COOK &amp; SON (<placeName ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName>), Ltd., <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> . 23788-28-8-905 </p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-ngi01">
                         <head>Navigation Générale Italienne.</head>
-                        <p>Societes Reunies Florio-Rubattino. - Services Postaux. - Departs de
-                            Juillet.</p>
+                        <p>Societes Reunies Florio-Rubattino. - Services Postaux. - Departs de Juillet.</p>
                         <table rows="5" cols="4">
                             <row>
                                 <cell>Les Jeudis</cell>
                                 <cell>6, 13, 20, et 27</cell>
                                 <cell>à 3 h. p.m.</cell>
-                                <cell>direct pour Messine, <placeName
-                                        ref="https://www.wikidata.org/wiki/Q2634">Naples</placeName>
-                                    , Livourne et Gênes.</cell>
+                                <cell>direct pour Messine, <placeName ref="https://www.wikidata.org/wiki/Q2634">Naples</placeName> , Livourne et Gênes.</cell>
                             </row>
                             <row>
                                 <cell>Les Samedis</cell>
@@ -918,9 +677,7 @@
                                 <cell>Le Lundi</cell>
                                 <cell>24</cell>
                                 <cell>à 4 h. p.m.</cell>
-                                <cell>pour Port-Saïd, <placeName
-                                        ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>
-                                    et Massawah.</cell>
+                                <cell>pour Port-Saïd, <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName> et Massawah.</cell>
                             </row>
                             <row>
                                 <cell>Le Vendredi</cell>
@@ -934,27 +691,15 @@
                         <head>NATIONAL BANK OF <placeName ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName>.</head>
                         <p>CAPITAL: L. 2,500,000. RESERVE (ENVIRON) : L. 862,000.</p>
                         <p>Gouverneur: Sir ELWIN PALMER, K.C.B., K.C.M.G.</p>
-                        <p>Siège Social au Caire, Succursale à <placeName
-                                ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>,
-                            Agence à Assiout, Assuoan, Benha, Beni-Suef, Chibin el Kom, Damanhour,
-                            Fayoum, Khartoum, Kéneh, Mansourah. Minieh, <placeName
-                                ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName> ,
-                            Suakin, Sohag, Tantah, Zagazig, Mouski (Caire) et Londres (4 et 5, King
-                            William Street).</p>
-                        <p>La National Bank of <placeName ref="https://www.wikidata.org/wiki/Q79"
-                                >Egypt</placeName> reçoit des dépots à termes fixes, fait des
-                            avances et ouvre des comptes courants sur titres, valeurs et
-                            marchandises. Elle s’occupe de l’achat et de la vente d'effets sur
-                            l’Etranger, de l'escompte, ainsi que de toutes opérations de Banque.
-                            31-12-904</p>
+                        <p>Siège Social au Caire, Succursale à <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>, Agence à Assiout, Assuoan, Benha, Beni-Suef, Chibin el Kom, Damanhour, Fayoum, Khartoum, Kéneh, Mansourah. Minieh, <placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName> , Suakin, Sohag, Tantah, Zagazig, Mouski (Caire) et Londres (4 et 5, King William Street).</p>
+                        <p>La National Bank of <placeName ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName> reçoit des dépots à termes fixes, fait des avances et ouvre des comptes courants sur titres, valeurs et marchandises. Elle s’occupe de l’achat et de la vente d'effets sur l’Etranger, de l'escompte, ainsi que de toutes opérations de Banque. 31-12-904</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-abw01">
                         <head><placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> BONDED WAREHOUSE COMPANY, LTD.</head>
                         <p>(Société des Entrepôts d'Alexandrie)</p>
                         <p>Bonded Warehouses</p>
                         <p>IN <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>, <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> , <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>, AND <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>.</p>
-                        <p>Special Departments for clearing and forwarding and for a luggage and parcel
-                            Express Service.</p>
+                        <p>Special Departments for clearing and forwarding and for a luggage and parcel Express Service.</p>
                         <p>Goods delivered against cash for account of shippers. 1-6-906</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-ela01">
@@ -962,11 +707,8 @@
                         <p>LIFE The Edinburgh Life Assurance Company.</p>
                         <p>MARINE Union Insurance Society of Canton (Limited).</p>
                         <p>FIDELITY National Guarantee &amp; Suretyship Association (Limited).</p>
-                        <p>Risks accepted at Tariff rates. -- Claimes liberally and promptly
-                            settled.</p>
-                        <p>Agents for <placeName ref="https://www.wikidata.org/wiki/Q79"
-                                >Egypt</placeName>: HEWAT &amp; Co., <placeName
-                                ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>.</p>
+                        <p>Risks accepted at Tariff rates. -- Claimes liberally and promptly settled.</p>
+                        <p>Agents for <placeName ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName>: HEWAT &amp; Co., <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>.</p>
                     </div>
                 </div>
             </div>
@@ -992,20 +734,13 @@
                         <p>Codes-- ABC, 4th and 5th Editions, A1.</p>
                         <p>MORNING &amp; NEAL'S.</p>
                         <p>Trade Mark — “INVINCIBLE."</p>
-                        <p>MANUFACTURERS OF THE LARGEST AND MOST EFFICIENT Centrifugal Pumping Machinery In
-                              the world, suitable fcr all purposes, including RECLAMATION, DRAINAGE,
-                              IRRIGATION, SEWAGE WORKS, GRAVING &amp; FLOATING DOCKS, MINES, &amp; ALL
-                              MANUFACTURING PURPOSES.</p>
-                        <p>These Pumps can be driven by Steam, Gas, Oil, Water, Electricity, or other power,
-                              for Lifts of from 1 ft. to 500ft., and from 5 to 500,000 Gallons a Minute.
-                              Makers of the Mex Pumps.</p>
+                        <p>MANUFACTURERS OF THE LARGEST AND MOST EFFICIENT Centrifugal Pumping Machinery In the world, suitable fcr all purposes, including RECLAMATION, DRAINAGE, IRRIGATION, SEWAGE WORKS, GRAVING &amp; FLOATING DOCKS, MINES, &amp; ALL MANUFACTURING PURPOSES.</p>
+                        <p>These Pumps can be driven by Steam, Gas, Oil, Water, Electricity, or other power, for Lifts of from 1 ft. to 500ft., and from 5 to 500,000 Gallons a Minute. Makers of the Mex Pumps.</p>
                         <p>Results Guaranteed.</p>
                         <p>Over 50 Years' Practical Experience.</p>
-                        <p>All kinds of Pumping and Irrigation Machinery specially designed to meet Egyptian
-                              requirements.</p>
+                        <p>All kinds of Pumping and Irrigation Machinery specially designed to meet Egyptian requirements.</p>
                         <p>London Offices— 81, Cannon Street, London, E.C.</p>
-                        <p>The British Engineering Company of Egypt, Ltd: Rue de la Gare du Caire,
-                              Alexandria.</p>
+                        <p>The British Engineering Company of Egypt, Ltd: Rue de la Gare du Caire, Alexandria.</p>
                         <p>Works- Hammersmith, London, W</p>
                         <p>23362-11-12-904</p>
                     </div>
@@ -1013,10 +748,8 @@
                         <head>THE ARTESIAN BORING AND PROSPECTING COMPANY.</head>
                         <p>(SOCIÉTÉ ANONYME)</p>
                         <p>CAIRO, 28, SHARIA-EL-MANAKH,<lb/> (OPPOSITE IMPERIAL OTTOMAN BANK).</p>
-                        <p>I. —Installation of complete Water supplies for drinking, agricultural, and<lb/>
-                              industrial purposes by means of artesian wells.</p>
-                        <p>II. - Deep borings for prospecting purposes in all conditions of soil by means of
-                              the<lb/> “Express Boring System."</p>
+                        <p>I. —Installation of complete Water supplies for drinking, agricultural, and<lb/> industrial purposes by means of artesian wells.</p>
+                        <p>II. - Deep borings for prospecting purposes in all conditions of soil by means of the<lb/> “Express Boring System."</p>
                         <p>24,437-12-1-905</p>
                     </div>
                     <cols n="2"/>
@@ -1027,30 +760,21 @@
                         <p>Subscribed Capital JS1.500,000</p>
                         <p> Paid up '' £ 500,000</p>
                         <p>Reserve Fund... 500,000</p>
-                        <p>The Anglo-Egyptian Bank. Limited, undertakes every description of banking
-                              business on the most favourable conditions.</p>
-                        <p>Current accounts opened with commercial homes and private individuals in
-                              conformity with the custom of Bankers.</p>
-                        <p>Fixed deposits for one year certain received at 8 per cent. per annum. Deposits
-                              at interest for shorter periods are also received at rates to be agreed upon.</p>
-                        <p>Letters of Credit for the use of travellers are issued payable in all parts of
-                              the World.</p>
+                        <p>The Anglo-Egyptian Bank. Limited, undertakes every description of banking business on the most favourable conditions.</p>
+                        <p>Current accounts opened with commercial homes and private individuals in conformity with the custom of Bankers.</p>
+                        <p>Fixed deposits for one year certain received at 8 per cent. per annum. Deposits at interest for shorter periods are also received at rates to be agreed upon.</p>
+                        <p>Letters of Credit for the use of travellers are issued payable in all parts of the World.</p>
                         <p>Approved bills discounted.</p>
                         <p>Bills, documentary invoices, etc, collected.</p>
                         <p>Drafts and telegraphic transfers issued payable all over the World.</p>
                         <p>Foreign exchange bought and sold.</p>
-                        <p>Advances made upon approved securities and upon cotton, cotton-seed, sugar and
-                              other merchandise.</p>
-                        <p>The purchase and sale of stocks and shares on the London Stock Exchange; and on
-                              the local and Continental Bourses, undertaken.</p>
-                        <p>Customers can deposit their valuables, bonds, etc., for safe custody in the
-                              Bank's fire-proof strong-rooms, and the Bank will attend to the collection of
-                              the coupons and drawn bonds so deporited as they fall due.</p>
+                        <p>Advances made upon approved securities and upon cotton, cotton-seed, sugar and other merchandise.</p>
+                        <p>The purchase and sale of stocks and shares on the London Stock Exchange; and on the local and Continental Bourses, undertaken.</p>
+                        <p>Customers can deposit their valuables, bonds, etc., for safe custody in the Bank's fire-proof strong-rooms, and the Bank will attend to the collection of the coupons and drawn bonds so deporited as they fall due.</p>
                         <p>Mercantile credits issued.</p>
                         <p>Annuities, pensions, dividends, etc., collected.</p>
                         <p>All farther particulars and information can be obtained on application.</p>
-                        <p>The officers and clerks of the Bank are pledged to secrecy as to the transactions
-                              of customers. 18-9-905</p>
+                        <p>The officers and clerks of the Bank are pledged to secrecy as to the transactions of customers. 18-9-905</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-cgg01">
                         <head>CHAMPAGNE GEORGE GOULET.</head>
@@ -1071,10 +795,8 @@
                         <p>DIRECT IMPORTER OF BRITISH AND IRISH TEXTILE MANUFACTURES.</p>
                         <p>LADIES’ SUMMER STOCKINGS.</p>
                         <p> IN SPUN SILK at P.T. 20 per pair.</p>
-                        <p>LISLE THREAD, in plain and lace open-work, in black, white, tan and usual shades,
-                              to suit boots worn in Egypt, frpm P.T. 5 per pair.</p>
-                        <p>Every pair is marked “Au De Rouge" which is a guarantee that the Color is
-                              absolutely fast and stainless.</p>
+                        <p>LISLE THREAD, in plain and lace open-work, in black, white, tan and usual shades, to suit boots worn in Egypt, frpm P.T. 5 per pair.</p>
+                        <p>Every pair is marked “Au De Rouge" which is a guarantee that the Color is absolutely fast and stainless.</p>
                         <p>24916-15-11-905</p>
                     </div>
                     <!-- TODO Ask for John B. Caffari -->
@@ -1086,7 +808,7 @@
                         <p>Brewers, Burton-on-Trent and Romford.</p>
                         <p>Pale Ale &amp; Double Stout, specially brewed for export.</p>
                         <p>Agents: Messrs. John Ross &amp; Co., Alexandria &amp; Cairo:</p>
-                        <p>48047  30-2-904</p>
+                        <p>48047 30-2-904</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-jbc01">
                         <head>John B. Caffari's "Economical Stores"</head>
@@ -1101,11 +823,9 @@
                     <div type="item" scope="advertisement" xml:id="deg-ad-eeh01">
                         <head>EASTERN EXCHANGE HOTEL, PORT SAID.</head>
                         <p>First Class Hotel. Modern in all respects.</p>
-                        <p>Fire-proof, Drained to the Sea, Lifts, Electric Light, English and French
-                              Billiards, Fresh and Salt Water Baths.</p>
+                        <p>Fire-proof, Drained to the Sea, Lifts, Electric Light, English and French Billiards, Fresh and Salt Water Baths.</p>
                         <p>The Coolest Summer Residence in Egypt.</p>
-                        <p>Special terms to Cairo Residents and their families desirous of enjoying the cool
-                              air and sea bathing during the summer months.</p>
+                        <p>Special terms to Cairo Residents and their families desirous of enjoying the cool air and sea bathing during the summer months.</p>
                         <p>Dragomans in Hotel Uniform Meet all Trains and Steamers.</p>
                         <p>22941-23-8-905</p>
                     </div>
@@ -1117,10 +837,8 @@
                         <p>The most charming Sea-side Residence in Egypt.</p>
                         <p>First Class Family Hotel with Every Modern Comfort.</p>
                         <p>Unique Situation on the Beach.</p>
-                        <p>Lovely Garden. Lawn Tennis. Large Terrace. Electric Light. Sea Baths. Own
-                              springs. Perfect sanitary arrangements. Stables for horses and carriages.</p>
-                        <p>Moderate Charges. -- Special terms for Government Officials and Officers of the
-                              Army of Occupation.</p>
+                        <p>Lovely Garden. Lawn Tennis. Large Terrace. Electric Light. Sea Baths. Own springs. Perfect sanitary arrangements. Stables for horses and carriages.</p>
+                        <p>Moderate Charges. -- Special terms for Government Officials and Officers of the Army of Occupation.</p>
                         <p>252-17.1.906</p>
                         <p>G. RUNCKEWITZ, Proprietor.</p>
                     </div>
@@ -1163,8 +881,7 @@
                     <div type="item" scope="advertisement" xml:id="deg-ad-spa01">
                         <head>Spathi's Grill Room.</head>
                         <p>Old Bourse St., Alexandria.</p>
-                        <p>Greatly enlarged and improved. New Chef. Unrivalled cooking. English specially
-                              catered for</p>
+                        <p>Greatly enlarged and improved. New Chef. Unrivalled cooking. English specially catered for</p>
                         <p>2063-14-1-906</p>
                     </div>
                     <cols n="1"/>
@@ -1379,17 +1096,17 @@
                     </div>
                 </div>
                 <div type="item" scope="calendar">
-                    <table cols="3" xml:id="CalendarOfTheWeek">
-                        <head>Calendar of Coming Events.</head>
-                        <div type="subsection">
-                            <head>Alexandria</head>
-                            <head type="sub">October</head>
+                    <head>Calendar of Coming Events.</head>
+                    <div type="subsection">
+                        <head>Alexandria</head>
+                        <head type="sub">October</head>
+                        <table cols="3" xml:id="CalendarOfComingEvents-Alexandria">
                             <row>
                                 <cell>Tues.</cell>
                                 <cell>3</cell>
                                 <cell>
                                     <p>E.T.C. Cricket Match. Seniors v.<lb/>Juniors. 1.30 p.m.</p>
-                                    <p>Mex Casino.  Reunion des Familles.<lb/>9.30 p.m.</p>
+                                    <p>Mex Casino. Reunion des Familles.<lb/>9.30 p.m.</p>
                                     <p>Mex. Prineaas' Restaurant des Bisins<lb/>Roumanian orchestra, every afternoon<lb/>Sundays, morning.</p>
                                     <p>Windsor Hotel. Orchestra. 6 to<lb/>11:30 p.m. every day.</p>
                                     <p>Alhambra -- Italian company --<lb/>I fourchambault. 9.15 p.m.</p>
@@ -1412,34 +1129,36 @@
                                     <p>B.R.C. Mustapha Pasha Range.<lb/>Practice and Cup Compeittion.<lb/>3 p.m.</p>
                                 </cell>
                             </row>
-                        </div>
+                        </table>
                         <div type="subsection">
                             <head>Cairo</head>
                             <head type="sub">October</head>
-                            <row>
-                                <cell>Tues.</cell>
-                                <cell>3</cell>
-                                <cell>
-                                    <p>Esbekieh Gardens. Performances by<lb/>British Military Band. 9 to 11 p.m.</p>
-                                    <p>Esbekieh Theater. French Operetta<lb/>Company.  9.15 p.m.</p>
-                                    <p>Tehatre des Nouvesutes. 9.30 p.m.</p>
-                                    <p>Aloazar Parisien. 9.30 p.m.</p>
-                                </cell>
-                            </row>
-                            <row>
-                                <cell>Fri.</cell>
-                                <cell>6</cell>
-                                <cell>
-                                    <p>Esbekieh Gardens. Performances by<lb/>British Military Band. 9 to 11 p.m.</p>
-                                </cell>
-                            </row>
-                            <row>
-                                <cell>Mon.</cell>
-                                <cell>16</cell>
-                                <cell>Cairo Musical and Dramatic Society.<lb/>Concert in aid of Calabrian Victims.<lb/>Distinguished Patronage.</cell>
-                            </row>
+                            <table>
+                                <row>
+                                    <cell>Tues.</cell>
+                                    <cell>3</cell>
+                                    <cell>
+                                        <p>Esbekieh Gardens. Performances by<lb/>British Military Band. 9 to 11 p.m.</p>
+                                        <p>Esbekieh Theater. French Operetta<lb/>Company. 9.15 p.m.</p>
+                                        <p>Tehatre des Nouvesutes. 9.30 p.m.</p>
+                                        <p>Aloazar Parisien. 9.30 p.m.</p>
+                                    </cell>
+                                </row>
+                                <row>
+                                    <cell>Fri.</cell>
+                                    <cell>6</cell>
+                                    <cell>
+                                        <p>Esbekieh Gardens. Performances by<lb/>British Military Band. 9 to 11 p.m.</p>
+                                    </cell>
+                                </row>
+                                <row>
+                                    <cell>Mon.</cell>
+                                    <cell>16</cell>
+                                    <cell>Cairo Musical and Dramatic Society.<lb/>Concert in aid of Calabrian Victims.<lb/>Distinguished Patronage.</cell>
+                                </row>
+                            </table>
                         </div>
-                    </table>
+                    </div>
                 </div>
                 <div type="item" scope="advertisement" xml:id="deg-ad-whr01">
                     <head>WINDSOR HOTEL Restaurant.</head>
@@ -1450,23 +1169,12 @@
                 <cb n="2"/>
                 <div type="item" scope="newspaper">
                     <head>THE EGYPTIAN GAZETTE.</head>
-                    <p>SUBSCRIPTIONS.—Alexandria, Cairo, and the Interior of Egypt (including
-                        delivery in Alexandria or postage to subscriber’s address) P.T. 231½ per
-                        annum, P.T. 116 for six months, P.T. 80 for three months. To other countries
-                        in the Postal Union P.T. 273 (£2.16s.) per annum. Six months P.T. 136½
-                        (£1.8s.), three months P.T. 92 (£0.19s.) N.B.—Subscriptions commence from
-                        the 1st or 16th of any month. </p>
-                    <p>ADVERTISEMENTS.—P.T. 4 per line. Minimum charge P.T. 20. Births, Marriages,
-                        or Deaths, not exceeding three lines, P.T. 20. Every additional line P.T.
-                        10. Notices in news column P.T. 20 per line. Contracts entered into for
-                        standing advertisements. </p>
-                    <p>SUBSCRIPTIONS and ADVERTISEMENTS are due in advance. P.O. Orders and Cheques
-                        to be made payable to the Editor and Manager, Rowland Snelling, Alexandria. </p>
+                    <p>SUBSCRIPTIONS.—Alexandria, Cairo, and the Interior of Egypt (including delivery in Alexandria or postage to subscriber’s address) P.T. 231½ per annum, P.T. 116 for six months, P.T. 80 for three months. To other countries in the Postal Union P.T. 273 (£2.16s.) per annum. Six months P.T. 136½ (£1.8s.), three months P.T. 92 (£0.19s.) N.B.—Subscriptions commence from the 1st or 16th of any month. </p>
+                    <p>ADVERTISEMENTS.—P.T. 4 per line. Minimum charge P.T. 20. Births, Marriages, or Deaths, not exceeding three lines, P.T. 20. Every additional line P.T. 10. Notices in news column P.T. 20 per line. Contracts entered into for standing advertisements. </p>
+                    <p>SUBSCRIPTIONS and ADVERTISEMENTS are due in advance. P.O. Orders and Cheques to be made payable to the Editor and Manager, Rowland Snelling, Alexandria. </p>
                     <p>London Offices : 36, New Broad-street. B.C. </p>
-                    <p>THE EGYPTIAN GAZETTE can be obtained in London at our office, 36, New Broad
-                        Street, E.C., and also at Messrs. May &amp; Williams 160, Piccadilly, W. </p>
-                    <p>THE “EGYPTIAN GAZETTE” IS PRINTED ON PAPER MANUFACTURED AND SUPPLIED BY THE
-                        LONDON PAPER MILLS Co., LIMITED (SALES OFFICE: 27, CANNON STREET, E.C.) </p>
+                    <p>THE EGYPTIAN GAZETTE can be obtained in London at our office, 36, New Broad Street, E.C., and also at Messrs. May &amp; Williams 160, Piccadilly, W. </p>
+                    <p>THE “EGYPTIAN GAZETTE” IS PRINTED ON PAPER MANUFACTURED AND SUPPLIED BY THE LONDON PAPER MILLS Co., LIMITED (SALES OFFICE: 27, CANNON STREET, E.C.) </p>
                 </div>
                 <div type="item" scope="newspaper">
                     <p>The Egyptian Gazette </p>
@@ -1485,421 +1193,213 @@
                         <head>MACEDONIAN FINANCIAL CONTROL.</head>
                         <head type="sub">SULTAN'S INSTRUCT IONS</head>
                         <dateline>Constantinople. October 3.</dateline>
-                        <p>The Porte's vote to the Ambassadors says that the Sultan is firmly
-                            resolved not to depart from his views as to the superfluity of financial
-                            control by the Powers in Macedonia, which constitutes an infraction on
-                            his Sovereign rights The authorities have been instructed not to
-                            recognise the financial delegates of the Powers, who have been sent to
-                            Salonika.</p>
+                        <p>The Porte's vote to the Ambassadors says that the Sultan is firmly resolved not to depart from his views as to the superfluity of financial control by the Powers in Macedonia, which constitutes an infraction on his Sovereign rights The authorities have been instructed not to recognise the financial delegates of the Powers, who have been sent to Salonika.</p>
                         <byline>(R)</byline>
                     </div>
                     <div type="article">
-                        <head>JAPANS COMMERCE INTRODUCTION OF FOREIGN CAPITAL Tokyo October
-                            3.</head>
-                        <p>At the meeting of the Associated Chambers of Commerce here the Minister
-                            of Commerce intimated that the Government is preparing to improve the
-                            internal communications, and that the introduction of foreign capital
-                            will be facilitated. The Vice-Minister of Finance urged the merchants to
-                            do their utmost, for the development of foreign trade.</p>
+                        <head>JAPANS COMMERCE INTRODUCTION OF FOREIGN CAPITAL Tokyo October 3.</head>
+                        <p>At the meeting of the Associated Chambers of Commerce here the Minister of Commerce intimated that the Government is preparing to improve the internal communications, and that the introduction of foreign capital will be facilitated. The Vice-Minister of Finance urged the merchants to do their utmost, for the development of foreign trade.</p>
                         <byline>(Reuter)</byline>
                     </div>
                     <div type="article">
                         <head>another imperial ukase</head>
                         <head>ELECTION OF NATIONAL ASSEMBLY.</head>
                         <dateline><placeName>St.</placeName> Petersburg, October 3.</dateline>
-                        <p>A Ukase orders the immediate preparation of regulations for the elections
-                            for the National Assembly.</p>
+                        <p>A Ukase orders the immediate preparation of regulations for the elections for the National Assembly.</p>
                         <byline>(Reuter)</byline>
                     </div>
                     <div type="article">
                         <head>FINNISH REVOLT.</head>
-                        <p><placeName>St. Petersburg</placeName>, October 3. Depots of arms and
-                            munitions are continually being found in Finland.</p>
+                        <p><placeName>St. Petersburg</placeName>, October 3. Depots of arms and munitions are continually being found in Finland.</p>
                         <byline>(Reuter)</byline>
                     </div>
                     <div type="article">
-                        <head>GERMANY AND <placeName ref="https://www.wikidata.org/wiki/Q148"
-                                >China</placeName>.</head>
+                        <head>GERMANY AND <placeName ref="https://www.wikidata.org/wiki/Q148">China</placeName>.</head>
                         <head>THE COMMERCIAL TREATY.</head>
                         <dateline><placeName>Berlin</placeName>, October 3.</dateline>
-                        <p>Sheng Koung Pao, the Chinese representative of the Germano-Chinese
-                            commercial treaty negotiations, has arrived here. The negotiations will
-                            begin to morrow.</p>
+                        <p>Sheng Koung Pao, the Chinese representative of the Germano-Chinese commercial treaty negotiations, has arrived here. The negotiations will begin to morrow.</p>
                         <byline>(Reuter)</byline>
                     </div>
                     <div type="article">
                         <head>THE GERMANS AND CZECHS. POLICE QUASH DEMONSTRATION.</head>
                         <dateline><placeName>Brunn</placeName>, October 3.</dateline>
-                        <p>In consequence of disputes between the Germans and Czechs the troops
-                            dispersed the demonstrators.</p>
+                        <p>In consequence of disputes between the Germans and Czechs the troops dispersed the demonstrators.</p>
                         <byline>(Havas)</byline>
                     </div>
                     <div type="article">
                         <head>STRIKES IN BERLIN.</head>
                         <dateline><placeName>Berlin</placeName>, October 3.</dateline>
-                        <p>Thirty-eight thousand electricians have gone on strike. The tramway
-                            service is suffering.</p>
+                        <p>Thirty-eight thousand electricians have gone on strike. The tramway service is suffering.</p>
                         <byline>(Havas)</byline>
                     </div>
                     <div type="article">
                         <head>THE MANILA HURRICANE. TWO STEAMERS LOST.</head>
                         <dateline><placeName>Manila</placeName>, October 3.</dateline>
-                        <p>Two inter-insular steamers were lost in the recent hurricane in the
-                            Philippines, and 144 persons were drowned. The damage done to the hemp
-                            plantations and warehouses is estimated at a million sterling. </p>
+                        <p>Two inter-insular steamers were lost in the recent hurricane in the Philippines, and 144 persons were drowned. The damage done to the hemp plantations and warehouses is estimated at a million sterling. </p>
                         <byline>(Reuter)</byline>
                     </div>
                     <div type="article">
                         <head>COUNT BRAZZA S FUNERAL.</head>
-                        <dateline><placeName><placeName ref="https://www.wikidata.org/wiki/Q90"
-                                    >Paris</placeName></placeName>, October 3.</dateline>
-                        <p>The State funeral of Count de Brazza took place yesterday and was largely
-                            attended.</p>
+                        <dateline><placeName><placeName ref="https://www.wikidata.org/wiki/Q90">Paris</placeName></placeName>, October 3.</dateline>
+                        <p>The State funeral of Count de Brazza took place yesterday and was largely attended.</p>
                         <byline>(Havas)</byline>
                     </div>
                     <div type="article">
                         <head>DEATH OF A POET.</head>
-                        <dateline><placeName><placeName ref="https://www.wikidata.org/wiki/Q90"
-                                    >Paris</placeName></placeName>, October 3.</dateline>
-                        <p>The poet Heredia is dead.</p>
-                        <byline>(Havas)</byline>
-                        <p>Of Creole origin and Spanish tastes and sympathies, Joaé-Maria de Heredia was the most exotic of modern French poets in choice of subjects, the most sonorously Latin in style. Much might be written on the metrical and artistic merits of his work ; enough that be looked on life and history as a pageant, end was swift to seize every colour and every grouping that pleased his eye and to reproduce its beauty in stately verse. A master of metrical form, he was at his best in the sonnet. His series of poems on ancient Egypt, the sonnets that describe the loves of Antony and Cleopatra with the extraordinary battle-piece commencing his chock avait ele tres rude, les tribute" , are <unclear reason="ink smudged">____</unclear>passed of their</p>
+                        <div type="item">
+                            <dateline><placeName ref="https://www.wikidata.org/wiki/Q90">Paris</placeName>, October 3.</dateline>
+                            <p>The poet Heredia is dead.</p>
+                        </div>
+                        <div type="item">
+                            <byline>(Havas)</byline>
+                            <p>Of Creole origin and Spanish tastes and sympathies, Joaé-Maria de Heredia was the most exotic of modern French poets in choice of subjects, the most sonorously Latin in style. Much might be written on the metrical and artistic merits of his work ; enough that be looked on life and history as a pageant, end was swift to seize every colour and every grouping that pleased his eye and to reproduce its beauty in stately verse. A master of metrical form, he was at his best in the sonnet. His series of poems on ancient Egypt, the sonnets that describe the loves of Antony and Cleopatra with the extraordinary battle-piece commencing his chock avait ele tres rude, les tribute" , are <unclear reason="ink smudged">____</unclear>passed of their</p>
+                        </div>
                     </div>
                 </div>
                 <div type="section">
                     <head>LOCAL AND GENERAL.</head>
                     <div type="article">
-                        <p>The Austro-Hangarian diplomatic agency has transferred its offices to
-                                <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>
-                            .</p>
+                        <p>The Austro-Hangarian diplomatic agency has transferred its offices to <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> .</p>
                     </div>
                     <div type="article">
-                        <head>Gold for <placeName ref="https://www.wikidata.org/wiki/Q79"
-                                >Egypt</placeName></head>
-                        <p>We are informed that the Crédit Lyonnais has received one million of
-                            pounds sterling in gold.</p>
+                        <head>Gold for <placeName ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName></head>
+                        <p>We are informed that the Crédit Lyonnais has received one million of pounds sterling in gold.</p>
                     </div>
                     <div type="article">
                         <head>The Sucreries.</head>
-                        <p>We hear that a number of the employes of the Sacrerios company have been
-                            dismissed for reasons of economy.</p>
+                        <p>We hear that a number of the employes of the Sacrerios company have been dismissed for reasons of economy.</p>
                     </div>
                     <div type="article">
-                        <head>The Bank or <placeName ref="https://www.wikidata.org/wiki/Q79"
-                                >Egypt</placeName> Ltd</head>
-                        <p>We are informed that the Zagazig agency of the Bank of <placeName
-                                ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName> Ltd. is
-                            row represented by Messrs. Gustave Jullien and Cesar Giordano who will
-                            sign conjointly as agents.</p>
+                        <head>The Bank or <placeName ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName> Ltd</head>
+                        <p>We are informed that the Zagazig agency of the Bank of <placeName ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName> Ltd. is row represented by Messrs. Gustave Jullien and Cesar Giordano who will sign conjointly as agents.</p>
                     </div>
                     <div type="article">
                         <head>Council of Ministers.</head>
-                        <p>The Council of Ministers will meet on Monday next. Among the agenda of
-                            the day will be the appointment of a successor to Hassan Bey Wassif,
-                            ex-Mondir of Girgeh, imprisoned for the part he played in the Rifaa
-                            affair.</p>
+                        <p>The Council of Ministers will meet on Monday next. Among the agenda of the day will be the appointment of a successor to Hassan Bey Wassif, ex-Mondir of Girgeh, imprisoned for the part he played in the Rifaa affair.</p>
                     </div>
                     <div type="article">
-                        <p>The Brindisi Mail, which arrived at <placeName
-                                ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>
-                            early this morning, will be forwarded to <placeName
-                                ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> by
-                            the train arriving at 7.35 p.m. Letters will be distributed at a quarter
-                            past nine to-night, and newspapers, etc. by first delivery to-morrow
-                            morning.</p>
+                        <p>The Brindisi Mail, which arrived at <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> early this morning, will be forwarded to <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> by the train arriving at 7.35 p.m. Letters will be distributed at a quarter past nine to-night, and newspapers, etc. by first delivery to-morrow morning.</p>
                     </div>
                     <div type="article">
                         <head>Sudan Government.</head>
-                        <p>Bimbashi <persName>A. A. C. Taylor</persName>, junior inspector,
-                            Bahr-el-Ghazal Province has been appointed junior inspector, Berber
-                            Province. Bimbashi <persName>H. W. Channer</persName>, 3rd Battalion,
-                            transferred to the Sudan Government, has been appointed junior
-                            inspector, Bahr-el-Ghazal Province, and Bimbashi <persName>F. C.
-                                Heneker</persName>, junior inspector, Kassala Province, is
-                            re-transferred to the Amy.</p>
+                        <p>Bimbashi <persName>A. A. C. Taylor</persName>, junior inspector, Bahr-el-Ghazal Province has been appointed junior inspector, Berber Province. Bimbashi <persName>H. W. Channer</persName>, 3rd Battalion, transferred to the Sudan Government, has been appointed junior inspector, Bahr-el-Ghazal Province, and Bimbashi <persName>F. C. Heneker</persName>, junior inspector, Kassala Province, is re-transferred to the Amy.</p>
                     </div>
                     <div type="article">
                         <head>The Cattle Plaque</head>
-                        <p>The Sanitary Department has ordered the veterinary inspectors to make a
-                            careful and thorough inspection of all the districts comprised in the
-                            province of Fayoum and those which lie to the north with the view to
-                            ascertaining the state of the towns and villages and to make certain of
-                            the entire disappearance of the cattle plague. It is believed that these
-                            steps have been taken as a preliminary to granting the necessary
-                            permission for the re-opening of the markets belonging to the Egyptian
-                            Markets Company, which have now been closed tor over two years.</p>
+                        <p>The Sanitary Department has ordered the veterinary inspectors to make a careful and thorough inspection of all the districts comprised in the province of Fayoum and those which lie to the north with the view to ascertaining the state of the towns and villages and to make certain of the entire disappearance of the cattle plague. It is believed that these steps have been taken as a preliminary to granting the necessary permission for the re-opening of the markets belonging to the Egyptian Markets Company, which have now been closed tor over two years.</p>
                     </div>
                     <div type="article">
                         <head>Fsbekieh Gardens Theatre.</head>
-                        <p>English playgoers in <placeName ref="https://www.wikidata.org/wiki/Q85"
-                                >Cairo</placeName> will be pleased to learn that Mr.
-                                <persName>Santini</persName> has obtained the necessary
-                            authorisation for a series of performances to be given by an English
-                            operetta and variety company, commencing from the 1st proximo. Mr. David
-                            B. Warwick, who came out to <placeName
-                                ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName> at the end
-                            of last month to make the preliminary arrangements, has now returned to
-                            England to bring out his troupe. Later in the season Mr. Leonidas, with
-                            his excellent variety company and performing animals, which performed
-                            with such success before the Cairene public in the beginning of last
-                            year, will return for a season of about one month. At present this
-                            troupe is performing at Constantinople and have appeared more than once
-                            at the Sultan's private theatre in Yildiz Kiosk.</p>
+                        <p>English playgoers in <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> will be pleased to learn that Mr. <persName>Santini</persName> has obtained the necessary authorisation for a series of performances to be given by an English operetta and variety company, commencing from the 1st proximo. Mr. David B. Warwick, who came out to <placeName ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName> at the end of last month to make the preliminary arrangements, has now returned to England to bring out his troupe. Later in the season Mr. Leonidas, with his excellent variety company and performing animals, which performed with such success before the Cairene public in the beginning of last year, will return for a season of about one month. At present this troupe is performing at Constantinople and have appeared more than once at the Sultan's private theatre in Yildiz Kiosk.</p>
                     </div>
                 </div>
                 <div type="section">
                     <head>PERSONAL AND SOCIAL.</head>
                     <div type="article">
-                        <p>It is reported that H.H. the Khedive will visit the Mansourah
-                            Agricultural Show on the 20th and 31st inst. and return to <placeName
-                                ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> on the
-                            25th inst.</p>
+                        <p>It is reported that H.H. the Khedive will visit the Mansourah Agricultural Show on the 20th and 31st inst. and return to <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> on the 25th inst.</p>
                     </div>
                     <div type="article">
-                        <p><persName ref="http://islamsci.mcgill.ca/RASI/BEA/Ahmad_Mukhtar_BEA.htm"
-                                >Ghazi Mukhtar</persName> Pasha will arrive at <placeName
-                                ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> by
-                            the Norddentscher Lloyd S S. Schleswig on Monday.</p>
+                        <p><persName ref="http://islamsci.mcgill.ca/RASI/BEA/Ahmad_Mukhtar_BEA.htm">Ghazi Mukhtar</persName> Pasha will arrive at <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> by the Norddentscher Lloyd S S. Schleswig on Monday.</p>
                     </div>
                     <div type="article">
-                        <p>The Judicial Adviser is expected to arrive at <placeName
-                                ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> to night
-                            from <placeName ref="https://www.wikidata.org/wiki/Q134509">Port
-                                Said</placeName>.</p>
+                        <p>The Judicial Adviser is expected to arrive at <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> to night from <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>.</p>
                     </div>
                     <div type="article">
-                        <p>Mr. M. de C. Findlay, C.M.G., acting British Agent, and Mr. Rumbold, 2nd
-                            Secretary to the British Agency, will return to <placeName
-                                ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> next
-                            week.</p>
+                        <p>Mr. M. de C. Findlay, C.M.G., acting British Agent, and Mr. Rumbold, 2nd Secretary to the British Agency, will return to <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> next week.</p>
                     </div>
                     <div type="article">
-                        <p><persName>Adly Pasha Yeghen</persName>, Governor of <placeName
-                                ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> , is
-                            expected to arrive in <placeName ref="https://www.wikidata.org/wiki/Q79"
-                                >Egypt</placeName> at the end of this month.</p>
+                        <p><persName>Adly Pasha Yeghen</persName>, Governor of <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> , is expected to arrive in <placeName ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName> at the end of this month.</p>
                     </div>
-                    <div type="article">
-                        <p>Amongst those arriving at <placeName
-                                ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>
-                            this morning by the P. &amp; O. mail boat Isis were Sir Elwin Palmer,
-                            Governor of the National Bank Mr. McGillivary, and Captain McMurdo.</p>
+                    <div type="wireReport">
+                        <p>Amongst those arriving at <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> this morning by the P. &amp; O. mail boat Isis were Sir Elwin Palmer, Governor of the National Bank Mr. McGillivary, and Captain McMurdo.</p>
                     </div>
-                    <div type="article">
-                        <p>Dr. Ruffer, President of the Quarantine Board, will return to <placeName
-                                ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> on
-                            October 8.</p>
+                    <div type="wireReport">
+                        <p>Dr. Ruffer, President of the Quarantine Board, will return to <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> on October 8.</p>
                     </div>
-                    <div type="article">
-                        <p>We greatly regret to announce the death of Mr. Samuel Gurney Sheppard,
-                            Chairman of the Aboukir Company, Limited, which occurred yesterday
-                            morning.</p>
+                    <div type="wireReport">
+                        <p>We greatly regret to announce the death of Mr. Samuel Gurney Sheppard, Chairman of the Aboukir Company, Limited, which occurred yesterday morning.</p>
                     </div>
-                    <div type="article">
-                        <p>Lieutenant C. E. G. Woollcombe-Adams, Royal Artillery, who has arrived in
-                                <placeName ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName>
-                            from England, has been taken on the strength of the Egyptian Army with
-                            the rank of Bimbaabi and is posted to the Artillery.</p>
+                    <div type="wireReport">
+                        <p>Lieutenant C. E. G. Woollcombe-Adams, Royal Artillery, who has arrived in <placeName ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName> from England, has been taken on the strength of the Egyptian Army with the rank of Bimbaabi and is posted to the Artillery.</p>
                     </div>
-                    <div type="article">
-                        <p>El Bimbashi A. J. B. Percival, D. S. O, Camel Corps, has been appointed
-                            local Kaima kam, whilst acting officer commanding the 15th Sudanese.</p>
+                    <div type="wireReport">
+                        <p>El Bimbashi A. J. B. Percival, D. S. O, Camel Corps, has been appointed local Kaima kam, whilst acting officer commanding the 15th Sudanese.</p>
                     </div>
-                    <div type="article">
-                        <p>M G. M. d'Ory, the new Spanish Minister to the Khédivial Government, is
-                            staying at Shepheards Hotel.</p>
+                    <div type="wireReport">
+                        <p>M G. M. d'Ory, the new Spanish Minister to the Khédivial Government, is staying at Shepheards Hotel.</p>
                     </div>
-                    <div type="article">
+                    <div type="wireReport">
                         <head>THE BRITISH ASSOCIATION.</head>
-                        <head type="sub">ARRIVAL AT <placeName
-                                ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>.</head>
+                        <head type="sub">ARRIVAL AT <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>.</head>
                         <p>( From a Correspondent ).</p>
-                        <p>(By Telegraph).	</p>
-                        <dateline><placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>, Wednesdays, 11.40 a.m.</dateline>
-                        <p>The members of the British Association among whom I recognised Professor Berry and Six Benjamin Baker, arrived bore this morning from South Africa by tho S.S. Durham Castle. One hundred and eighty members of the party are leaving for <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>  by special train and after spending a few days in the Capital will reembark for <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> at <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>.</p>
+                        <p>(By Telegraph). </p>
+                        <div type="item">
+                            <dateline><placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>, Wednesdays, 11.40 a.m.</dateline>
+                            <p>The members of the British Association among whom I recognised Professor Berry and Six Benjamin Baker, arrived bore this morning from South Africa by tho S.S. Durham Castle. One hundred and eighty members of the party are leaving for <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> by special train and after spending a few days in the Capital will reembark for <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> at <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>.</p>
+                        </div>
                     </div>
                     <div type="article">
                         <head>THE PHARMACY REGULATIONS. !</head>
-                        <p>A serions infringement of the pharmacy regulations, which have now been
-                            in operation for a little over a year is reported from <placeName
-                                ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> . A Greek,
-                            named Pistis, applied last year for authorisation to open the Pharmacie
-                            Hellenique, and forwarded at the same time to the Sanitary
-                            Administration what purported to be the diploma of the chemist who was
-                            to be in charge. The diploma proving to be authentic, the necessary
-                            permission was granted in January, but in May, on receipt of an
-                            anonymous communcation, enquiries were set on foot by the police
-                            authorities, with the result that it was discovered that the diploma in
-                            question to belonged to another man of the same nationality who had been
-                            dead since November, 1896. It is alleged that Pistis had purchased the
-                            deceased man's diploma from a local pharmacy where he hid been serving
-                            at the time of his death. The Parquet is now making fuller investigation
-                            before bringing the delinquent before the Native Tribunal for trial, hot
-                            in the meanwhile the accused has asked for an adjournment of the case
-                            for two months to enable him to prove his foreign nationality.</p>
+                        <p>A serions infringement of the pharmacy regulations, which have now been in operation for a little over a year is reported from <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> . A Greek, named Pistis, applied last year for authorisation to open the Pharmacie Hellenique, and forwarded at the same time to the Sanitary Administration what purported to be the diploma of the chemist who was to be in charge. The diploma proving to be authentic, the necessary permission was granted in January, but in May, on receipt of an anonymous communcation, enquiries were set on foot by the police authorities, with the result that it was discovered that the diploma in question to belonged to another man of the same nationality who had been dead since November, 1896. It is alleged that Pistis had purchased the deceased man's diploma from a local pharmacy where he hid been serving at the time of his death. The Parquet is now making fuller investigation before
+                            bringing the delinquent before the Native Tribunal for trial, hot in the meanwhile the accused has asked for an adjournment of the case for two months to enable him to prove his foreign nationality.</p>
                     </div>
                     <div type="article">
                         <head>SERIOUS RAILWAY ACCIDENT.</head>
-                        <p>A serions collision occured yesterday near Kassassin station between the
-                            passenger train which left Ismailia at 6.20 a.m. for Benha and another
-                            coming from the opposite direction. An official telegram recieved at the
-                            Ministry of the Interior stated that a third class carriage and several
-                            goods waggons were completely smashed, and that 23 persons had been more
-                            or less injured, one very seriously. On the news reaching Zagazig a
-                            special train was at once despatched to the scene of the accident,
-                            conveying the commandant of police, the substitute of the Parquet, and a
-                            medical officer. Most of the injured passengers were taken to the
-                            hospital at Ismailia.</p>
+                        <p>A serions collision occured yesterday near Kassassin station between the passenger train which left Ismailia at 6.20 a.m. for Benha and another coming from the opposite direction. An official telegram recieved at the Ministry of the Interior stated that a third class carriage and several goods waggons were completely smashed, and that 23 persons had been more or less injured, one very seriously. On the news reaching Zagazig a special train was at once despatched to the scene of the accident, conveying the commandant of police, the substitute of the Parquet, and a medical officer. Most of the injured passengers were taken to the hospital at Ismailia.</p>
                     </div>
                     <div type="article">
-                        <head><placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>
-                            DRAINAGE.</head>
-                        <p>The Sanitary Administration has decided to extend the drains for rain
-                            water which were commenced about three years ago, and is at present
-                            engaged upon studying the possibility of adopting some method whereby
-                            these drains can be made available when the time comes for a proper
-                            system of sewers for draining the houses to be undertaken. As the
-                            streets of the Capital that are not yet supplied with drains become
-                            impassable, sometimes for days, whenever there is a heavy rainfall, it
-                            is to be hoped that the work now in contemplation will be taken in hand
-                            without any farther delay. That the city was well drained one or two
-                            centuries ago was fully proved by the discoveries that were made at the
-                            time the first drains for rain water were being constructed, and which
-                            greatly simplified the task of the engineers and contractors entrusted
-                            with the work.</p>
+                        <head><placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> DRAINAGE.</head>
+                        <p>The Sanitary Administration has decided to extend the drains for rain water which were commenced about three years ago, and is at present engaged upon studying the possibility of adopting some method whereby these drains can be made available when the time comes for a proper system of sewers for draining the houses to be undertaken. As the streets of the Capital that are not yet supplied with drains become impassable, sometimes for days, whenever there is a heavy rainfall, it is to be hoped that the work now in contemplation will be taken in hand without any farther delay. That the city was well drained one or two centuries ago was fully proved by the discoveries that were made at the time the first drains for rain water were being constructed, and which greatly simplified the task of the engineers and contractors entrusted with the work.</p>
                     </div>
                     <div type="article">
                         <head>THE NUBARIEH CANAL.</head>
-                        <p>An official communication was sent yesterday to the Press bureau whereby
-                            the Ministry of Public Works notifies for public informaiton that the
-                            statement published recently by some of the local papers to the effect
-                            that it was intended to prolong the Nubarieh Canal, for the irrigation
-                            of some of the lands situated in the northern parte of <placeName
-                                ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName>, is
-                            incorrect ; and the Government thinks it its duty to declare that it
-                            intends to conform stirctly to the notification that appeared in the
-                            “Journal Officiel" of the 31st May last, to the effect that it has no
-                            intention of prolonging this canal in the near future. This decision was
-                            originally taken some months ago, when Sir William Garstin recommended
-                            that the sale of Government waste lands should be suspended until the
-                            question of a farther supply of water for irrigation purposes has been
-                            finally settled.</p>
+                        <p>An official communication was sent yesterday to the Press bureau whereby the Ministry of Public Works notifies for public informaiton that the statement published recently by some of the local papers to the effect that it was intended to prolong the Nubarieh Canal, for the irrigation of some of the lands situated in the northern parte of <placeName ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName>, is incorrect ; and the Government thinks it its duty to declare that it intends to conform stirctly to the notification that appeared in the “Journal Officiel" of the 31st May last, to the effect that it has no intention of prolonging this canal in the near future. This decision was originally taken some months ago, when Sir William Garstin recommended that the sale of Government waste lands should be suspended until the question of a farther supply of water for irrigation purposes has been finally settled.</p>
                     </div>
                     <div type="article">
                         <head>STEAMER MOVEMENTS.</head>
                         <p>The S.S. Persian Prince from Antwerp, left <placeName ref="https://www.wikidata.org/wiki/Q233">Malta</placeName> yesterday with a general cargo and is due to arrive at <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> on Saturday.</p>
-                        <p>The Khedivial express mail steamship El Kahira will leave <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> at 4 p.m. on Saturday, <placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName>  at 4 p.m on Sunday for Beyrouth, Tripoli, Meriana, Alexandretta, Larnaca, Limassol, Caiffa and Jaffa.</p>
+                        <p>The Khedivial express mail steamship El Kahira will leave <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> at 4 p.m. on Saturday, <placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName> at 4 p.m on Sunday for Beyrouth, Tripoli, Meriana, Alexandretta, Larnaca, Limassol, Caiffa and Jaffa.</p>
                     </div>
                     <div type="article">
                         <!-- ADVERTIESMENT? -->
                         <head>BERLITZ SCHOOLS OF LANGUAGES</head>
                         <p>236 BRANCHES.</p>
-                        <p>French, German, Italian, Greek, Arabic, etc. Private Lessons, Residence
-                            Lessons, taught by Native Masters.</p>
-                        <p><placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>
-                            ; 26 Rue de l'Eglise Copte.</p>
-                        <p><placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> : 1
-                            Sharia Kamel.</p>
+                        <p>French, German, Italian, Greek, Arabic, etc. Private Lessons, Residence Lessons, taught by Native Masters.</p>
+                        <p><placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> ; 26 Rue de l'Eglise Copte.</p>
+                        <p><placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> : 1 Sharia Kamel.</p>
                         <p>TRIAL Lesson Free.</p>
                     </div>
                 </div>
                 <div type="section">
-                    <head>NOTES FROM <placeName ref="https://www.wikidata.org/wiki/Q134509">Port
-                            Said</placeName>.</head>
+                    <head>NOTES FROM <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>.</head>
                     <div type="article">
                         <head>THE CHATHAM WRECKAGE</head>
                         <byline>(From our Correspondent.)</byline>
-                        <dateline><placeName ref="https://www.wikidata.org/wiki/Q134509">Port
-                                Said</placeName> Tuesday.</dateline>
-                        <p>I notice several intereating bat absolutely ridiculous articles in local
-                            and other journals on the subject of the probability of there stillbeing
-                            quantities of explosives, lying loose as it were, at the bottom of the
-                            canal. After the explosion you will remember that certain rough
-                            roundings were taken which revealed little beyond the foot that the
-                            middle of the canal had been partially filled up, and that a large hole
-                            had been blown in the east bank. Careful and complete lines of soundings
-                            were made on Thursday, Friday, and Saturday, and since that date divers
-                            have lean engaged walking about the canal bed round kilometre 18,
-                            finding the pieces of ship which are scattered about. The thorough
-                            examinations made have shown that not a single trace of the forward part
-                            of the vessel is now to be found anywhere near the spot where the vessel
-                            originally lay ; the desert for a mile round the scene of the explosion
-                            is smothered in pieces of steel torn out of the ship, and coke and pig
-                            iron, of which the major part of the Chatham’s cargo was composed, cover
-                            the canal banks in all directions. Bearing these foots in mind, is it
-                            likely or even probable that even a portion of a case remains anywhere
-                            near the spot to testify to the explosion </p>
-                        <p>The divers who have been sent from France are now engaged breaking op the
-                            largest pieces of plate and frame which have been found; explosives are
-                            being used, and I hear that it is hoped that the worst part of the work
-                            will be all over by Thursday. The dredgers, of which there are six on
-                            the spot, are working behind the six divers and their accompanying
-                            derricks and shear legs, removing upwards of 5,000 cubic metres of sand
-                            per day. The largest piece of metal which has been so far lifted from
-                            the canal bed measures the astonishing length of over 80 feet and weighs
-                            something over 80 tons. Again, is it possible that any cases of
-                            explosives remain anywhere near where this unfortunate ship lay before
-                            she was blown up. The idea is ridiculous and absurd in the extreme.</p>
+                        <dateline><placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> Tuesday.</dateline>
+                        <p>I notice several intereating bat absolutely ridiculous articles in local and other journals on the subject of the probability of there stillbeing quantities of explosives, lying loose as it were, at the bottom of the canal. After the explosion you will remember that certain rough roundings were taken which revealed little beyond the foot that the middle of the canal had been partially filled up, and that a large hole had been blown in the east bank. Careful and complete lines of soundings were made on Thursday, Friday, and Saturday, and since that date divers have lean engaged walking about the canal bed round kilometre 18, finding the pieces of ship which are scattered about. The thorough examinations made have shown that not a single trace of the forward part of the vessel is now to be found anywhere near the spot where the vessel originally lay ; the desert for a mile round the scene of the explosion is smothered in pieces of steel torn out of the ship,
+                            and coke and pig iron, of which the major part of the Chatham’s cargo was composed, cover the canal banks in all directions. Bearing these foots in mind, is it likely or even probable that even a portion of a case remains anywhere near the spot to testify to the explosion </p>
+                        <p>The divers who have been sent from France are now engaged breaking op the largest pieces of plate and frame which have been found; explosives are being used, and I hear that it is hoped that the worst part of the work will be all over by Thursday. The dredgers, of which there are six on the spot, are working behind the six divers and their accompanying derricks and shear legs, removing upwards of 5,000 cubic metres of sand per day. The largest piece of metal which has been so far lifted from the canal bed measures the astonishing length of over 80 feet and weighs something over 80 tons. Again, is it possible that any cases of explosives remain anywhere near where this unfortunate ship lay before she was blown up. The idea is ridiculous and absurd in the extreme.</p>
                     </div>
                     <div type="article">
                         <head>THE CONGESTED HARBOUR.</head>
-                        <p>The harbour of <placeName ref="https://www.wikidata.org/wiki/Q134509"
-                                >Port Said</placeName> now shows signs of congestion in a marked
-                            degree. Besides the colliers there are no lees than 27 large vessels now
-                            in the harbour, several of which, for want of space, are being made fast
-                            to each other. The ships now here, in their order of arrival, are as
-                            follows :—Ping Sney, Rugia, Menelaus, Avoca, Mahratta and Meeton Hall
-                            (arrived 28th ulto); Staat_-Kratke, Persia, Weissenfels, and Langdale
-                            (arrived 29th). Statesman and Oxos, (arrived 30th). Ataka,Brida, Sicilia
-                            and Donally (arrived 1st inst) ; Yarra, Siam, Palermo, Sachsen and
-                            Arabistan (arrived 2nd inst) ; Goentor, Flores, Africa, and another
-                            arrived to-day. Counting coasting ships of the various kinds we have
-                            here to-day no less than 40 ships and still they come.</p>
+                        <p>The harbour of <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> now shows signs of congestion in a marked degree. Besides the colliers there are no lees than 27 large vessels now in the harbour, several of which, for want of space, are being made fast to each other. The ships now here, in their order of arrival, are as follows :—Ping Sney, Rugia, Menelaus, Avoca, Mahratta and Meeton Hall (arrived 28th ulto); Staat_-Kratke, Persia, Weissenfels, and Langdale (arrived 29th). Statesman and Oxos, (arrived 30th). Ataka,Brida, Sicilia and Donally (arrived 1st inst) ; Yarra, Siam, Palermo, Sachsen and Arabistan (arrived 2nd inst) ; Goentor, Flores, Africa, and another arrived to-day. Counting coasting ships of the various kinds we have here to-day no less than 40 ships and still they come.</p>
                     </div>
                     <div type="article">
                         <head>THE SUNKEN DREDGER.</head>
-                        <p>The work in connection with the salvage of the dredger Pharaon II. is at
-                            a standstill. It will be remembered that a mouth ago efforts were made
-                            to raise her, but that they were stultified owing to the collapse of ore
-                            of the double lighters. These are now all ready, and much improved,
-                            being internally strengthened, but the remains of the Chatham claim all
-                            the attention of the engineers staff, and it will probably be some time
-                            before this unfortunate craft sees the full light of day.</p>
+                        <p>The work in connection with the salvage of the dredger Pharaon II. is at a standstill. It will be remembered that a mouth ago efforts were made to raise her, but that they were stultified owing to the collapse of ore of the double lighters. These are now all ready, and much improved, being internally strengthened, but the remains of the Chatham claim all the attention of the engineers staff, and it will probably be some time before this unfortunate craft sees the full light of day.</p>
                     </div>
                     <div type="article">
                         <head>THE AUSTRIAN CONSUL.</head>
-                        <p>The Austrian Lloyd Africa which arrived to-day had on board the Austrian
-                            Consul, who returns after three month’s leave.</p>
+                        <p>The Austrian Lloyd Africa which arrived to-day had on board the Austrian Consul, who returns after three month’s leave.</p>
                     </div>
                     <div type="article">
                         <head>THE DANGERS OF THE RED SEA.</head>
-                        <p>A Board of Trade inquiry was concluded at Newosa le-on-Tyne on Saturday
-                            the 16th ult. into the circumstances attending the stranding of the
-                            steam ship Foyle, of <placeName ref="https://www.wikidata.org/wiki/Q84"
-                                >London</placeName>, in the Red Sea, on June 13. The vessel struck
-                            on the Mushejera Beef, 6 1/6 miles out of the intended course, and the
-                            master believed that she must have been set to the westward by a
-                            current. He was, he said, familiar with the Admiralty sailing
-                            directions, which said “Strong currents occasionally set across the Red
-                            Sea, so a good berth should be given to outlying reefs and shoals. That
-                            is the more necessary because the strength of those currents increases
-                            rapidly as the shoals are neared, and they form one of the chief
-                            obstacles to the safe navigation of the Red Sea, and to them are to be
-                            attributed the losses of several steamers daring recent years. A
-                            knowledge of their existence should impress mariners with the necessity
-                            of constant vigilance.” The Court found that the courses set and steered
-                            were safe and proper. The vessel was not navigated at too great a rate
-                            of speed. The most probable cause of the causalty was an unusually
-                            strong current setting the vessel to the westward alter she had passed
-                            Mokhah light, causing her to strand on Mushajera Island, whereby she
-                            sustained serious damage. The vessel was navigated with proper and
-                            seamanlike care, and the Court found that the master (Captain Alfred
-                            Thomas Page) and the officers were not in fault</p>
+                        <p>A Board of Trade inquiry was concluded at Newosa le-on-Tyne on Saturday the 16th ult. into the circumstances attending the stranding of the steam ship Foyle, of <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName>, in the Red Sea, on June 13. The vessel struck on the Mushejera Beef, 6 1/6 miles out of the intended course, and the master believed that she must have been set to the westward by a current. He was, he said, familiar with the Admiralty sailing directions, which said “Strong currents occasionally set across the Red Sea, so a good berth should be given to outlying reefs and shoals. That is the more necessary because the strength of those currents increases rapidly as the shoals are neared, and they form one of the chief obstacles to the safe navigation of the Red Sea, and to them are to be attributed the losses of several steamers daring recent years. A knowledge of their existence should impress mariners with the necessity of
+                            constant vigilance.” The Court found that the courses set and steered were safe and proper. The vessel was not navigated at too great a rate of speed. The most probable cause of the causalty was an unusually strong current setting the vessel to the westward alter she had passed Mokhah light, causing her to strand on Mushajera Island, whereby she sustained serious damage. The vessel was navigated with proper and seamanlike care, and the Court found that the master (Captain Alfred Thomas Page) and the officers were not in fault</p>
                     </div>
                 </div>
                 <div type="section">
-                    <head>ARCHÆOLOGY IN <placeName ref="https://www.wikidata.org/wiki/Q43"
-                            >Turkey</placeName>.</head>
+                    <head>ARCHÆOLOGY IN <placeName ref="https://www.wikidata.org/wiki/Q43">Turkey</placeName>.</head>
                     <div type="article" scope="letters">
                         <head>A SHORT REVIEW</head>
                         <p>(From a Constantinople Correspondent).</p>
@@ -1909,10 +1409,14 @@
                         <p>The sarcophagi of Sidon belong to the fifth and sixth centuries of Greek art To this same period, and to the third century also, belongs another interesting series of anthropoid sarcophagi.</p>
                         <p>There are two sarcophagi which have scenes borrowed from the legend of Phsedrus and are good specimens of Graeco-Roman art Amongst other Byzantine relica, mast be mentioned a fragment which very probably belonged to the sarcophagus of Constantine I. and his mother Helen.</p>
                         <p>But that which gives to the museum its especial character is the unique series of Phœnician sarcophagi from Sidon.</p>
-                        <p>Here two hypogœi side by side, hewn out of a bed of sandstone, the Ramleh of the Arabs, were laid bare and explored. One contained a diorite tomb of Tabnith, son of Eshmuuazar, King of Sidon. The other, divided into seven sepulchres, contained seventeen sarcophagi, one of which is that beautiful masterpiece, the tomb of Alexander. This sarcophagus, unique for its perfect preservation, is in an elongated form of a Greek temple. It is of Pentelic marble and is 3.18 metres long, 2.18 metres from base to roof, and 1.67 metres broad The base, on whioh it stands, juts out 14 centimeters; this base consists of a border surmounted by a moulding (torus) adorned with tresses, then a lintel, a scotia, a row of heart shapes, and a row of pearls. The cornice, projecting 065 metres from the body, consists of a double meander surmounting a row of ovals and pearls. This ornamentation in which plain surfaces alternate with the richest mouldings has been sculptured with a delicacy which gives the profile of the tomb an incomparable beauty of style. Between the pedestal and the cornice is the body of the sarcophagus properly speaking. It is 58 centimeters high, and is adorned with beautiful reliefs emblematical of the life and character of the great warrior to whose memory the tomb is evidently dedicated, one of these representing a cavalry engagement (probably that of Issus or Arbela). This beautiful shrine is in one hall of the building, and forms the centre of attraction to all corner. In the hall on the other side there is a sarcophagus, also from the royal necropolis of Saida, which rot so gloriously beautiful, may, nevertheless, for perfect work and life-like expression take the next place It is that of the Weepers. Unfortunately par of the roofing, the side, and a head, have been broken off. Like that of Alexander it is in the form of a Greek temple, and instead of the frieze sculptured on its ride has Iconic columns, five on the large sides, and two on the small. In between these columns, are figures, in relief, of women in every expression and posture of grief. The ornamentation is not at all so profuse as in that of Alexander, but it is the perfectly natural expression and pose of the figures, wonderfully done, which contitutes the beauty of the tomb. The set includes an Egyptian sarcophagus in black marble of a very fine grain, — the tomb of a woman, belonging to the fifth century. It is polished and was originally covered with hieroglyphics, which have since been obliterated. Although similar to the Egyptian style in the matter of shape, it differs as to the material, which is in this instance marble, whereas the Egyptian tomb was usally of wood.</p>
-                        <p>One of the most noteworthy features of these monumnets is the variety of the style, which is peculiar to such different epochs and countries. For in these contiguous hypoœi were found Egyptian and Phoenician tombs; others snob as that of Alexander, and three other email sarcophagi which probably came from Attica ; another is undoubtedly, from Lycia ; the tomb of the Satrap came from an Ionian school of sculpture; while the ‘Weepers’’ is the work of an Athenian. Moreover, as regards date, the “Satrap” tomb belongs to the early part of the 5th century; the Lycian to the end of that century, while the “Weepers” and the tomb of Alexander belong respectively to the beginning and end of the 4th century. Thus this collection of monuments, containing as it does relics of such a diversity as regards data and origin, is valuable inasmuch as it provides information concerning the funeral customs of the Phœnicians, who, as is known, had no art of their own. They often appropriated tombs made in other lands, as in tin case of King Tabnith, who bought in Egypt for his own use, a sarcophagus which had been need by an Egyptian general.</p>
+                        <p>Here two hypogœi side by side, hewn out of a bed of sandstone, the Ramleh of the Arabs, were laid bare and explored. One contained a diorite tomb of Tabnith, son of Eshmuuazar, King of Sidon. The other, divided into seven sepulchres, contained seventeen sarcophagi, one of which is that beautiful masterpiece, the tomb of Alexander. This sarcophagus, unique for its perfect preservation, is in an elongated form of a Greek temple. It is of Pentelic marble and is 3.18 metres long, 2.18 metres from base to roof, and 1.67 metres broad The base, on whioh it stands, juts out 14 centimeters; this base consists of a border surmounted by a moulding (torus) adorned with tresses, then a lintel, a scotia, a row of heart shapes, and a row of pearls. The cornice, projecting 065 metres from the body, consists of a double meander surmounting a row of ovals and pearls. This ornamentation in which plain surfaces alternate with the richest mouldings has been sculptured with a
+                            delicacy which gives the profile of the tomb an incomparable beauty of style. Between the pedestal and the cornice is the body of the sarcophagus properly speaking. It is 58 centimeters high, and is adorned with beautiful reliefs emblematical of the life and character of the great warrior to whose memory the tomb is evidently dedicated, one of these representing a cavalry engagement (probably that of Issus or Arbela). This beautiful shrine is in one hall of the building, and forms the centre of attraction to all corner. In the hall on the other side there is a sarcophagus, also from the royal necropolis of Saida, which rot so gloriously beautiful, may, nevertheless, for perfect work and life-like expression take the next place It is that of the Weepers. Unfortunately par of the roofing, the side, and a head, have been broken off. Like that of Alexander it is in the form of a Greek temple, and instead of the frieze sculptured on its ride has Iconic columns,
+                            five on the large sides, and two on the small. In between these columns, are figures, in relief, of women in every expression and posture of grief. The ornamentation is not at all so profuse as in that of Alexander, but it is the perfectly natural expression and pose of the figures, wonderfully done, which contitutes the beauty of the tomb. The set includes an Egyptian sarcophagus in black marble of a very fine grain, — the tomb of a woman, belonging to the fifth century. It is polished and was originally covered with hieroglyphics, which have since been obliterated. Although similar to the Egyptian style in the matter of shape, it differs as to the material, which is in this instance marble, whereas the Egyptian tomb was usally of wood.</p>
+                        <p>One of the most noteworthy features of these monumnets is the variety of the style, which is peculiar to such different epochs and countries. For in these contiguous hypoœi were found Egyptian and Phoenician tombs; others snob as that of Alexander, and three other email sarcophagi which probably came from Attica ; another is undoubtedly, from Lycia ; the tomb of the Satrap came from an Ionian school of sculpture; while the ‘Weepers’’ is the work of an Athenian. Moreover, as regards date, the “Satrap” tomb belongs to the early part of the 5th century; the Lycian to the end of that century, while the “Weepers” and the tomb of Alexander belong respectively to the beginning and end of the 4th century. Thus this collection of monuments, containing as it does relics of such a diversity as regards data and origin, is valuable inasmuch as it provides information concerning the funeral customs of the Phœnicians, who, as is known, had no art of their own. They often
+                            appropriated tombs made in other lands, as in tin case of King Tabnith, who bought in Egypt for his own use, a sarcophagus which had been need by an Egyptian general.</p>
                         <p>On this tomb is the following inscription in Phoenician "It is I, Tabnith, Priest of Astarte, King of the Sidonians, who lie in this tomb. O man I whoever thou art that shall discover this tomb, do not open my sepulchral chamber; nor trouble me For there is neither silver, gold, nor treasure beside me. I alone lie in this tomb. Open not this sepulcrhal chamber, as such an act is an abomination in the eyes of Astarte. If thou shouldst open my sepulcrhal chamber and shouldst come to trouble me, mayest thou never have posterity amongst the living under the son, nor bed among the dead.” The King has been removed from his "sepulchral” chamber, and is exposed under a glass case not far from the empty sarcophagus, and despite the course and abomination unto Astarte, no harm teems to have befallen Hamdi Bey for the desecration.</p>
-                        <p>A study of these monuments, taken alone, is of great aid in treeing the development of Greek style. Firstly, what has been a veritable revelation for science is the existence, at the brilliant epoch of Greek art, the fifth and fourth centuries B. C. of sarcophagi, in the form of temples decorated with bas reliefs. The most ancient sarcophagi of this style, which are known, are those of the Amazons, at present in the Vienna Museum (a moulding of which is in the Stamboul institution), and belong to the third century ; all the others are of Graeco-Roman style. Moreover the Sidon tombs may be considered the most perfect of funeral sculpture of the fifth and fourth centuries B.C. Finally each marks a date in the history of Greek sculpture.  The sarcophagus of the Satrap is the most perfect specimen of an art which must have flourished on the coasts of Ionia from the middle of the fourth century until the time of the Median Wars and of which the explorations at Eoheaus and Mitylene give one but faint impressions.</p>
+                        <p>A study of these monuments, taken alone, is of great aid in treeing the development of Greek style. Firstly, what has been a veritable revelation for science is the existence, at the brilliant epoch of Greek art, the fifth and fourth centuries B. C. of sarcophagi, in the form of temples decorated with bas reliefs. The most ancient sarcophagi of this style, which are known, are those of the Amazons, at present in the Vienna Museum (a moulding of which is in the Stamboul institution), and belong to the third century ; all the others are of Graeco-Roman style. Moreover the Sidon tombs may be considered the most perfect of funeral sculpture of the fifth and fourth centuries B.C. Finally each marks a date in the history of Greek sculpture. The sarcophagus of the Satrap is the most perfect specimen of an art which must have flourished on the coasts of Ionia from the middle of the fourth century until the time of the Median Wars and of which the explorations at
+                            Eoheaus and Mitylene give one but faint impressions.</p>
                         <p>The sarcophagus of "the Weepers” is the most beautiful example of the funeral art which inspired the sculptors of the fourth and third centuries.</p>
                         <p>Finally although tbs sarcophagus of Alexander has only definitely decided the question as to the polychrome of Greek sculpture and shown us to what perfection the masters of the end of the fourth centery, the contemporaries of Lysippus and Bryaxs had brought the art of decorative composition ; it, must be said that this sarcophagus is the greatest achievement of the art of the century for explaining the history of ancient sculpture.</p>
                         <p>The series of antrhopic sarcophagi, embracing more than four centuries, worthily completes this collection of Phœnician monuments and deserves profound study. In this series one traces the growth of the art from the time when the sculptor sought to imitate the mummy coffin with a more hardy substance than wood, that is to ray, in stone and marble ; then his attempts to give his work the form of a statue and portrait and then even to give it a human form reproducing the members and even adding an expression of natural detail ; finally, the Egyptian art and realistic work are abandoned for the pare conventional Greek type, in the formation of which the influence of Polycletian sculpture is noticeable.</p>
@@ -1928,343 +1432,128 @@
                         <!-- TODO SPORTS TABLE -->
                         <head>CRICKET.</head>
                         <head type="sub">E. T. C. SENIORS v. JUNIORS.</head>
-                        <p>This return match was played yesterday, and ended in a somewhat easy win
-                            for the Juniors by 146 runs. For the Juniors, Byrne played a fine
-                            innings of 103, not out. The Seniors did not do at all well against the
-                            bowling of Messrs. Harvey and Byrne, and were all out close on time for
-                            73, Steele being top scorer with 26. Scores :— Juniors.</p>
-                        <table> Mr. Harrison c. Hanley, b. R. McLean... 24 „ Henley c. Stacey, b.
-                            R.. McLean... 6 <row>
-                                <cell>„ Byrne not out... 108</cell>
-                            </row>
-                            <row>
-                                <cell>„ Chessman b. Steele.................. ... 26</cell>
-                            </row>
-                            <row>
-                                <cell>„ Blythman c. Lowell, b. R. McLean... 2</cell>
-                            </row>
-                            <row>
-                                <cell>„ Thurston not out................................. 43</cell>
-                            </row>
-                            <row>
-                                <cell>„ Harvey Scarth |</cell>
-                            </row>
-                            <row>
-                                <cell>„ Lees did not bat</cell>
-                            </row>
-                            <row>
-                                <cell>„ Lester „ Garfiled</cell>
-                            </row>
-                            <row>
-                                <cell>Extras ...................... 15</cell>
-                            </row>
-                            <row>
-                                <cell>Total for 4 wk's............. 219</cell>
-                            </row>
-                        </table>
-                        <head>Bowling</head>
+                        <p>This return match was played yesterday, and ended in a somewhat easy win for the Juniors by 146 runs. For the Juniors, Byrne played a fine innings of 103, not out. The Seniors did not do at all well against the bowling of Messrs. Harvey and Byrne, and were all out close on time for 73, Steele being top scorer with 26. Scores :— Juniors.</p>
+                        <div type="subsection">
+                            <table>
+                                <row>
+                                    <cell>Mr. Harrison c. Hanley, b. R. McLean... 24 „ Henley c. Stacey, b. R.. McLean... 6 </cell>
+                                    <cell>„ Byrne not out... 108</cell>
+                                </row>
+                                <row>
+                                    <cell>„ Chessman b. Steele.................. ... 26</cell>
+                                </row>
+                                <row>
+                                    <cell>„ Blythman c. Lowell, b. R. McLean... 2</cell>
+                                </row>
+                                <row>
+                                    <cell>„ Thurston not out................................. 43</cell>
+                                </row>
+                                <row>
+                                    <cell>„ Harvey Scarth |</cell>
+                                </row>
+                                <row>
+                                    <cell>„ Lees did not bat</cell>
+                                </row>
+                                <row>
+                                    <cell>„ Lester „ Garfiled</cell>
+                                </row>
+                                <row>
+                                    <cell>Extras ...................... 15</cell>
+                                </row>
+                                <row>
+                                    <cell>Total for 4 wk's............. 219</cell>
+                                </row>
+                            </table>
+                        </div>
+                        <div type="subsection">
+                            <table>
+                                <head>Bowling</head>
+                                <row>
+                                    <cell/>
+                                </row>
+                            </table>
+                        </div>
                     </div>
                 </div>
             </div>
             <div type="page" n="4">
                 <head>THE Egyptian GAZETTE, WEDNESDAY OCTOBER 4, 1905</head>
                 <div type="article">
-                    <head><persName ref="http://www.oxforddnb.com/view/article/39736"
-                            >Saltin</persName> PASHA &amp; THE SUDAN.</head>
-                    <p>awakened, like the fellaheen in Upper <placeName
-                            ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName>, to the
-                        advantages of money, and realise that they can only obtain it by the sweat
-                        of then brows. "Hence," says <persName
-                            ref="http://www.oxforddnb.com/view/article/39736">Slatin</persName>
-                        Pasha, “with tin</p>
-                    <p>We recently published an interview with Sir R. von <persName
-                            ref="http://www.oxforddnb.com/view/article/39736">Slatin</persName>
-                        Pasha by a "Standard” correspondent, and we now add the leading article
-                        which that paper devoted to the work of the Inspector General of the
-                        Sudan.</p>
-                    <p>Among the men of our own time, none, we think, has a more romantic record
-                        than <persName ref="http://www.oxforddnb.com/view/article/39736"
-                            >Slatin</persName> Pasha, the gallant Austrian appointed by General
-                        Gordon to be Governor of Darfur, who afterwards fell into the Mahdi's hands,
-                        and survived the tortures of his long captivity to become Inspector General,
-                        under Sir Reginald <persName
-                            ref="http://www.oxforddnb.com/view/article/36977">Wingate</persName>, of
-                        the region over which his conqueror had exercised a ruthless terrorism. It
-                        is with great pleasure that we have published, the account of a long
-                        conversation held by our representative with a modern hero as
-                        '‘much-enduring" as Odysseus himself. Restored to the civilisation which he
-                        has help ed to construct, Sir Radolph <persName
-                            ref="http://www.oxforddnb.com/view/article/39736">Slatin</persName>
-                        shows no more trace of his sufferings and travail than the Ithacan wanderer,
-                        and has addressed himself to administrative problems with as fresh an energy
-                        and as alert an intelligence as any hopeful novice fresh from his
-                        examination for the Indian Civil Servie. The man who was dragged in chains
-                        by the Mahdi's horse, a symbol and victim of the False Prophet's fleeting
-                        triumph, has at his finger’s ends all the latest statistics as to the
-                        revenue of the reconquered provinces. He describes, with the concentrated
-                        interest of a practical philanthropist, the elaborate measures which have
-                        been taken or are being prepared for the improvement of railway and motor
-                        communication between the interior and the coast and for the irrigation of a
-                        thirsty land. It has been the privilege and delight of Lord <persName
-                            ref="http://www.oxforddnb.com/view/article/30583?docPos=1"
-                            >Cromer</persName> to enlist and instruct many zealous and intelligent
-                        subalterns in the great work of civilisations to which the least favorable
-                        critics of Great Britain yield unstinted praise; but no member of that
-                        memorable band has rendered better service or given shrewder counsel to his
-                        chief than the quiet, thoughtful gentleman who in twenty years has passed
-                        from imminent jeopardy of a living death back again to a career of
-                        beneficent activity. For the details of the industrial development which
-                            <persName ref="http://www.oxforddnb.com/view/article/39736"
-                            >Slatin</persName> Pasha supervises we may refer our readers to his own
-                        words, which present, in a concentrated form, the essence of the yearly
-                        reports published under Lord <persName
-                            ref="http://www.oxforddnb.com/view/article/30583?docPos=1"
-                            >Cromer</persName>'s authority. It is to the human aspect of his story
-                        that we weald direct especial attention, because this illustrates the signal
-                        success which, in every part of the world, attends British colonisers in
-                        their dealings with races of inferior or retarded development. Take, for
-                        instance, the missionary question. How do the Anglo-Egyptian authorities
-                        face that always thorny problem <persName
-                            ref="http://www.oxforddnb.com/view/article/39736">Slatin</persName>
-                        Pasha explains, in a few sentences, the principle on which they proceed.
-                        Roughly, the Sudan is divided into two political regions. The northern part
-                        is inhabited mainly, if not entirely, by Moslems, and on their fanatical
-                        faith and stereotyped stage of culture it has hitherto been found impossible
-                        for the evangelists of Christianity to make any sensible impression. As to
-                        the future, it would be inexcusable to hazard a general prophecy, but, at
-                        the present time, and in the Northern Sudan, it would endanger the permanent
-                        interests of civilisation if the Government were to sanction proselytising
-                        efforts which would surely be interpreted as an insidious and especially
-                        hateful form of political aggression. We must work more patiently, and be
-                        content with intermediate revolts. There are missionary schools established
-                        at Kharatoum for the children of Christian residents, and we are glad to
-                        learn that these are attended by young Moslems. But it is well
-                        understood—and the compact is faithfully observed—that these institutions
-                        are maintained for the purposes of general education, and not with a view to
-                        undermine the ancient religion of the people. In the southern districts of
-                        the Sudan the conditions are different, and another rule is observed. The
-                        people are pagans of a rather low type, and, knowing the Moslems chiefly as
-                        slave raiders, bear no affection for the faith of their persecutors. There
-                        the field is comparatively open to missionary enterprise, and has already
-                        yielded a certain spiritual harvest But the more prudent pioneers, of that
-                        light which the Western races are giving back to the Oriental source from
-                        which it was borrowed are content to move slowly, step by step. They make no
-                        raid on the polygamous custom which is the base of a primitive morality. To
-                        insist on the dismissal of all but s single — probably the most elderly —
-                        wife would not merely be a sacrifice that would appal the hesitating
-                        convert. It would also shake the social system of the tribe, deprive
-                        innocent women of their reoognieed status, and brand innumerable children
-                        with an unintelligible illegitimacy.</p>
-                    <p>Similar caution had at first to be observed in the treatment of another
-                        "domestic institution.” The barbarities of the slave trade have been
-                        summarily suppressed throughout the Sudan. "There is no raiding on a big
-                        scale,” says <persName ref="http://www.oxforddnb.com/view/article/39736"
-                            >Slatin</persName> Pasha. Isolated revivals are attempted in remote
-                        spots and kidnapping is sometimes reported. But the delinquents are sharply
-                        punched, and the dangers that attend the sport—for that is the light in
-                        which it presents itself to Arab adventurers — are generally understood.
-                        “The traffic in human flesh," we are told, "has practically ceased." We
-                        would not aver that it is nowhere possible to purchase a slave-girl, but the
-                        business has become clandestine and is rapidly dying away. Nevertheless, the
-                        absolute abolition of slavery, which was decreed after Lord Kitchener’s
-                        re-conquest of the Sudan, was not without its drawbacks. As in our West
-                        Indies and in the United States, a race which had hitherto worked only under
-                        compulsion did not easily take to voluntary labour. By degrees, however, the
-                        lazy, easy-going but not unintelligent negroes have agreement and assistance
-                        of the Arab population, we are gradually changing the status of slavery into
-                        one of paid labour.' This, ha adds, "will be liked by both master and
-                        servant” For that revolution of sentiment we must be content to wait a
-                        generation. It is not in human nature either for employers to relish paying
-                        money for work that they used to get for nothing, or for employes to have
-                        their reward proportioned to the amount of energy that they put into their
-                        task. We have our wages problems and labour troubles even in this
-                        enlightened land. Other discontent in the Sudan there seems to be none—none,
-                        at least, of a dangerous kind. There are trilab feuds which the Government
-                        has to check with a cold, impartial hand. And not long ago crack-brained
-                        pretender tried to set up a new religion and proclaimed himself to be the
-                        "Prophet Jesus.” We have witnessed similar phenomena nearer home. It is
-                        interesting to note that the Sudanese impostor only suceeded in winning
-                        eleven disciples. <persName
-                            ref="http://www.oxforddnb.com/view/article/39736">Slatin</persName>
-                        Pasha does not describe the methods of reconversion adopted by the
-                        Government We infer, however, that the action taken was short, sharp, and
-                        decisive.</p>
-                    <p>Not the least interesting passage in Sir Rudolph’s account of his personal
-                        experiences relates to an interview that he held with a number of sheikhs
-                        representative of the nomad Arab tribes. They object to paying tribute—
-                        contributing to the expenses of public administration—but the reason which
-                        they put forward may seem paradoxical to the western mind. They understand
-                        and acknowledge the authority of superior strength. It is the principle by
-                        which they have justified their secular exploitation of weaker or less
-                        intelligent races. In the British they have met with a greater power than
-                        their own, and they are content to submit to what they regard as the logical
-                        oonsequences. "I am willing," said a consistent upholder of the ancien
-                        regime, to pay yon tribute because you are the stronger. The lion has a
-                        right to take toll of the herd because he is king of the forest. But I am
-                        not willing to pay tribute tor being protected." Ha could protect himself!
-                        What, of course, he meant was that he objected to being protected under a
-                        system which protected others against himself. That, in fact was what ho
-                        practically confessed. The Arabs, he declared, are a fighting race, and the
-                        Pax Britannica had "taken all the spice out of their life." Nor are these
-                        unabashed champions of the "good old role, the simple plan,” quite ignorant
-                        of contemporary events in the civilised world. The echoes of oru quarrels
-                        reverberate to the inner Sudan. <persName
-                            ref="http://www.oxforddnb.com/view/article/39736">Slatin</persName>
-                        Pasha was hard put to it to find a convincing answer when his Arab
-                        interrogator asked him whether we do not sometimes have wars in Europe. All
-                        he could plead in reply was the vague formula about "reasons of State."
-                        "It’s all the same,” was the almost pathetic rejoinder; "you have the sport
-                        and fun of fighting." There was no more to be said. The point of view was
-                        too hopelessly different Protesting his loyally, the aggrieved sheikh went
-                        his way, not without regretting that he "had been made like a woman.”
-                        Undoubtedly, the problem which his valdediction presents will not be solved
-                        within a few years. The Arabs, who stand for the higher, though abruptly
-                        arrested, type of social evolution in Africa, are not without certain
-                        aptitudes for civilised life. They are versed in all the arts of barter and
-                        exchange. As merchants and distributors of native products the better class
-                        may accommodate themselves to modern conditions, and the lower grade,
-                        especially when they have been crossed with negro blood, are not specially
-                        faithless or inefficient in domestic service. But for steady industrial toil
-                        they have been unfitted by centuries of idleness in the open air. Fighting
-                        is the one serious profession which appeals to their genius, and evokes
-                        their best, as well as their worst, qualities. The process of adaptation to
-                        peaceful and monotonous usefulness has hardly commenced, and it will not be
-                        completed within the lifetime of any living person. The best hope of
-                        eventual civilisation lies in their readiness to assimilate some elements of
-                        European culture. The schools and colleges which have been set at work at
-                        various centres in the Sudan may, in course of time, revive the dormant
-                        intellectual gifts of a race which at one time preserved the learning that
-                        had almost expired in the dark ages of European history Author Avrrhous may
-                        arise from the city which less than ten years ago was the unapproachable
-                        stronghold of tyranny and brutish ignorance.</p>
-                    <p>British Chamber of Commerce.—We would draw the attention of manufacturers and
-                        merchants to the work of the British Chamber of Commerce of <placeName
-                            ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName>, which was
-                        formed in 1896 with the sole object of assisting British trade in this
-                        country. The services of the Chamber are always at the disposal of any
-                        member desiring information on trade matters generally, including the
-                        question of appointing suitable agents. As no fee is charged for such
-                        advice, it is obviously in the interests of all British traders here to
-                        become members, especially when it is remembered that the annual
-                        subscription is merely the nominal one of £1. The latter payment also
-                        includes a copy of the monthly Journal issued by the Chamber. Home enquirers
-                        can obtain farther particulars from our Loudon office, 36, New Broad-street,
-                        which acts as agents to the Chamber.</p>
+                    <head><persName ref="http://www.oxforddnb.com/view/article/39736">Saltin</persName> PASHA &amp; THE SUDAN.</head>
+                    <p>awakened, like the fellaheen in Upper <placeName ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName>, to the advantages of money, and realise that they can only obtain it by the sweat of then brows. "Hence," says <persName ref="http://www.oxforddnb.com/view/article/39736">Slatin</persName> Pasha, “with tin</p>
+                    <p>We recently published an interview with Sir R. von <persName ref="http://www.oxforddnb.com/view/article/39736">Slatin</persName> Pasha by a "Standard” correspondent, and we now add the leading article which that paper devoted to the work of the Inspector General of the Sudan.</p>
+                    <p>Among the men of our own time, none, we think, has a more romantic record than <persName ref="http://www.oxforddnb.com/view/article/39736">Slatin</persName> Pasha, the gallant Austrian appointed by General Gordon to be Governor of Darfur, who afterwards fell into the Mahdi's hands, and survived the tortures of his long captivity to become Inspector General, under Sir Reginald <persName ref="http://www.oxforddnb.com/view/article/36977">Wingate</persName>, of the region over which his conqueror had exercised a ruthless terrorism. It is with great pleasure that we have published, the account of a long conversation held by our representative with a modern hero as '‘much-enduring" as Odysseus himself. Restored to the civilisation which he has help ed to construct, Sir Radolph <persName ref="http://www.oxforddnb.com/view/article/39736">Slatin</persName> shows no more trace of his sufferings and travail than the Ithacan wanderer, and has addressed himself to
+                        administrative problems with as fresh an energy and as alert an intelligence as any hopeful novice fresh from his examination for the Indian Civil Servie. The man who was dragged in chains by the Mahdi's horse, a symbol and victim of the False Prophet's fleeting triumph, has at his finger’s ends all the latest statistics as to the revenue of the reconquered provinces. He describes, with the concentrated interest of a practical philanthropist, the elaborate measures which have been taken or are being prepared for the improvement of railway and motor communication between the interior and the coast and for the irrigation of a thirsty land. It has been the privilege and delight of Lord <persName ref="http://www.oxforddnb.com/view/article/30583?docPos=1">Cromer</persName> to enlist and instruct many zealous and intelligent subalterns in the great work of civilisations to which the least favorable critics of Great Britain yield unstinted praise; but no member of that
+                        memorable band has rendered better service or given shrewder counsel to his chief than the quiet, thoughtful gentleman who in twenty years has passed from imminent jeopardy of a living death back again to a career of beneficent activity. For the details of the industrial development which <persName ref="http://www.oxforddnb.com/view/article/39736">Slatin</persName> Pasha supervises we may refer our readers to his own words, which present, in a concentrated form, the essence of the yearly reports published under Lord <persName ref="http://www.oxforddnb.com/view/article/30583?docPos=1">Cromer</persName>'s authority. It is to the human aspect of his story that we weald direct especial attention, because this illustrates the signal success which, in every part of the world, attends British colonisers in their dealings with races of inferior or retarded development. Take, for instance, the missionary question. How do the Anglo-Egyptian authorities face that always
+                        thorny problem <persName ref="http://www.oxforddnb.com/view/article/39736">Slatin</persName> Pasha explains, in a few sentences, the principle on which they proceed. Roughly, the Sudan is divided into two political regions. The northern part is inhabited mainly, if not entirely, by Moslems, and on their fanatical faith and stereotyped stage of culture it has hitherto been found impossible for the evangelists of Christianity to make any sensible impression. As to the future, it would be inexcusable to hazard a general prophecy, but, at the present time, and in the Northern Sudan, it would endanger the permanent interests of civilisation if the Government were to sanction proselytising efforts which would surely be interpreted as an insidious and especially hateful form of political aggression. We must work more patiently, and be content with intermediate revolts. There are missionary schools established at Kharatoum for the children of Christian residents, and we
+                        are glad to learn that these are attended by young Moslems. But it is well understood—and the compact is faithfully observed—that these institutions are maintained for the purposes of general education, and not with a view to undermine the ancient religion of the people. In the southern districts of the Sudan the conditions are different, and another rule is observed. The people are pagans of a rather low type, and, knowing the Moslems chiefly as slave raiders, bear no affection for the faith of their persecutors. There the field is comparatively open to missionary enterprise, and has already yielded a certain spiritual harvest But the more prudent pioneers, of that light which the Western races are giving back to the Oriental source from which it was borrowed are content to move slowly, step by step. They make no raid on the polygamous custom which is the base of a primitive morality. To insist on the dismissal of all but s single — probably the most elderly —
+                        wife would not merely be a sacrifice that would appal the hesitating convert. It would also shake the social system of the tribe, deprive innocent women of their reoognieed status, and brand innumerable children with an unintelligible illegitimacy.</p>
+                    <p>Similar caution had at first to be observed in the treatment of another "domestic institution.” The barbarities of the slave trade have been summarily suppressed throughout the Sudan. "There is no raiding on a big scale,” says <persName ref="http://www.oxforddnb.com/view/article/39736">Slatin</persName> Pasha. Isolated revivals are attempted in remote spots and kidnapping is sometimes reported. But the delinquents are sharply punched, and the dangers that attend the sport—for that is the light in which it presents itself to Arab adventurers — are generally understood. “The traffic in human flesh," we are told, "has practically ceased." We would not aver that it is nowhere possible to purchase a slave-girl, but the business has become clandestine and is rapidly dying away. Nevertheless, the absolute abolition of slavery, which was decreed after Lord Kitchener’s re-conquest of the Sudan, was not without its drawbacks. As in our West Indies and in the United States,
+                        a race which had hitherto worked only under compulsion did not easily take to voluntary labour. By degrees, however, the lazy, easy-going but not unintelligent negroes have agreement and assistance of the Arab population, we are gradually changing the status of slavery into one of paid labour.' This, ha adds, "will be liked by both master and servant” For that revolution of sentiment we must be content to wait a generation. It is not in human nature either for employers to relish paying money for work that they used to get for nothing, or for employes to have their reward proportioned to the amount of energy that they put into their task. We have our wages problems and labour troubles even in this enlightened land. Other discontent in the Sudan there seems to be none—none, at least, of a dangerous kind. There are trilab feuds which the Government has to check with a cold, impartial hand. And not long ago crack-brained pretender tried to set up a new religion and
+                        proclaimed himself to be the "Prophet Jesus.” We have witnessed similar phenomena nearer home. It is interesting to note that the Sudanese impostor only suceeded in winning eleven disciples. <persName ref="http://www.oxforddnb.com/view/article/39736">Slatin</persName> Pasha does not describe the methods of reconversion adopted by the Government We infer, however, that the action taken was short, sharp, and decisive.</p>
+                    <p>Not the least interesting passage in Sir Rudolph’s account of his personal experiences relates to an interview that he held with a number of sheikhs representative of the nomad Arab tribes. They object to paying tribute— contributing to the expenses of public administration—but the reason which they put forward may seem paradoxical to the western mind. They understand and acknowledge the authority of superior strength. It is the principle by which they have justified their secular exploitation of weaker or less intelligent races. In the British they have met with a greater power than their own, and they are content to submit to what they regard as the logical oonsequences. "I am willing," said a consistent upholder of the ancien regime, to pay yon tribute because you are the stronger. The lion has a right to take toll of the herd because he is king of the forest. But I am not willing to pay tribute tor being protected." Ha could protect himself! What, of course,
+                        he meant was that he objected to being protected under a system which protected others against himself. That, in fact was what ho practically confessed. The Arabs, he declared, are a fighting race, and the Pax Britannica had "taken all the spice out of their life." Nor are these unabashed champions of the "good old role, the simple plan,” quite ignorant of contemporary events in the civilised world. The echoes of oru quarrels reverberate to the inner Sudan. <persName ref="http://www.oxforddnb.com/view/article/39736">Slatin</persName> Pasha was hard put to it to find a convincing answer when his Arab interrogator asked him whether we do not sometimes have wars in Europe. All he could plead in reply was the vague formula about "reasons of State." "It’s all the same,” was the almost pathetic rejoinder; "you have the sport and fun of fighting." There was no more to be said. The point of view was too hopelessly different Protesting his loyally, the aggrieved sheikh
+                        went his way, not without regretting that he "had been made like a woman.” Undoubtedly, the problem which his valdediction presents will not be solved within a few years. The Arabs, who stand for the higher, though abruptly arrested, type of social evolution in Africa, are not without certain aptitudes for civilised life. They are versed in all the arts of barter and exchange. As merchants and distributors of native products the better class may accommodate themselves to modern conditions, and the lower grade, especially when they have been crossed with negro blood, are not specially faithless or inefficient in domestic service. But for steady industrial toil they have been unfitted by centuries of idleness in the open air. Fighting is the one serious profession which appeals to their genius, and evokes their best, as well as their worst, qualities. The process of adaptation to peaceful and monotonous usefulness has hardly commenced, and it will not be completed
+                        within the lifetime of any living person. The best hope of eventual civilisation lies in their readiness to assimilate some elements of European culture. The schools and colleges which have been set at work at various centres in the Sudan may, in course of time, revive the dormant intellectual gifts of a race which at one time preserved the learning that had almost expired in the dark ages of European history Author Avrrhous may arise from the city which less than ten years ago was the unapproachable stronghold of tyranny and brutish ignorance.</p>
+                    <p>British Chamber of Commerce.—We would draw the attention of manufacturers and merchants to the work of the British Chamber of Commerce of <placeName ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName>, which was formed in 1896 with the sole object of assisting British trade in this country. The services of the Chamber are always at the disposal of any member desiring information on trade matters generally, including the question of appointing suitable agents. As no fee is charged for such advice, it is obviously in the interests of all British traders here to become members, especially when it is remembered that the annual subscription is merely the nominal one of £1. The latter payment also includes a copy of the monthly Journal issued by the Chamber. Home enquirers can obtain farther particulars from our Loudon office, 36, New Broad-street, which acts as agents to the Chamber.</p>
                 </div>
                 <div type="article">
                     <head> Anglo-American Nile Steiners &amp; HOTEL COMPANY. </head>
-                    <p>After transport OF goods between <placeName
-                            ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> &amp;
-                            <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>
+                    <p>After transport OF goods between <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> &amp; <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>
                     </p>
-                    <p><placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>
-                        Banker Warehouse BR, LB, Is NOT a Makeshift NOR a Substitute but simply Pure
-                        Mountain Pasture CREAM. Guaranteed free from Preservative and put up in
-                        Sterilized Tins. Keeps good IN ANY CLIMATE for MANY MONTHS. On sale almost
-                        everywhere, but if any difficulty in procuring it, apply to</p>
+                    <p><placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> Banker Warehouse BR, LB, Is NOT a Makeshift NOR a Substitute but simply Pure Mountain Pasture CREAM. Guaranteed free from Preservative and put up in Sterilized Tins. Keeps good IN ANY CLIMATE for MANY MONTHS. On sale almost everywhere, but if any difficulty in procuring it, apply to</p>
                 </div>
-                <div type="article"><!-- TODO Replace with Add boilerplate --> McLAREN’S STEAM
-                    PLOUGHS BRIDGE'S NoShock J. &amp; H.,McLAREN J. &amp; F. HOWARD, Bedford,
-                    England, Brass Door Plate With Mahogany Block Ready for FIxing to Door Wall or
-                    Gate Bulac Road . COMPLETE CLUTCH Cearing And hauling 200 Page Catalogue Free
-                    DAVID BRIDGE &amp; Co., <placeName ref="https://www.wikidata.org/wiki/Q85"
-                        >Cairo</placeName> Works, Castleton, Manchester, ENGLAND. 24773.12.5 </div>
+                <div type="article">
+                    <!-- TODO Replace with Add boilerplate -->
+                    <p>McLAREN’S STEAM PLOUGHS BRIDGE'S NoShock J. &amp; H.,McLAREN J. &amp; F. HOWARD, Bedford, England, Brass Door Plate With Mahogany Block Ready for FIxing to Door Wall or Gate Bulac Road . COMPLETE CLUTCH Cearing And hauling 200 Page Catalogue Free DAVID BRIDGE &amp; Co., <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> Works, Castleton, Manchester, ENGLAND. 24773.12.5</p>
+                </div>
                 <div type="article">
                     <head>PROMISE AND FULFILMENT.</head>
-                    <p>The story told of Lord <persName
-                            ref="http://www.oxforddnb.com/view/article/32680">Curzon</persName>,
-                        when leaving Eton, promising to make a schoolfellow Chancellor of the
-                        Exchequer when himself Prime Minister, will be borne in mind, with a view to
-                        seeing if fulfilment attend the pledge, and when Lord <persName
-                            ref="http://www.oxforddnb.com/view/article/32680">Curzon</persName>
-                        realises his own boyish ambition. Lord <persName
-                            ref="http://www.oxforddnb.com/view/article/35612">Rosebery</persName> as
-                        a boy declared for the Premiership and the Derby, and has enjoyed the honors
-                        of both and is not yet old. Lord <persName
-                            ref="http://www.oxforddnb.com/view/article/32680">Curzon</persName>'s
-                        horoscope, cast by a learned Hindu, includes the Premiership; hence his
-                        old-time friend may hope on. Boys' promises are easily made, and still more
-                        easily forgotten; still, some of them are redeemed. Said Disraeli to
-                        Chochare-Baillie, his school chum, "When I am Prime Minister of England,
-                        Cocky, I'll make you a peer.” And he did, and the present baron is the
-                        second holder of the title promised by a boy and given by a statesman.</p>
+                    <p>The story told of Lord <persName ref="http://www.oxforddnb.com/view/article/32680">Curzon</persName>, when leaving Eton, promising to make a schoolfellow Chancellor of the Exchequer when himself Prime Minister, will be borne in mind, with a view to seeing if fulfilment attend the pledge, and when Lord <persName ref="http://www.oxforddnb.com/view/article/32680">Curzon</persName> realises his own boyish ambition. Lord <persName ref="http://www.oxforddnb.com/view/article/35612">Rosebery</persName> as a boy declared for the Premiership and the Derby, and has enjoyed the honors of both and is not yet old. Lord <persName ref="http://www.oxforddnb.com/view/article/32680">Curzon</persName>'s horoscope, cast by a learned Hindu, includes the Premiership; hence his old-time friend may hope on. Boys' promises are easily made, and still more easily forgotten; still, some of them are redeemed. Said Disraeli to Chochare-Baillie, his school chum, "When I am Prime Minister of
+                        England, Cocky, I'll make you a peer.” And he did, and the present baron is the second holder of the title promised by a boy and given by a statesman.</p>
                 </div>
                 <div type="article">
                     <head>AFRICA'S FUTURE RIVIERA.</head>
-                    <p>Great progress is being made in the opening up of the French Niger country.
-                        The railway has been carried as far as Koulikoro, on the Niger, and a
-                        steamer service has for the first time been established between this point
-                        and Timbuctoo, the river journey occupying three days. From <placeName
-                            ref="https://www.wikidata.org/wiki/Q90">Paris</placeName>, Timbuctoo can
-                        now be reached in 15 days. It is one of the dreams of French expansion that
-                        steady improvement of the means of access may render the Niger as much a
-                        winter resort as the Nile now is.</p>
+                    <p>Great progress is being made in the opening up of the French Niger country. The railway has been carried as far as Koulikoro, on the Niger, and a steamer service has for the first time been established between this point and Timbuctoo, the river journey occupying three days. From <placeName ref="https://www.wikidata.org/wiki/Q90">Paris</placeName>, Timbuctoo can now be reached in 15 days. It is one of the dreams of French expansion that steady improvement of the means of access may render the Niger as much a winter resort as the Nile now is.</p>
                 </div>
                 <div type="article">
                     <head>FOR SALE.</head>
-                    <p>Abont 8 tons of used tents also a quantity of wood and iron, all of whioh can
-                        be seen at the Ordonance Depot, Mustapha Barracks, where a detailed list of
-                        each Lot can also be obtained.</p>
-                    <p>The offers to be marked Confidential and addressed to the Chief Ordonance
-                        Officer British Head Quarters <placeName
-                            ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> , so as to
-                        reach him on or before the 10th October, 1905.</p>
+                    <p>Abont 8 tons of used tents also a quantity of wood and iron, all of whioh can be seen at the Ordonance Depot, Mustapha Barracks, where a detailed list of each Lot can also be obtained.</p>
+                    <p>The offers to be marked Confidential and addressed to the Chief Ordonance Officer British Head Quarters <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> , so as to reach him on or before the 10th October, 1905.</p>
                 </div>
-                <div type="article"><!-- TODO Figure out how to represent the byline/closer -->
-                    26499-1 <head>SOCIETE ANONYME DES EAUX DU CAIRE</head>
+                <div type="article">
+                    <!-- TODO Figure out how to represent the byline/closer -->
+                    <head>SOCIETE ANONYME DES EAUX DU CAIRE</head>
                     <p>A. Paiement de coupons.</p>
                     <p>B. Fracionnement des actions.</p>
-                    <p>A partir. du ler octobre prochain, la Societe payera le solde du dividende de
-                        l'Exercice 1904, savoir:</p>
-                    <!-- TODO Replace with table or figure out other representation --> action de
-                    capital, coupon N. 32, L.E 0.427m/m jouissance, „ „ 22, „ 0.434 „ Part de
-                    fondateur, „ „ 32, „ 0.616 „ <p>et procedera en mem temps a l'excange des
-                        nouvelles actions contre celles actuelles dont le fractionnement a ete
-                        decide par l'Assemblee generale extraordinaire du <dateline>9 Mars
-                            1905.</dateline></p>
-                    <p>Las interesses auront done a presenter lean titres en meme temps quo les
-                        bordereaux numeriques des coupons.</p>
-                    <p>Les coupons mentionnes ci-dessus ne devront pas etre detaches. Ils resteront
-                        attaches aux titres presentes.</p>
-                    <p>Le montant des bordereaux sera paye de suite. Quant aux titres nouveax, en
-                        raison du travail que cette operation d'exchange exigera, ils seront
-                        deliveres ulferieuremant ; les actions a exchanger seront deposees contre
-                        recepisses.</p>
-                    <p>La remise dee titres nouveaux aura lieu, aussitot que possible, sur
-                        presentation de ces recepisses.</p>
+                    <p>A partir. du ler octobre prochain, la Societe payera le solde du dividende de l'Exercice 1904, savoir:</p>
+                    <!-- TODO Replace with table or figure out other representation -->
+                    <p>action de capital, coupon N. 32, L.E 0.427m/m jouissance, „ „ 22, „ 0.434 „ Part de fondateur, „ „ 32, „ 0.616 „</p>
+                    <p>et procedera en mem temps a l'excange des nouvelles actions contre celles actuelles dont le fractionnement a ete decide par l'Assemblee generale extraordinaire du <date when="1905-04-09">9 Mars 1905.</date></p>
+                    <p>Las interesses auront done a presenter lean titres en meme temps quo les bordereaux numeriques des coupons.</p>
+                    <p>Les coupons mentionnes ci-dessus ne devront pas etre detaches. Ils resteront attaches aux titres presentes.</p>
+                    <p>Le montant des bordereaux sera paye de suite. Quant aux titres nouveax, en raison du travail que cette operation d'exchange exigera, ils seront deliveres ulferieuremant ; les actions a exchanger seront deposees contre recepisses.</p>
+                    <p>La remise dee titres nouveaux aura lieu, aussitot que possible, sur presentation de ces recepisses.</p>
                     <p>L'exchange des action sere fait sans conformite de numero.</p>
-                    <p>Le paiement des coupons, ainsi que l'echange des titres, sera effectue an
-                        siege de la Societe au Caire et aux guichets du Credit Lyonnais a <placeName
-                            ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>.</p>
-                    <p>Il est rappele que le fractionnement dee titres decide par l'Assemblde
-                        generale precitee, se fera comme suit:</p>
-                    <p>a) L’action actuelle de capital sera exchangee contre quatre actions de
-                        "jouissance” et une aotion de "capital" — cette derniere d'une valeur
-                        nominale de 125 Fr. donnant droit a un intere fixe de 4 % et remboursable
-                        par voie de tirages annuels.</p>
-                    <p>b) L'action actuelle de "jouissance" sera exchange contre quatre actions de
-                        "jouissance."</p>
-                    <p>c) Le fracctionement des "Parts de fondateur" en diximes, a ete egalement
-                        decide, mais il est facultatif et le porteur qui en fera la demande aura a
-                        payer les frais de confection des nouveaux titres.</p>
+                    <p>Le paiement des coupons, ainsi que l'echange des titres, sera effectue an siege de la Societe au Caire et aux guichets du Credit Lyonnais a <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>.</p>
+                    <p>Il est rappele que le fractionnement dee titres decide par l'Assemblde generale precitee, se fera comme suit:</p>
+                    <p>a) L’action actuelle de capital sera exchangee contre quatre actions de "jouissance” et une aotion de "capital" — cette derniere d'une valeur nominale de 125 Fr. donnant droit a un intere fixe de 4 % et remboursable par voie de tirages annuels.</p>
+                    <p>b) L'action actuelle de "jouissance" sera exchange contre quatre actions de "jouissance."</p>
+                    <p>c) Le fracctionement des "Parts de fondateur" en diximes, a ete egalement decide, mais il est facultatif et le porteur qui en fera la demande aura a payer les frais de confection des nouveaux titres.</p>
                     <p>Le Directeur p.i.</p>
                     <p>L Galvin.</p>
-                    <dateline>Le <placeName ref="https://www.wikidata.org/wiki/Q85"
-                            >Cairo</placeName> ,le <date value="1905-09-14">14 Septembre
-                        1905</date>. 26428-6-4</dateline>
+                    <dateline>Le <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> ,le <date when="1905-09-14">14 Septembre 1905</date>. 26428-6-4</dateline>
                 </div>
                 <div type="article">
                     <head>SELLING OFF SURPLUS DRAPERY STOCK OF MAGASINS VICTORIA.</head>
-                    <p>Premises lately occupied by “Papeterie Commerciale," Rue Sesostris, 3 doors
-                        from Cherif Pasha Street. For particulars see</p>
+                    <p>Premises lately occupied by “Papeterie Commerciale," Rue Sesostris, 3 doors from Cherif Pasha Street. For particulars see</p>
                 </div>
                 <div type="article">
                     <head>BUTTER-SCOTCH</head>
                     <p>(The Celebrated Sweet for Children).</p>
                     <p>Messrs. Tanured Bonniui &amp; Co.,</p>
                     <p>The Patisserie De La Bourse,</p>
-                    <p>Manufactory: <placeName ref="https://www.wikidata.org/wiki/Q84"
-                            >London</placeName>. England.</p>
+                    <p>Manufactory: <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName>. England.</p>
                 </div>
                 <div type="article">
                     <head>BON-ACCORD</head>
@@ -2272,32 +1561,12 @@
                     <p>Patent Friction Clutches.</p>
                 </div>
                 <div type="article">
-                    <head><placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> &amp;
-                        Alexander</head>
-                    <p>NB.—This Whisky is the same as supplied to the Bed Cross Society, Loudon, for
-                        use by the invalided troops and hospitals in 8outh Africa, to the House of
-                        Lords and House of Commons.</p>
+                    <head><placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> &amp; Alexander</head>
+                    <p>NB.—This Whisky is the same as supplied to the Bed Cross Society, Loudon, for use by the invalided troops and hospitals in 8outh Africa, to the House of Lords and House of Commons.</p>
                 </div>
-                <div type="article"><!-- TODO Replace with Add boilerplate -->
-                    <head>THE VAL DE TRAVERS ASPHALTE PAVING COMPANY, LIMITED.</head> Hamilton
-                    House, Bishopgate St. Without <placeName ref="https://www.wikidata.org/wiki/Q84"
-                        >London</placeName> E.C. CONTRAOTORS TO BRITISH WAR OFFICE Pyrimont-Seyesel,
-                    Servas (France) Ragusa (Sicily), Guanipa. (Venezuela), Mine Owners Egyptian
-                    BRANCH - FIR8T ASPHALT FACTORY ESTABLISHED IN <placeName
-                        ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName>. The Best Drink
-                    for Hot Countries is WATER. The Best Way to make Barley Water it to use It can
-                    be obtained in One Pound Tins at the Local Store, Manufacturers: KEEN. ROBINSON
-                    &amp; Co., Ltd., <placeName ref="https://www.wikidata.org/wiki/Q84"
-                        >London</placeName>. ENGLAND. Makers of ROBINSON's PATENT GROATS. STEAM,
-                    ELECTRICITY, GAS. OIL OR BELT, FOR IRRIGATION, DRAINAGE, DOCKS, etc. Apply in
-                        <placeName ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName>,
-                        <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> and
-                        <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>,
-                    A. ABOAF &amp; C°. (where a stock is kept.) DRYSDALE &amp; Co. Manufacturers
-                    Bon-Accord Engine Works, Glasgow. Telegrams : Telephone : "BON-ACCORD, GLASGOW."
-                    A B C &amp; LIEBER'S 2505 NATIONAL. 24386-7-1 COOES. Y 279 CORPORATION. Agents
-                    EXPORT OFFICE, wanted through <placeName ref="https://www.wikidata.org/wiki/Q79"
-                        >Egypt</placeName>. ENGLISH MADE PLOUGHS FOR ALL COUNTRIES AND ALL PURPOSES.
+                <div type="article">
+                    <!-- TODO Replace with Add boilerplate -->
+                    <head>THE VAL DE TRAVERS ASPHALTE PAVING COMPANY, LIMITED.</head>
                 </div>
             </div>
             <div type="page" n="5"> </div>

--- a/1905-10-05.xml
+++ b/1905-10-05.xml
@@ -36,15 +36,8 @@
                     <div type="item" scope="advertisement" xml:id="deg-ad-pos01">
                         <head>Peninsular and Oriental S. N. Company.</head>
                         <p>Summer Rates will be charged from 2 May to 31 October. </p>
-                        <p>For the convenience of families and others, a large portion of each ship’s
-                            accommodation has been reserved for Egypt, so that Berths can be definitely
-                            engaged at once, as if the voyage were commencing at <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>. Plans can be
-                            seen at the Offices of the Company’s Agents. </p>
-                        <p>The through Steamers for <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName> and <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> are intended to leave <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>
-                            after the arrival of the 11 a.m. train from <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> , every Tuesday for the present
-                            except the MONGOLIA, which is taking passengers to the Anglo-French Naval
-                            Review, and will not wait at <placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName>  on 24/25 July. A steam tender will meet
-                            the train to convey passengers to the ship. </p>
+                        <p>For the convenience of families and others, a large portion of each ship’s accommodation has been reserved for Egypt, so that Berths can be definitely engaged at once, as if the voyage were commencing at <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>. Plans can be seen at the Offices of the Company’s Agents. </p>
+                        <p>The through Steamers for <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName> and <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> are intended to leave <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> after the arrival of the 11 a.m. train from <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> , every Tuesday for the present except the MONGOLIA, which is taking passengers to the Anglo-French Naval Review, and will not wait at <placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName> on 24/25 July. A steam tender will meet the train to convey passengers to the ship. </p>
                         <table>
                             <row>
                                 <cell><placeName ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName></cell>
@@ -79,8 +72,7 @@
                                 <cell>19 Sept.</cell>
                             </row>
                         </table>
-                        <p>The Brindisi Express Steamers leave <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> directly the Indian Mails arrive.
-                            Passengers can go on board the evening before. The Fare remains as usual. </p>
+                        <p>The Brindisi Express Steamers leave <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> directly the Indian Mails arrive. Passengers can go on board the evening before. The Fare remains as usual. </p>
                         <p>For all further information apply to the Company's Agents, </p>
                         <p>Messrs. THOS. COOK &amp; SON (Egypt) Ltd. <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> . </p>
                         <p>GEORGE ROYLE, Esq. <placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName> . </p>
@@ -91,15 +83,13 @@
                         <head>Orient-Pacific Line of Royal Mail Steamers.</head>
                         <p>REDUCED SUMMER FARES FROM MAY TO OCTOBER INCLUSIVE.</p>
                         <p>OUTWARDS to <placeName ref="https://www.wikidata.org/wiki/Q408">Australia</placeName>.</p>
-                        <p>R.M.S. “Orotava" will leave <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName> about July 28 | R.M.S "Ormuz" will leave <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>
-                            about August 11. </p>
+                        <p>R.M.S. “Orotava" will leave <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName> about July 28 | R.M.S "Ormuz" will leave <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName> about August 11. </p>
                         <p>HOMEWARDS to NAPLES <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName>, GIBRALTAR, PLYMOUTH, <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName>, TILBURY</p>
-                        <p>R.M.S. "Oroya" will leave <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> about July 18 | R.M.S. “Ortona" will leave
-                            <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> about August 1</p>
+                        <p>R.M.S. "Oroya" will leave <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> about July 18 | R.M.S. “Ortona" will leave <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> about August 1</p>
                         <table>
                             <row>
                                 <cell rows="4">Reduced Summer Fares</cell>
-                                <cell><placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName>  to Naples</cell>
+                                <cell><placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName> to Naples</cell>
                                 <cell>1st Class</cell>
                                 <cell>£ 11</cell>
                                 <cell>2nd Class</cell>
@@ -108,7 +98,7 @@
                                 <cell>£ 4.8</cell>
                             </row>
                             <row>
-                                <cell><placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName>  to <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName></cell>
+                                <cell><placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName> to <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName></cell>
                                 <cell>1st Class</cell>
                                 <cell>£ 12.12</cell>
                                 <cell>2nd Class</cell>
@@ -117,7 +107,7 @@
                                 <cell>£ 5.10</cell>
                             </row>
                             <row>
-                                <cell><placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName>  to Gibraltar</cell>
+                                <cell><placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName> to Gibraltar</cell>
                                 <cell>1st Class</cell>
                                 <cell>£ 18.0</cell>
                                 <cell>2nd Class</cell>
@@ -126,7 +116,7 @@
                                 <cell>£ 5.10</cell>
                             </row>
                             <row>
-                                <cell><placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName>  to Plymouth or Tilbury</cell>
+                                <cell><placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName> to Plymouth or Tilbury</cell>
                                 <cell>1st Class</cell>
                                 <cell>£ 16.16</cell>
                                 <cell>2nd Class</cell>
@@ -136,13 +126,9 @@
                             </row>
                         </table>
                         <p>Egyptian Government Officials allowed a rebate of 15% off the above fares.</p>
-                        <p>Return tickets no longer issued, but passengers paying full fare in one direction
-                            allowed abatement of 1/3 fare back if return voyage be within 4 months of
-                            arrival, or abatement of 20 o/o if return voyage be made within 8 months of
-                            arrival.</p>
-                        <p>Agents. <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> :—Thos. Cook &amp; Son. <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> : —R. J. Moss &amp; Co.—For all
-                            information apply </p>
-                        <p>Wm. STAPLEDON &amp; Sons, <placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName>  &amp; PORT-TEWFIK (<placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>) 31-12-904</p>
+                        <p>Return tickets no longer issued, but passengers paying full fare in one direction allowed abatement of 1/3 fare back if return voyage be within 4 months of arrival, or abatement of 20 o/o if return voyage be made within 8 months of arrival.</p>
+                        <p>Agents. <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> :—Thos. Cook &amp; Son. <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> : —R. J. Moss &amp; Co.—For all information apply </p>
+                        <p>Wm. STAPLEDON &amp; Sons, <placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName> &amp; PORT-TEWFIK (<placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>) 31-12-904</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-blm01">
                         <head>BIBBY LINE MAIL STEAMERS.</head>
@@ -153,37 +139,30 @@
                         <p>HOMEWARDS to <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName> and <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName>. Departures from <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>.</p>
                         <p>S.S. Worcestershire 7,160 tons, leaves about July 26.</p>
                         <p>S.S. Yorkshire 4,196 tons leaves about August 9,</p>
-                        <p>FARES from <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> to <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName> £12.0.0, <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> £17.0.0, Colombo £32.10.0,
-                            Rangoon £37.10.0. </p>
-                        <p>Agents <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> : THOS. COOK &amp; SON. <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName> &amp; <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> : WM. STAPLEDON &amp; SONS,
-                            31-12-905</p>
+                        <p>FARES from <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> to <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName> £12.0.0, <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> £17.0.0, Colombo £32.10.0, Rangoon £37.10.0. </p>
+                        <p>Agents <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> : THOS. COOK &amp; SON. <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName> &amp; <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> : WM. STAPLEDON &amp; SONS, 31-12-905</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-kml01">
                         <head>KHEDIVIAL MAIL LINE.</head>
-                        <head type="sub">FAST BRITISH PASSENGER STEAMERS</head>
-                        <head type="sub"><placeName ref="https://www.wikidata.org/wiki/Q41">Greece</placeName> - <placeName ref="https://www.wikidata.org/wiki/Q43">Turkey</placeName> LINE.</head>
-                        <p>Express Steamers leave <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> every Wednesday at 4 p.m. for PIRAEUS, SMYRNA,
-                            MITYLENE, and CONSTANTINOPLE, in connection with Orient Express train-de-luxe
-                            for Vienna, <placeName ref="https://www.wikidata.org/wiki/Q90">Paris</placeName>, and <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName>.</p>
-                        <head type="sub">PALESTINE - SYRIA LINE.</head>
-                        <p>Fast steamers leave <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> every Saturday at 6 p.m., and <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> every
-                            Sunday at 6 p.m., for JAFFA (for Jerusalem), CAIFFA (for Nazareth), BEYROUT (for
-                            Damascus), TRIPOLI, ALEXANDRETTA, MESSINA, continuing in alternate weeks to
-                            LARNACA and LIMASSOL (Cyprus).</p>
-                        <head type="sub">RED SEA LINE.</head>
-                        <p>Steamers leave <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName> fortnightly on Wednesday at 6 p.m. for JEDDAH, SUAKIN,
-                            MASSOWAH, HODBIDAH, and ADEN ; and in the intervening weeks for PORT SUDAN and
-                            SUAKIN direct. Calls will be made at TOR (for Mount Sinai) as required.</p>
-                        <p>N.B.—Deck chairs provided for the use of passengers, excellent cuisine and table
-                            wine free.</p>
-                        <p>Steamer plans may be seen and passages booked at the Company’s Agencies at
-                            <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>, <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> , <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>, and <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>, or at THOS. COOK &amp; SON or other
-                            Tourist Agency. 31-12-904</p>
+                        <div type="subsection">
+                            <head type="sub">FAST BRITISH PASSENGER STEAMERS</head>
+                            <head type="sub"><placeName ref="https://www.wikidata.org/wiki/Q41">Greece</placeName> - <placeName ref="https://www.wikidata.org/wiki/Q43">Turkey</placeName> LINE.</head>
+                            <p>Express Steamers leave <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> every Wednesday at 4 p.m. for PIRAEUS, SMYRNA, MITYLENE, and CONSTANTINOPLE, in connection with Orient Express train-de-luxe for Vienna, <placeName ref="https://www.wikidata.org/wiki/Q90">Paris</placeName>, and <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName>.</p>
+                        </div>
+                        <div type="subsection">
+                            <head type="sub">PALESTINE - SYRIA LINE.</head>
+                            <p>Fast steamers leave <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> every Saturday at 6 p.m., and <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> every Sunday at 6 p.m., for JAFFA (for Jerusalem), CAIFFA (for Nazareth), BEYROUT (for Damascus), TRIPOLI, ALEXANDRETTA, MESSINA, continuing in alternate weeks to LARNACA and LIMASSOL (Cyprus).</p>
+                        </div>
+                        <div type="subsection">
+                            <head type="sub">RED SEA LINE.</head>
+                            <p>Steamers leave <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName> fortnightly on Wednesday at 6 p.m. for JEDDAH, SUAKIN, MASSOWAH, HODBIDAH, and ADEN ; and in the intervening weeks for PORT SUDAN and SUAKIN direct. Calls will be made at TOR (for Mount Sinai) as required.</p>
+                            <p>N.B.—Deck chairs provided for the use of passengers, excellent cuisine and table wine free.</p>
+                            <p>Steamer plans may be seen and passages booked at the Company’s Agencies at <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>, <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> , <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>, and <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>, or at THOS. COOK &amp; SON or other Tourist Agency. 31-12-904</p>
+                        </div>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-mss01">
                         <head>The Moss S.S. Company, Ltd.</head>
-                        <p>For <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName> calling at <placeName ref="https://www.wikidata.org/wiki/Q233">Malta</placeName> (Messrs. JAMES MOSS &amp; Co. 31, James St,
-                            <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName>, Managers.)</p>
+                        <p>For <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName> calling at <placeName ref="https://www.wikidata.org/wiki/Q233">Malta</placeName> (Messrs. JAMES MOSS &amp; Co. 31, James St, <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName>, Managers.)</p>
                         <table rows="3" cols="8">
                             <row>
                                 <cell>*Amasis</cell>
@@ -216,18 +195,11 @@
                                 <cell>(Building)</cell>
                             </row>
                         </table>
-                        <p>*Second class accommodation only, unless specially reserved.—Fares : <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>
-                            to <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName>, 1st, £14 Single, £25 Return. 2nd, £9 Single, £15 Return.—To <placeName ref="https://www.wikidata.org/wiki/Q233">Malta</placeName>,
-                            1st, £5 Single, £9 Return, 2nd, £3 Single, £5 Return.—Return tickets available
-                            for six months.</p>
-                        <p>S.S. Seti now on the berth, will sail on or about Monday, July 17, to be followed
-                            by S.S. Menes.</p>
+                        <p>*Second class accommodation only, unless specially reserved.—Fares : <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> to <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName>, 1st, £14 Single, £25 Return. 2nd, £9 Single, £15 Return.—To <placeName ref="https://www.wikidata.org/wiki/Q233">Malta</placeName>, 1st, £5 Single, £9 Return, 2nd, £3 Single, £5 Return.—Return tickets available for six months.</p>
+                        <p>S.S. Seti now on the berth, will sail on or about Monday, July 17, to be followed by S.S. Menes.</p>
                         <p>S.S Tabor for Havre via <placeName ref="https://www.wikidata.org/wiki/Q233">Malta</placeName> to sail about Saturday l5th inst.</p>
-                        <p>Through freight rates on cotton, etc., to Lancashire inland towns, Boston, New
-                            York and other U.S.A. towns, obtained on application. Cargo taken by special
-                            agreement only. </p>
-                        <p>Passenger Tickets also issued inclusive of Railway fare through to and from
-                            <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> . Particulars on application to </p>
+                        <p>Through freight rates on cotton, etc., to Lancashire inland towns, Boston, New York and other U.S.A. towns, obtained on application. Cargo taken by special agreement only. </p>
+                        <p>Passenger Tickets also issued inclusive of Railway fare through to and from <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> . Particulars on application to </p>
                         <p>R. J. MOSS &amp; Co., <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>, Agents. 26-12-905</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-mic01">
@@ -239,11 +211,8 @@
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-tce01">
                         <head>Telephone Company of Egypt, Limited.</head>
-                        <p><placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> -<placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> TELEPHONE.--Rates as follows P.T. 5 for each 3 minutes, or
-                            fraction of 3 minutes; P.T. 10 for over 3 up to 8 minutes communication.</p>
-                        <p>PUBLIC CALL-OFFICES : <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> , Central Office, Opera Square, and New Bar; Helouan,
-                            Central Office, Maison Purvis ; <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>, St Mark’s Buildings, Egyptian Bar,
-                            I. Castelli &amp; Co.; Ramleh, Central Office. San Stefano Casino 30.4.906</p>
+                        <p><placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> -<placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> TELEPHONE.--Rates as follows P.T. 5 for each 3 minutes, or fraction of 3 minutes; P.T. 10 for over 3 up to 8 minutes communication.</p>
+                        <p>PUBLIC CALL-OFFICES : <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> , Central Office, Opera Square, and New Bar; Helouan, Central Office, Maison Purvis ; <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>, St Mark’s Buildings, Egyptian Bar, I. Castelli &amp; Co.; Ramleh, Central Office. San Stefano Casino 30.4.906</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-hcl01">
                         <head>P. HENDERSON &amp; CO’s LINE.</head>
@@ -253,8 +222,7 @@
                         <p>S.S. BURMA 5600 Tons will leave <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> about August 6 for <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName>.</p>
                         <p>S.S. ARRACAN 5800 Tons will leave <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> about 20 for <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName></p>
                         <p>Due in <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> or <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName> 12 days thereafter.</p>
-                        <p>Apply WORMS &amp; Co., <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> and <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>. THOS. COOK &amp; SON, (EGYPT) LD.,
-                            <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>  ;</p>
+                        <p>Apply WORMS &amp; Co., <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> and <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>. THOS. COOK &amp; SON, (EGYPT) LD., <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> ;</p>
                         <p>G. J. GRACE &amp; CO., <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>.</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-tcs01">
@@ -264,21 +232,11 @@
                         <p><placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>, <placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName> , <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>, Luxor, Assuan, Haifa, &amp; Khartum.</p>
                         <p>GENERAL RAILWAY AND STEAMSHIP AGENTS. BANKERS.</p>
                         <p>BAGGAGE AND FORWARDING AGENTS.</p>
-                        <p>Officially appointed &amp; Sole Agents in <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>  to the P.&amp;O. S.N. Co.</p>
-                        <p>RESIDENTS IN <placeName ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName>proceeding to Europe for the summer are requested to apply to
-                            our offices for information respecting their Passages, where steamer plans may
-                            be consulted and Berths secured by all Lines of Steamers to all parts of the
-                            Globe; arrangements can also be made for the collection and forwarding of their
-                            baggage and clearance at port of arrival.</p>
-                        <p>CIRCULAR NOTES issued payable at the current rate of exchange in all the
-                            principal cities of Europe. Cook’s Interpreters in uniform are present at the
-                            principal Railway stations and Landing-places in Europe to assist passengers
-                            holding their travelling tickets.</p>
-                        <p>Large and splendidly appointed steamers belonging to the Co. leave <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>  thrice
-                            weekly, between November and March, for Luxor, Assouan and Wady-Halfa in
-                            connection with trains de luxe to Khartoum. Moderate fares. </p>
-                        <p>FREIGHT SERVICE, Steamers leave <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>  every Saturday and Tuesday for Assouan and
-                            Halfa.</p>
+                        <p>Officially appointed &amp; Sole Agents in <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> to the P.&amp;O. S.N. Co.</p>
+                        <p>RESIDENTS IN <placeName ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName>proceeding to Europe for the summer are requested to apply to our offices for information respecting their Passages, where steamer plans may be consulted and Berths secured by all Lines of Steamers to all parts of the Globe; arrangements can also be made for the collection and forwarding of their baggage and clearance at port of arrival.</p>
+                        <p>CIRCULAR NOTES issued payable at the current rate of exchange in all the principal cities of Europe. Cook’s Interpreters in uniform are present at the principal Railway stations and Landing-places in Europe to assist passengers holding their travelling tickets.</p>
+                        <p>Large and splendidly appointed steamers belonging to the Co. leave <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> thrice weekly, between November and March, for Luxor, Assouan and Wady-Halfa in connection with trains de luxe to Khartoum. Moderate fares. </p>
+                        <p>FREIGHT SERVICE, Steamers leave <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> every Saturday and Tuesday for Assouan and Halfa.</p>
                         <p>Special Steamers and Dahabeahs for private parties.</p>
                         <p>Special arrangements for tour in PALESTINE, SYRIA and the DESERT, Lowest Rates.</p>
                         <p>Best camp equipment in the country! 10 12-904 </p>
@@ -288,10 +246,8 @@
                         <head>British <placeName ref="https://www.wikidata.org/wiki/Q668">India</placeName> S. N. Company, Limited.</head>
                         <p>MAIL AND PASSENGER STEAM SHIPS.</p>
                         <p>SAILINGS FROM <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>, <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> and CALCUTTA LINE.</p>
-                        <p>Calling at ADEN, COLOMBO and MADRAS Outward, and <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName> (GENOA and PLYMOUTH
-                            optional) Homeward. </p>
-                        <p>Fortnightly Service in connection with the Co's Indian Mail Lines and monthly
-                            with the East African Mail Line between ADEN, MOMBASSA and Zanzibar. </p>
+                        <p>Calling at ADEN, COLOMBO and MADRAS Outward, and <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName> (GENOA and PLYMOUTH optional) Homeward. </p>
+                        <p>Fortnightly Service in connection with the Co's Indian Mail Lines and monthly with the East African Mail Line between ADEN, MOMBASSA and Zanzibar. </p>
                         <p>OUTWARD.—S.S. Fazilka ... July 22 | HOMEWARD.—S.S. Mombassa ... July 21 </p>
                         <p>Queensland Line of Steamers Between <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> and Brisbane.</p>
                         <p>Calling at Colombo, Batavia, Cooktown, Townsville, and Rockhamptom.</p>
@@ -320,16 +276,11 @@
                                 <cell>£19. 0</cell>
                             </row>
                         </table>
-                        <p>From <placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName>  £2 less Homeward, and £2 more Outward. Second class, two thirds of
-                            1st Class Fares.</p>
-                        <p>Agents at <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>, for the <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName>, Calcutta and Persian Gulf Lines, Messrs.
-                            Worms &amp; Co.</p>
-                        <p>Agents at <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>, for the <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> and Queensland Line, Messrs. Wills &amp; Co.,
-                            Limited.</p>
-                        <p>Messrs. Thos. Cook &amp; Son and the Anglo-American Hotel &amp; Steamer Company,
-                            <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>  &amp; <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>.</p>
-                        <p>For further particulars. Freight and Passage apply to G. BEYTS &amp; Co. Agents,
-                            <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>. 31-12-905</p>
+                        <p>From <placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName> £2 less Homeward, and £2 more Outward. Second class, two thirds of 1st Class Fares.</p>
+                        <p>Agents at <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>, for the <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName>, Calcutta and Persian Gulf Lines, Messrs. Worms &amp; Co.</p>
+                        <p>Agents at <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>, for the <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> and Queensland Line, Messrs. Wills &amp; Co., Limited.</p>
+                        <p>Messrs. Thos. Cook &amp; Son and the Anglo-American Hotel &amp; Steamer Company, <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> &amp; <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>.</p>
+                        <p>For further particulars. Freight and Passage apply to G. BEYTS &amp; Co. Agents, <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>. 31-12-905</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-all01">
                         <head>ANCHOR LINE, LIMITED.</head>
@@ -354,23 +305,14 @@
                                 <cell>July 23</cell>
                             </row>
                         </table>
-                        <p>Saloon Fares: from <placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName> , to Gibraltar £9; <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName> £9: <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName> (all sea
-                            route) £15; <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> (all sea route) £ 12 <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> via <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName> £15.5.0.
-                            Passengers embarking at <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName> £2 more, 10 % reduction for officers of army of
-                            Occupation and Government employés. Through tickets issued to New-York (via
-                            Glasgow). Fares on application. </p>
-                        <p> Agents in <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> , Messrs. Thos. Cook &amp; Son. <placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName> , Messrs. Cory Brothers
-                            &amp; Co., Ltd.</p>
-                        <p>For further partienlan of Freight or Passage apply to G. BEYTS &amp; Co., <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>.
-                            31-12-905</p>
+                        <p>Saloon Fares: from <placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName> , to Gibraltar £9; <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName> £9: <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName> (all sea route) £15; <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> (all sea route) £ 12 <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> via <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName> £15.5.0. Passengers embarking at <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName> £2 more, 10 % reduction for officers of army of Occupation and Government employés. Through tickets issued to New-York (via Glasgow). Fares on application. </p>
+                        <p> Agents in <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> , Messrs. Thos. Cook &amp; Son. <placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName> , Messrs. Cory Brothers &amp; Co., Ltd.</p>
+                        <p>For further partienlan of Freight or Passage apply to G. BEYTS &amp; Co., <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>. 31-12-905</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-dll01">
                         <head>Deutsche Levante-Linie.</head>
-                        <p>Mail and Passenger Steamships. Regular three-weekly Service from <lb/> HAMBURG,
-                            via ANTWERP &amp; <placeName ref="https://www.wikidata.org/wiki/Q233">Malta</placeName>, to <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> and vice-versa, admitting<lb/> goods from
-                            all chief German Railway Stations on direct Bill of Landing to<lb/> <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>
-                            and all chief ports of Egypt, Syria, etc., at favourable through<lb/> rates of
-                            DEUTSCHE <lb/> VERKEHR (traffic).</p>
+                        <p>Mail and Passenger Steamships. Regular three-weekly Service from <lb/> HAMBURG, via ANTWERP &amp; <placeName ref="https://www.wikidata.org/wiki/Q233">Malta</placeName>, to <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> and vice-versa, admitting<lb/> goods from all chief German Railway Stations on direct Bill of Landing to<lb/>
+                            <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> and all chief ports of Egypt, Syria, etc., at favourable through<lb/> rates of DEUTSCHE <lb/> VERKEHR (traffic).</p>
                         <p>EXPECTED AT <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>.</p>
                         <p>S.S. Lesbos July 20 from Antwerp.</p>
                         <p>S.S. Androos July 20 from Hamburg bound for Beyrout.</p>
@@ -474,8 +416,7 @@
                                 <cell>2nd Class</cell>
                             </row>
                             <row>
-                                <cell>From <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> or <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> (directly or via <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>) To
-                                    <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName></cell>
+                                <cell>From <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> or <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> (directly or via <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>) To <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName></cell>
                                 <cell>£12.9.8 </cell>
                                 <cell>£9.10.3</cell>
                             </row>
@@ -500,20 +441,17 @@
                                 <cell>£10.12.5</cell>
                             </row>
                             <row>
-                                <cell>Through tickets for <placeName ref="https://www.wikidata.org/wiki/Q90">Paris</placeName> (via <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName>) from <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> (directly or
-                                    via <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>) </cell>
+                                <cell>Through tickets for <placeName ref="https://www.wikidata.org/wiki/Q90">Paris</placeName> (via <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName>) from <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> (directly or via <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>) </cell>
                                 <cell>£16.5.11</cell>
                                 <cell>£12.1.5</cell>
                             </row>
                             <row>
-                                <cell>Through tickets for <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> (via <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName>) (Calais-Douvree) from
-                                    <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> or <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> (directly or via <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>)</cell>
+                                <cell>Through tickets for <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> (via <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName>) (Calais-Douvree) from <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> or <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> (directly or via <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>)</cell>
                                 <cell>£16.12.10</cell>
                                 <cell>£12.9.8</cell>
                             </row>
                             <row>
-                                <cell>Interchangeable return tickets with the Austrian Lloyd Cy. (available
-                                    one way by Messageries</cell>
+                                <cell>Interchangeable return tickets with the Austrian Lloyd Cy. (available one way by Messageries</cell>
                                 <cell>£21.11.10</cell>
                                 <cell>£15.11.2</cell>
                             </row>
@@ -570,8 +508,7 @@
                         <table rend="frame" xml:id="SailingfromSuez">
                             <head><hi rend="bold">Sailing from <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName> in July, 1905</hi></head>
                             <row>
-                                <cell rows="2">For Aden, Colombo, Singapore, Saigon, Hong-Kong, Shanghai,
-                                    Kobe and Yokohama</cell>
+                                <cell rows="2">For Aden, Colombo, Singapore, Saigon, Hong-Kong, Shanghai, Kobe and Yokohama</cell>
                                 <cell>Saturday</cell>
                                 <cell>1</cell>
                                 <cell>July</cell>
@@ -586,8 +523,7 @@
                                 <cell>Capt. Bourdon</cell>
                             </row>
                             <row>
-                                <cell>For Djibouti, Colombo, Singapore, Saigon, Hong-Kong, Shanghai, Kobe
-                                    and Yokohama</cell>
+                                <cell>For Djibouti, Colombo, Singapore, Saigon, Hong-Kong, Shanghai, Kobe and Yokohama</cell>
                                 <cell>Saturday</cell>
                                 <cell>15</cell>
                                 <cell>July</cell>
@@ -595,8 +531,7 @@
                                 <cell>Capt. Guionnet</cell>
                             </row>
                             <row>
-                                <cell>For Djibouti, Zanzibar, Mutsamudu, Mayotte, Majunga, Nossi-Bé, D.
-                                    Suares, Tamatave, La Réunion and Maurice</cell>
+                                <cell>For Djibouti, Zanzibar, Mutsamudu, Mayotte, Majunga, Nossi-Bé, D. Suares, Tamatave, La Réunion and Maurice</cell>
                                 <cell>Sunday</cell>
                                 <cell>16</cell>
                                 <cell>July</cell>
@@ -604,8 +539,7 @@
                                 <cell>Capt. Jourdan</cell>
                             </row>
                             <row>
-                                <cell rows="2">For Djibouti, Aden, Mabé Diego-Suares, Ste. Marie, Tamatave,
-                                    La Réunion and Maurice</cell>
+                                <cell rows="2">For Djibouti, Aden, Mabé Diego-Suares, Ste. Marie, Tamatave, La Réunion and Maurice</cell>
                                 <cell>Saturday</cell>
                                 <cell>1</cell>
                                 <cell>July</cell>
@@ -620,8 +554,7 @@
                                 <cell>Capt. Riquier</cell>
                             </row>
                             <row>
-                                <cell>For Aden, <placeName ref="https://www.wikidata.org/wiki/Q1156">Bombay</placeName>, Colombo, Freemantle, Adelaide, Melbourne, Sidney, and
-                                    Noumes</cell>
+                                <cell>For Aden, <placeName ref="https://www.wikidata.org/wiki/Q1156">Bombay</placeName>, Colombo, Freemantle, Adelaide, Melbourne, Sidney, and Noumes</cell>
                                 <cell>Monday</cell>
                                 <cell>10</cell>
                                 <cell>July</cell>
@@ -629,7 +562,7 @@
                                 <cell>Capt. Boyer</cell>
                             </row>
                         </table>
-                        <p><placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>  Agency (Shepheard's Hotel) 28-2-905</p>
+                        <p><placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> Agency (Shepheard's Hotel) 28-2-905</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-pri01">
                         <head>Prince Line.</head>
@@ -764,8 +697,7 @@
                             </row>
                         </table>
                         <p>Good Accommodation for Passengers.</p>
-                        <p>Sailings every 10 days from Manchester and <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName> and fortnightly from Antwerp
-                            and <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> to <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> and Syrian Coast. The dates are approximate</p>
+                        <p>Sailings every 10 days from Manchester and <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName> and fortnightly from Antwerp and <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> to <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> and Syrian Coast. The dates are approximate</p>
                         <table rows="4" cols="8">
                             <row>
                                 <cell>OCEAN PRINCE</cell>
@@ -809,8 +741,7 @@
                             </row>
                         </table>
                         <p>HOMEWARD SAILINGS: -- The S.S. SPARTAN PRINCE is now loading for Manchester.</p>
-                        <p>For terms of freight or passage apply to C. J. Grace &amp; Co., <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>,
-                            Agents. 31-12-904</p>
+                        <p>For terms of freight or passage apply to C. J. Grace &amp; Co., <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>, Agents. 31-12-904</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-nml01">
                         <head>THE NATIONAL MUTUAL LIFE ASSOCIATION OF AUSTRALASIA, LIMITED.</head>
@@ -818,8 +749,7 @@
                         <p>With Profits Distributed every 3 Years. </p>
                         <p>Nearest Age 30.-Sun Assured £1,000.-Payable at age 50.</p>
                         <p>ANNUAL PREMIUM £47:18:4 TOTAL COST £958:6:8</p>
-                        <p>Minimum Return Over Cost exclusive of Bonuses £41:13:4. Several options at the
-                            end of 20 years. Guaranteed benefits during 20 years.</p>
+                        <p>Minimum Return Over Cost exclusive of Bonuses £41:13:4. Several options at the end of 20 years. Guaranteed benefits during 20 years.</p>
                         <table rend="frame">
                             <row>
                                 <cell/>
@@ -866,13 +796,8 @@
                     <div type="item" scope="advertisement" xml:id="deg-ad-bal01">
                         <head>BANK OF ATHENS, LIMITED.</head>
                         <p><hi rend="bold">Capital 20,000,000 (Fully paid up).</hi></p>
-                        <p>BRANCHES: <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> 55-56 Bishops gate-street Within-<placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>, <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> ,
-                            Constantinople, Smyrna, At Candia and throughout <placeName ref="https://www.wikidata.org/wiki/Q41">Greece</placeName>.</p>
-                        <p>The Bank undertakes all banking business in Egypt, <placeName ref="https://www.wikidata.org/wiki/Q41">Greece</placeName>,<lb/> etc.
-                            Interest, on cash deposits: 3 0/0 per ann. at sight; 3 1/2 0/0 <lb/> per
-                            ann. for 6 months ; 4 0/0 per ann. for 12 months ; 5 0/0 per<lb/> ann.
-                            for 3 years and over. Savings Bank Branch receives de-<lb/>posits at 3
-                            1/2 0/0 per ann., from P.T. 30 to P.T. 10,000. 23538-19-1.905</p>
+                        <p>BRANCHES: <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> 55-56 Bishops gate-street Within-<placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>, <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> , Constantinople, Smyrna, At Candia and throughout <placeName ref="https://www.wikidata.org/wiki/Q41">Greece</placeName>.</p>
+                        <p>The Bank undertakes all banking business in Egypt, <placeName ref="https://www.wikidata.org/wiki/Q41">Greece</placeName>,<lb/> etc. Interest, on cash deposits: 3 0/0 per ann. at sight; 3 1/2 0/0 <lb/> per ann. for 6 months ; 4 0/0 per ann. for 12 months ; 5 0/0 per<lb/> ann. for 3 years and over. Savings Bank Branch receives de-<lb/>posits at 3 1/2 0/0 per ann., from P.T. 30 to P.T. 10,000. 23538-19-1.905</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-iob01">
                         <head>IMPERIAL OTTOMAN BANK.</head>
@@ -880,23 +805,20 @@
                         <p>HEAD OFFIOE IN CONSTANTINOPLE. CHIEF AGENCIES: <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> &amp; <placeName ref="https://www.wikidata.org/wiki/Q90">Paris</placeName>.</p>
                         <p>BRANCHES IN ALL THE PRINCIPAL TOWNS IN <placeName ref="https://www.wikidata.org/wiki/Q43">Turkey</placeName>.</p>
                         <p>Agencies in <placeName ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName>: <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>, <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> , &amp; <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>.</p>
-                        <p>Advances on Merchandise and Securities in current account and for fixed periods.
-                            Purchase and sale of stocks and Shares on the <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> and Continental exchanges,
-                            letters of credit issued, valuables reoeived in safe custody. Drafts, cheques
-                            and telegraphic transfers issued on the principal towns of the world. Foreign
-                            exchange purchased, bills discounted, bills, invoices, annuities and dividends
-                            collected and every description of banking business transacted. 18-4-906</p>
+                        <p>Advances on Merchandise and Securities in current account and for fixed periods. Purchase and sale of stocks and Shares on the <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> and Continental exchanges, letters of credit issued, valuables reoeived in safe custody. Drafts, cheques and telegraphic transfers issued on the principal towns of the world. Foreign exchange purchased, bills discounted, bills, invoices, annuities and dividends collected and every description of banking business transacted. 18-4-906</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-sgr01">
                         <head>SUDAN GOVERNMENT RAILWAYS.</head>
                         <p><placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> -KHARTOUM SUMMER MAIL SERVICE.</p>
 
-                            <table rows="3" cols="7">
+
+                        <table rows="3" cols="7">
                             <row>
                                 <cell>Wednesday and *Saturday</cell>
                                 <cell>8 p.m.</cell>
                                 <cell>depart</cell>
-                                <cell><placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> </cell>
+                                <cell><placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>
+                                </cell>
                                 <cell>arrive</cell>
                                 <cell>*Monday and *Friday</cell>
                                 <cell>7.20 a.m.</cell>
@@ -929,34 +851,20 @@
                                 <cell>12 noon</cell>
                             </row>
                         </table>
-                        <p>Mail delivered Khartoum, Sun. and Wednesday evening, and <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> , Mon. and Friday
-                            evening. *Dining and Sleeping Cars.</p>
+                        <p>Mail delivered Khartoum, Sun. and Wednesday evening, and <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> , Mon. and Friday evening. *Dining and Sleeping Cars.</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-sde01">
                         <head>SUDAN DEVELOPMENT &amp; EXPLORATION COMPANY, LIMITED</head>
-                        <p>KHARTOUM: <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>  Office, Sharia Kasr-el-Nil.</p>
-                        <p>TRANSPORT DEPARTMENT. Six days White Nile Tourist Trip dep. Khartoum Tuesdays.
-                            Steamer plans may be seen and passages booked at all <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>  Tourist Agents. -
-                            Special Steamers for private charter. - Trips arranged and transport of goods
-                            undertaken to all places on White and Blue Niles within navigation limits.</p>
-                        <p>ENGINEERING DEPARTMENT. Shipyard for construction of sternwheel steamers, barges,
-                            stream, motor launches, etc. Contractors for supply and erection of all classes
-                            of machinery, buildings, irrigation pumps, etc.</p>
-                        <p>SOLE AGENTS FOR Dudbridges Oil Engines from 1 to 25 B.H.P. as supplied to Sudan
-                            Government. Seamless xxxxxxxxxxxxxxxxxxxxx</p>
+                        <p>KHARTOUM: <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> Office, Sharia Kasr-el-Nil.</p>
+                        <p>TRANSPORT DEPARTMENT. Six days White Nile Tourist Trip dep. Khartoum Tuesdays. Steamer plans may be seen and passages booked at all <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> Tourist Agents. - Special Steamers for private charter. - Trips arranged and transport of goods undertaken to all places on White and Blue Niles within navigation limits.</p>
+                        <p>ENGINEERING DEPARTMENT. Shipyard for construction of sternwheel steamers, barges, stream, motor launches, etc. Contractors for supply and erection of all classes of machinery, buildings, irrigation pumps, etc.</p>
+                        <p>SOLE AGENTS FOR Dudbridges Oil Engines from 1 to 25 B.H.P. as supplied to Sudan Government. Seamless xxxxxxxxxxxxxxxxxxxxx</p>
                     </div>
                     <cb n="3"/>
                     <div type="item" scope="advertisement" xml:id="deg-ad-aan01">
                         <head>Anglo-American Nile Steamer &amp; Hotel Coy.</head>
-                        <p>Weekly departure during Winter Season by the<lb/> Luxurious First Class Tourist
-                            Steamers VICTORIA, PURITAN &amp; MAYFLOWER.<lb/> Regular weekly Departures to
-                            the SECOND CATARACT by the S.S. IndianA.<lb/> THROUGH BOOKINGS TO KHARTOUM,
-                            GONDOKORO AND THE WHITE NILE.<lb/> Steamers and Dahabeahs for private charter.
-                            Steam Tugs and Steam Launches for hire.<lb/> FREIGHT SERVICE BY STEAM BARGES
-                            BETWEEN <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>  AND <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>.<lb/> Working in conjunction and under special
-                            arrangement with the<lb/> “Upper <placeName ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName>Hotels Company."</p>
-                        <p>For details and illustrated programmes apply to "THE ANGLO-AMERICAN NILE STEAMER
-                            and<lb/> HOTEL COMPANY."</p>
+                        <p>Weekly departure during Winter Season by the<lb/> Luxurious First Class Tourist Steamers VICTORIA, PURITAN &amp; MAYFLOWER.<lb/> Regular weekly Departures to the SECOND CATARACT by the S.S. IndianA.<lb/> THROUGH BOOKINGS TO KHARTOUM, GONDOKORO AND THE WHITE NILE.<lb/> Steamers and Dahabeahs for private charter. Steam Tugs and Steam Launches for hire.<lb/> FREIGHT SERVICE BY STEAM BARGES BETWEEN <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> AND <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>.<lb/> Working in conjunction and under special arrangement with the<lb/> “Upper <placeName ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName>Hotels Company."</p>
+                        <p>For details and illustrated programmes apply to "THE ANGLO-AMERICAN NILE STEAMER and<lb/> HOTEL COMPANY."</p>
                         <p> OFFICES IN <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> : Sharia Boulac, "Grand Continental Hotel Buildings.” 31-3-06</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-nll01">
@@ -966,8 +874,7 @@
                         <p>The following steamers are intended to leave <placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName> : </p>
                         <table rows="14" cols="3">
                             <row>
-                                <cell cols="3">HOMEWARD : for Bremen Hamburg via Naples, Genoa, (Gibraltar),
-                                    Southampton, Antwerp.</cell>
+                                <cell cols="3">HOMEWARD : for Bremen Hamburg via Naples, Genoa, (Gibraltar), Southampton, Antwerp.</cell>
                             </row>
                             <row>
                                 <cell>Zieten</cell>
@@ -995,8 +902,7 @@
                                 <cell>about 28 August</cell>
                             </row>
                             <row>
-                                <cell cols="3">OUTWARD: for <placeName ref="https://www.wikidata.org/wiki/Q148">China</placeName> and JAPAN via <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>, ADEN, COLOMBO, PENANG,
-                                    SINGAPORE.</cell>
+                                <cell cols="3">OUTWARD: for <placeName ref="https://www.wikidata.org/wiki/Q148">China</placeName> and JAPAN via <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>, ADEN, COLOMBO, PENANG, SINGAPORE.</cell>
                             </row>
                             <row>
                                 <cell>Prinz E. Friedrich</cell>
@@ -1033,19 +939,15 @@
                             </row>
                         </table>
                         <p>FOR FURTHER PARTICULARS APPLY TO THE AGENTS OF THE </p>
-                        <p>NORDDEUTSCHER LLOYD at <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> , <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>, <placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName>  and <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>. </p>
+                        <p>NORDDEUTSCHER LLOYD at <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> , <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>, <placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName> and <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>. </p>
                         <p>OTTO STERZING, Agent In <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> , Opera Square. </p>
                         <p>C. H. SCHOELLER, Agent In <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>, Cleopatra Lane.</p>
-                        <p>Messrs. THOS. COOK &amp; SON (Egypt) LTD., and CARL STANGENS REISEBUREAN are
-                            anthorised to sell tickets in <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>  and <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>, 31-8-905</p>
+                        <p>Messrs. THOS. COOK &amp; SON (Egypt) LTD., and CARL STANGENS REISEBUREAN are anthorised to sell tickets in <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> and <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>, 31-8-905</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-als01">
                         <head>Austrian Lloyd’s Steam Navigation</head>
                         <p><placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>-Brindisi-Venice-Trieste.</p>
-                        <p>Weekly Express Mail Service. Steamers leave <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> every Saturday at 4 p.m.
-                            arrive at Brindisi, Tuesday a.m. in time for express to <placeName ref="https://www.wikidata.org/wiki/Q90">Paris</placeName>, <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName>, Naples,
-                            Rome. Arrival Trieste Wednesday noon connecting with Vienna Express
-                            (Trieste-Ostende through carriage) and expresses to Italy and Germany.</p>
+                        <p>Weekly Express Mail Service. Steamers leave <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> every Saturday at 4 p.m. arrive at Brindisi, Tuesday a.m. in time for express to <placeName ref="https://www.wikidata.org/wiki/Q90">Paris</placeName>, <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName>, Naples, Rome. Arrival Trieste Wednesday noon connecting with Vienna Express (Trieste-Ostende through carriage) and expresses to Italy and Germany.</p>
                         <table rows="3" cols="8">
                             <row>
                                 <cell>July 8</cell>
@@ -1091,20 +993,13 @@
                                 <cell>Capt. Knezevich</cell>
                             </row>
                         </table>
-                        <p>(Departures from <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>) To Aden, <placeName ref="https://www.wikidata.org/wiki/Q1156">Bombay</placeName>, Colombo, Penang, Singapore, Hong-Kong,
-                            Shanghai, Yokohama, Kobé about July 5 and August 4. To Aden, Karachi, and <placeName ref="https://www.wikidata.org/wiki/Q1156">Bombay</placeName>
-                            accelerated service about August 18. To Aden, Karachi, <placeName ref="https://www.wikidata.org/wiki/Q1156">Bombay</placeName>, Colombo, Madras,
-                            Rangoon, and Calcutta about July 20.</p>
+                        <p>(Departures from <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>) To Aden, <placeName ref="https://www.wikidata.org/wiki/Q1156">Bombay</placeName>, Colombo, Penang, Singapore, Hong-Kong, Shanghai, Yokohama, Kobé about July 5 and August 4. To Aden, Karachi, and <placeName ref="https://www.wikidata.org/wiki/Q1156">Bombay</placeName> accelerated service about August 18. To Aden, Karachi, <placeName ref="https://www.wikidata.org/wiki/Q1156">Bombay</placeName>, Colombo, Madras, Rangoon, and Calcutta about July 20.</p>
                         <p>East African Line.</p>
-                        <p>To Aden, Mombassa, Zanzibar, Beira, Delagoa Bay, Durban, about July 4 and August
-                            3.</p>
+                        <p>To Aden, Mombassa, Zanzibar, Beira, Delagoa Bay, Durban, about July 4 and August 3.</p>
                         <p>Syrian-Cyprus-Caramanian Line.</p>
                         <p>Steamers leaves <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> on or about July 3, 17 and 31.</p>
-                        <p>For information apply to the Agents, <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>, <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> and <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>, Thos. Cook
-                            &amp; Son, Ld., Leon Heller, <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>  Agent, 4, Sharia Maghraby, (Telephone 192),
-                            <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> ; F. Tedeschi, Helouan.</p>
-                        <p>Special passage rates granted to Egyptian Government officials, members of the
-                            Army of Occupation and their families. </p>
+                        <p>For information apply to the Agents, <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>, <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> and <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>, Thos. Cook &amp; Son, Ld., Leon Heller, <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> Agent, 4, Sharia Maghraby, (Telephone 192), <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> ; F. Tedeschi, Helouan.</p>
+                        <p>Special passage rates granted to Egyptian Government officials, members of the Army of Occupation and their families. </p>
                         <p>31-12-905</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-cun01">
@@ -1112,8 +1007,7 @@
                         <table rows="4" cols="6">
                             <head><placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> to New-York and Boston via the Continent and <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName></head>
                             <row>
-                                <cell cols="6">Sailings from <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName> on Saturdays and Tuesdays. Royal Mail
-                                    Steamers:</cell>
+                                <cell cols="6">Sailings from <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName> on Saturdays and Tuesdays. Royal Mail Steamers:</cell>
                             </row>
                             <row>
                                 <cell>Caronia</cell>
@@ -1143,8 +1037,7 @@
                         <table rows="3" cols="4">
                             <head><placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> to New-York via Trieste, Fiume or Palermo</head>
                             <row>
-                                <cell cols="4">Regular twin-screw Passenger Service from the Adriatic.
-                                    Excellent accommodation.</cell>
+                                <cell cols="4">Regular twin-screw Passenger Service from the Adriatic. Excellent accommodation.</cell>
                             </row>
                             <row>
                                 <cell>Carpathia</cell>
@@ -1159,25 +1052,17 @@
                                 <cell>10,402 tons</cell>
                             </row>
                         </table>
-                        <p>All steamers fitted with Marconi's wireless telegraphy. For through tickets from
-                            Egypt, and particulars aply to the Agents Rodacanachi &amp; Co., <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>;
-                            Nic. Kerzis, <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> ; R. Broadbent, <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>. 19-1-905</p>
+                        <p>All steamers fitted with Marconi's wireless telegraphy. For through tickets from Egypt, and particulars aply to the Agents Rodacanachi &amp; Co., <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>; Nic. Kerzis, <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> ; R. Broadbent, <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>. 19-1-905</p>
                     </div>
                     <!-- TODO Russian Steam Navigation -->
                     <div type="item" scope="advertisement" xml:id="deg-ad-pap01">
                         <head>THE PAPAYANNI LINE.</head>
                         <head type="sub">(The Ellerman Lines, Ltd.)</head>
-                        <p>Frequent Sailings from <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> to <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName>, also Regular Services from
-                            <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName> to <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> and to ALGERIA, <placeName ref="https://www.wikidata.org/wiki/Q233">Malta</placeName>, LEVANT, BLACK SEA, and other
-                            Mediterranean Ports.</p>
-                        <p>Excellent Passenger Accommodation. Stewardess carried. Liberal table and Moderate
-                            Fares for single and retnrn tickets. </p>
-                        <p>The S S. SARDINIA will sail for <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName> (via Bona) on Friday, the 7th inst. at
-                            4 p.m.</p>
-                        <p>CARGO taken by special agreement only. Through Freights quoted for the UNITED
-                            STATES and INLAND TOWNS in GREAT BRITAIN.</p>
-                        <p>For passage or freight apply to the Agents, BARKER &amp; Co., <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>.
-                            2061-17-10-905 </p>
+                        <p>Frequent Sailings from <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> to <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName>, also Regular Services from <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName> to <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> and to ALGERIA, <placeName ref="https://www.wikidata.org/wiki/Q233">Malta</placeName>, LEVANT, BLACK SEA, and other Mediterranean Ports.</p>
+                        <p>Excellent Passenger Accommodation. Stewardess carried. Liberal table and Moderate Fares for single and retnrn tickets. </p>
+                        <p>The S S. SARDINIA will sail for <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName> (via Bona) on Friday, the 7th inst. at 4 p.m.</p>
+                        <p>CARGO taken by special agreement only. Through Freights quoted for the UNITED STATES and INLAND TOWNS in GREAT BRITAIN.</p>
+                        <p>For passage or freight apply to the Agents, BARKER &amp; Co., <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>. 2061-17-10-905 </p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-ell01">
                         <head>Ellerman Lines, Limited.</head>
@@ -1185,16 +1070,15 @@
                             <row>
                                 <cell cols="3">CITY LINE to <placeName ref="https://www.wikidata.org/wiki/Q233">Malta</placeName>, <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName>, COLOMBO &amp; CALCUTTA.</cell>
                                 <cell cols="3">
-                                    <p>CITY &amp; HALL LINES. Joint Service to <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName>, <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName>, <placeName ref="https://www.wikidata.org/wiki/Q1156">Bombay</placeName>
-                                        &amp; KARACHI.</p>
+                                    <p>CITY &amp; HALL LINES. Joint Service to <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName>, <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName>, <placeName ref="https://www.wikidata.org/wiki/Q1156">Bombay</placeName> &amp; KARACHI.</p>
                                 </cell>
                             </row>
                             <row>
-                                <cell cols="6">The undermentioned First Class Passenger Steamers will be
-                                    dispatched from <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> on or about the following dates for </cell>
+                                <cell cols="6">The undermentioned First Class Passenger Steamers will be dispatched from <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> on or about the following dates for </cell>
                             </row>
                             <row>
-                                <cell><placeName ref="https://www.wikidata.org/wiki/Q233">Malta</placeName> and <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> </cell>
+                                <cell><placeName ref="https://www.wikidata.org/wiki/Q233">Malta</placeName> and <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName>
+                                </cell>
                                 <cell>S.S. City of Corinth </cell>
                                 <cell>July 26</cell>
                                 <cell><placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName> and <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName></cell>
@@ -1210,20 +1094,13 @@
                                 <cell>July 13</cell>
                             </row>
                         </table>
-                        <p>SALOON FARES:—<placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> to <placeName ref="https://www.wikidata.org/wiki/Q233">Malta</placeName> £4.10.0. <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName>. £8.0.0. <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> or
-                            <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName>, £l2.l0.0. Colombo, Calcutta, <placeName ref="https://www.wikidata.org/wiki/Q1156">Bombay</placeName> or Karachi, £35.0.0. Special
-                            rates for steamers not carrying Doctor or Stewardess. For further particulars
-                            apply to </p>
-                        <p>CORY BROS. &amp; Co., Ltd., Agents for CITY Line, <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>: W. STAPLEDON &amp;
-                            SON, Agents for Hall Line, <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> ; or COOK &amp; SON (Egypt), Ltd., <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> .
-                            23788-28-8-905 </p>
+                        <p>SALOON FARES:—<placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> to <placeName ref="https://www.wikidata.org/wiki/Q233">Malta</placeName> £4.10.0. <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName>. £8.0.0. <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> or <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName>, £l2.l0.0. Colombo, Calcutta, <placeName ref="https://www.wikidata.org/wiki/Q1156">Bombay</placeName> or Karachi, £35.0.0. Special rates for steamers not carrying Doctor or Stewardess. For further particulars apply to </p>
+                        <p>CORY BROS. &amp; Co., Ltd., Agents for CITY Line, <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>: W. STAPLEDON &amp; SON, Agents for Hall Line, <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> ; or COOK &amp; SON (Egypt), Ltd., <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> . 23788-28-8-905 </p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-ell02">
                         <head>The Ellerman Lines, Limited.</head>
                         <head type="sub">(Including Westcott &amp; Laurance Line.)</head>
-                        <p>Regular sailings from <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName>, Glasgow, Antwerp and <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> to <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>.
-                            Frequent sailings from <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> to <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName> and <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName>. Through freight rates
-                            to Inland towns in Great Britain also to the U.S.A</p>
+                        <p>Regular sailings from <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName>, Glasgow, Antwerp and <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> to <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>. Frequent sailings from <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> to <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName> and <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName>. Through freight rates to Inland towns in Great Britain also to the U.S.A</p>
                         <table rows="4" cols="5">
                             <row>
                                 <cell>Westcott S.S. Joshua Nicholson</cell>
@@ -1254,8 +1131,7 @@
                                 <cell>July 30</cell>
                             </row>
                         </table>
-                        <p>Ellerman S.S. Britannia now on the berth for <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName> is expected to sail about
-                            the 25th inst.</p>
+                        <p>Ellerman S.S. Britannia now on the berth for <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName> is expected to sail about the 25th inst.</p>
                         <p>N. E. TAMVACO <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> agents 23186-20-3-3</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-ngi01">
@@ -1297,7 +1173,7 @@
                 </div>
             </div>
             <div type="page" n="2">
-                <div type="section" scope="advertisment">
+                <div type="section" scope="advertisement">
                     <cb n="1"/>
                     <div type="item" scope="advertisement" xml:id="deg-ad-ric01">
                         <head>Royal Insurance Coy</head>
@@ -1314,10 +1190,8 @@
                         <head>THE ARTESIAN BORING AND PROSPECTING COMPANY.</head>
                         <p>(SOCIÉTÉ ANONYME)</p>
                         <p>CAIRO, 28, SHARIA-EL-MANAKH,<lb/> (OPPOSITE IMPERIAL OTTOMAN BANK).</p>
-                        <p>I. —Installation of complete Water supplies for drinking, agricultural, and<lb/>
-                              industrial purposes by means of artesian wells.</p>
-                        <p>II. - Deep borings for prospecting purposes in all conditions of soil by means of
-                              the<lb/> “Express Boring System."</p>
+                        <p>I. —Installation of complete Water supplies for drinking, agricultural, and<lb/> industrial purposes by means of artesian wells.</p>
+                        <p>II. - Deep borings for prospecting purposes in all conditions of soil by means of the<lb/> “Express Boring System."</p>
                         <p>24,437-12-1-905</p>
                     </div>
                     <cols n="2"/>
@@ -1360,30 +1234,21 @@
                         <p>Subscribed Capital JS1.500,000</p>
                         <p> Paid up '' £ 500,000</p>
                         <p>Reserve Fund... 500,000</p>
-                        <p>The Anglo-Egyptian Bank. Limited, undertakes every description of banking
-                              business on the most favourable conditions.</p>
-                        <p>Current accounts opened with commercial homes and private individuals in
-                              conformity with the custom of Bankers.</p>
-                        <p>Fixed deposits for one year certain received at 8 per cent. per annum. Deposits
-                              at interest for shorter periods are also received at rates to be agreed upon.</p>
-                        <p>Letters of Credit for the use of travellers are issued payable in all parts of
-                              the World.</p>
+                        <p>The Anglo-Egyptian Bank. Limited, undertakes every description of banking business on the most favourable conditions.</p>
+                        <p>Current accounts opened with commercial homes and private individuals in conformity with the custom of Bankers.</p>
+                        <p>Fixed deposits for one year certain received at 8 per cent. per annum. Deposits at interest for shorter periods are also received at rates to be agreed upon.</p>
+                        <p>Letters of Credit for the use of travellers are issued payable in all parts of the World.</p>
                         <p>Approved bills discounted.</p>
                         <p>Bills, documentary invoices, etc, collected.</p>
                         <p>Drafts and telegraphic transfers issued payable all over the World.</p>
                         <p>Foreign exchange bought and sold.</p>
-                        <p>Advances made upon approved securities and upon cotton, cotton-seed, sugar and
-                              other merchandise.</p>
-                        <p>The purchase and sale of stocks and shares on the London Stock Exchange; and on
-                              the local and Continental Bourses, undertaken.</p>
-                        <p>Customers can deposit their valuables, bonds, etc., for safe custody in the
-                              Bank's fire-proof strong-rooms, and the Bank will attend to the collection of
-                              the coupons and drawn bonds so deporited as they fall due.</p>
+                        <p>Advances made upon approved securities and upon cotton, cotton-seed, sugar and other merchandise.</p>
+                        <p>The purchase and sale of stocks and shares on the London Stock Exchange; and on the local and Continental Bourses, undertaken.</p>
+                        <p>Customers can deposit their valuables, bonds, etc., for safe custody in the Bank's fire-proof strong-rooms, and the Bank will attend to the collection of the coupons and drawn bonds so deporited as they fall due.</p>
                         <p>Mercantile credits issued.</p>
                         <p>Annuities, pensions, dividends, etc., collected.</p>
                         <p>All farther particulars and information can be obtained on application.</p>
-                        <p>The officers and clerks of the Bank are pledged to secrecy as to the transactions
-                              of customers. 18-9-905</p>
+                        <p>The officers and clerks of the Bank are pledged to secrecy as to the transactions of customers. 18-9-905</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-adr">
                         <head>“AU DE ROUGE."</head>
@@ -1393,10 +1258,8 @@
                         <p>DIRECT IMPORTER OF BRITISH AND IRISH TEXTILE MANUFACTURES.</p>
                         <p>LADIES’ SUMMER STOCKINGS.</p>
                         <p> IN SPUN SILK at P.T. 20 per pair.</p>
-                        <p>LISLE THREAD, in plain and lace open-work, in black, white, tan and usual shades,
-                              to suit boots worn in Egypt, frpm P.T. 5 per pair.</p>
-                        <p>Every pair is marked “Au De Rouge" which is a guarantee that the Color is
-                              absolutely fast and stainless.</p>
+                        <p>LISLE THREAD, in plain and lace open-work, in black, white, tan and usual shades, to suit boots worn in Egypt, frpm P.T. 5 per pair.</p>
+                        <p>Every pair is marked “Au De Rouge" which is a guarantee that the Color is absolutely fast and stainless.</p>
                         <p>24916-15-11-905</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-pel01">
@@ -1434,14 +1297,12 @@
                         <p>Mackie &amp; Co. Glasgow. Lagavulin, White Horse Cellar &amp; other Whiskies.</p>
                         <p>Dunville &amp; Co, Ltd. Belfast. Old Irish Whiskies.</p>
                         <p>Wm. Lanahan &amp; Son. Baltimore. Monongshels XXXX Whiskey.</p>
-                        <p>The Cook &amp; Bernheimer Co. New York. Old Valley Whiskey and Gold Lion
-                              Cocktails.</p>
+                        <p>The Cook &amp; Bernheimer Co. New York. Old Valley Whiskey and Gold Lion Cocktails.</p>
                         <p>Stone &amp; Son. London. Guinness' Stout &amp; Bass' Pale Ale.</p>
                         <p>Freund Ballor &amp; Co. Tornio. Vermouth.</p>
                         <p>Pierre Bisset. Cette. Vermouth &amp; Aperitives.</p>
                         <p>Terrabonatea Company, Ld. Teas.</p>
-                        <p>Depot for Prince Metternich's "Richardsquelle," the best mineral table water in
-                              the world.</p>
+                        <p>Depot for Prince Metternich's "Richardsquelle," the best mineral table water in the world.</p>
                         <p>Great assortment of Wines, Spirits, Liqueurs, of the finest Brands, etc</p>
                     </div>
                     <cols n="2"/>
@@ -1451,9 +1312,9 @@
                 </div>
                 <cb n="2"/>
                 <div type="item" scope="calendar">
-                    <table cols="3" xml:id="CalendarOfTheWeek">
-                        <head>Calendar of Coming Events.</head>
-                        <div type="subsection">
+                    <head>Calendar of Coming Events.</head>
+                    <div type="subsection">
+                        <table cols="3" xml:id="CalendarOfTheWeek-Alexandria">
                             <head>Alexandria</head>
                             <head type="sub">October</head>
                             <row>
@@ -1461,8 +1322,8 @@
                                 <cell>5</cell>
                                 <cell>
                                     <p>Mex Casino. Reunion des Familles. 9.30 p.m.</p>
-                                    <p>Mex. Prinea's Restaurant des Bains Roumanian orechestra, every after-noon.  Sundays, morning.</p>
-                                    <p>Windsor Hotel.  Orchestra.  6 to 11.30 p.m. every day.</p>
+                                    <p>Mex. Prinea's Restaurant des Bains Roumanian orechestra, every after-noon. Sundays, morning.</p>
+                                    <p>Windsor Hotel. Orchestra. 6 to 11.30 p.m. every day.</p>
                                     <p>Alhambra -- Italian company. -- Frou Frou. 9.15 p.m.</p>
                                     <p>Crown Casino. Ibrahimieh. 9.30 p.m.</p>
                                     <p>Tour Eiffel. Variety Company. 9 p.m.</p>
@@ -1473,7 +1334,7 @@
                                 <cell>7</cell>
                                 <cell>
                                     <p>Alex. Swimming Club. 3rd Annual<lb/>Aquatic Sports. New Graving<lb/>Dock, Gabbari. 3 p.m.</p>
-                                    <p>San Stefano Casino.  Telepathy Demonstration. 9.30 p.m.</p>
+                                    <p>San Stefano Casino. Telepathy Demonstration. 9.30 p.m.</p>
                                 </cell>
                             </row>
                             <row>
@@ -1484,15 +1345,17 @@
                                     <p>B.R.C. Mustapha Pasha Range.<lb/>Practice and Cup Compeittion.<lb/>3 p.m.</p>
                                 </cell>
                             </row>
-                        </div>
-                        <div type="subsection">
+                        </table>
+                    </div>
+                    <div type="subsection">
+                        <table cols="3" xml:id="CalendarOfTheWeek-Cairo">
                             <head>Cairo</head>
                             <head type="sub">October</head>
                             <row>
                                 <cell>Thrus.</cell>
                                 <cell>5</cell>
                                 <cell>
-                                    <p>Esbekieh Theatre.  French Operetta Company. 9.15 p.m.</p>
+                                    <p>Esbekieh Theatre. French Operetta Company. 9.15 p.m.</p>
                                     <p>Theatre des Nouveautes. 9.30 p.m.</p>
                                     <p>Alcazar Parisien. 9.30 p.m.</p>
                                 </cell>
@@ -1508,7 +1371,7 @@
                                 <cell>Tues.</cell>
                                 <cell>10</cell>
                                 <cell>
-                                    <p>Esbekieh Gardens.  performance by British Military Band. 9 to 11 p.m.</p>
+                                    <p>Esbekieh Gardens. performance by British Military Band. 9 to 11 p.m.</p>
                                 </cell>
                             </row>
                             <row>
@@ -1516,8 +1379,8 @@
                                 <cell>16</cell>
                                 <cell>Cairo Musical and Dramatic Society.<lb/>Concert in aid of Calabrian Victims.<lb/>Distinguished Patronage.</cell>
                             </row>
-                        </div>
-                    </table>
+                        </table>
+                    </div>
                 </div>
                 <cols n="1"/>
                 <cb n="3"/>
@@ -1526,8 +1389,7 @@
                     <head type="sub">ALBERT BENSILUM<lb/>Deceased</head>
                     <p>Pursuant to Act of Parliament 22nd and 23rd Vic. Ch 35 Sec. 29 Notice is hereby given tha tthe creditors of Albert Bensilum late of <placeName>Wadi Natron</placeName> who died intestate on or about the 29th of June 1905 and letters of administratin were granted the 4th day of October 1905 by the above mentioned Court to Leone Bensilum deceased's lawful uncle, are required to send in particulars of their claims to the undersigeriadvocate of the said administrator within thirdy days from the date hereof after which the said administrator will proceed to distribute the assets of the deceased having regard only to the lcaims of which he shall then have notice and will nto be liable for the assets so distributed to any person of whose claims he shall not then have thus recieved notice.</p>
                     <dateline>Dated this 5th day of October 1905.</dateline>
-                    <byline>M. A. Caloyanni.</byline>
-                    <p>Avocat a la Cour d'Appel.  Barrister-at-Law.</p>
+                    <byline>M. A. Caloyanni.<lb/>Avocat a la Cour d'Appel. Barrister-at-Law.</byline>
                 </div>
                 <div type="section" scope="weather">
                     <head>DAILY WEATHER REPORT</head>
@@ -1736,23 +1598,12 @@
                 </div>
                 <div type="item" scope="newspaper">
                     <head>THE EGYPTIAN GAZETTE.</head>
-                    <p>SUBSCRIPTIONS.—Alexandria, Cairo, and the Interior of Egypt (including
-                        delivery in Alexandria or postage to subscriber’s address) P.T. 231½ per
-                        annum, P.T. 116 for six months, P.T. 80 for three months. To other countries
-                        in the Postal Union P.T. 273 (£2.16s.) per annum. Six months P.T. 136½
-                        (£1.8s.), three months P.T. 92 (£0.19s.) N.B.—Subscriptions commence from
-                        the 1st or 16th of any month. </p>
-                    <p>ADVERTISEMENTS.—P.T. 4 per line. Minimum charge P.T. 20. Births, Marriages,
-                        or Deaths, not exceeding three lines, P.T. 20. Every additional line P.T.
-                        10. Notices in news column P.T. 20 per line. Contracts entered into for
-                        standing advertisements. </p>
-                    <p>SUBSCRIPTIONS and ADVERTISEMENTS are due in advance. P.O. Orders and Cheques
-                        to be made payable to the Editor and Manager, Rowland Snelling, Alexandria. </p>
+                    <p>SUBSCRIPTIONS.—Alexandria, Cairo, and the Interior of Egypt (including delivery in Alexandria or postage to subscriber’s address) P.T. 231½ per annum, P.T. 116 for six months, P.T. 80 for three months. To other countries in the Postal Union P.T. 273 (£2.16s.) per annum. Six months P.T. 136½ (£1.8s.), three months P.T. 92 (£0.19s.) N.B.—Subscriptions commence from the 1st or 16th of any month. </p>
+                    <p>ADVERTISEMENTS.—P.T. 4 per line. Minimum charge P.T. 20. Births, Marriages, or Deaths, not exceeding three lines, P.T. 20. Every additional line P.T. 10. Notices in news column P.T. 20 per line. Contracts entered into for standing advertisements. </p>
+                    <p>SUBSCRIPTIONS and ADVERTISEMENTS are due in advance. P.O. Orders and Cheques to be made payable to the Editor and Manager, Rowland Snelling, Alexandria. </p>
                     <p>London Offices : 36, New Broad-street. B.C. </p>
-                    <p>THE EGYPTIAN GAZETTE can be obtained in London at our office, 36, New Broad
-                        Street, E.C., and also at Messrs. May &amp; Williams 160, Piccadilly, W. </p>
-                    <p>THE “EGYPTIAN GAZETTE” IS PRINTED ON PAPER MANUFACTURED AND SUPPLIED BY THE
-                        LONDON PAPER MILLS Co., LIMITED (SALES OFFICE: 27, CANNON STREET, E.C.) </p>
+                    <p>THE EGYPTIAN GAZETTE can be obtained in London at our office, 36, New Broad Street, E.C., and also at Messrs. May &amp; Williams 160, Piccadilly, W. </p>
+                    <p>THE “EGYPTIAN GAZETTE” IS PRINTED ON PAPER MANUFACTURED AND SUPPLIED BY THE LONDON PAPER MILLS Co., LIMITED (SALES OFFICE: 27, CANNON STREET, E.C.) </p>
                 </div>
                 <div type="item">
                     <head>MARRIAGE</head>

--- a/1905-10-06.xml
+++ b/1905-10-06.xml
@@ -36,18 +36,12 @@
                     <div type="item" scope="advertisement" xml:id="deg-ad-pos01">
                         <head>Peninsular and Oriental S. N. Company.</head>
                         <p>Summer Rates will be charged from 2 May to 31 October. </p>
-                        <p>For the convenience of families and others, a large portion of each ship’s
-                            accommodation has been reserved for Egypt, so that Berths can be definitely
-                            engaged at once, as if the voyage were commencing at <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>. Plans can be
-                            seen at the Offices of the Company’s Agents. </p>
-                        <p>The through Steamers for <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName> and <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> are intended to leave <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>
-                            after the arrival of the 11 a.m. train from <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> , every Tuesday for the present
-                            except the MONGOLIA, which is taking passengers to the Anglo-French Naval
-                            Review, and will not wait at <placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName>  on 24/25 July. A steam tender will meet
-                            the train to convey passengers to the ship. </p>
+                        <p>For the convenience of families and others, a large portion of each ship’s accommodation has been reserved for Egypt, so that Berths can be definitely engaged at once, as if the voyage were commencing at <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>. Plans can be seen at the Offices of the Company’s Agents. </p>
+                        <p>The through Steamers for <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName> and <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> are intended to leave <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> after the arrival of the 11 a.m. train from <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> , every Tuesday for the present except the MONGOLIA, which is taking passengers to the Anglo-French Naval Review, and will not wait at <placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName> on 24/25 July. A steam tender will meet the train to convey passengers to the ship. </p>
                         <table>
                             <row>
-                                <cell><placeName ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName> </cell>
+                                <cell><placeName ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName>
+                                </cell>
                                 <cell>4 July</cell>
                                 <cell>Arcadia </cell>
                                 <cell>1 August</cell>
@@ -67,7 +61,8 @@
                                 <cell>18 July</cell>
                                 <cell>Arabia </cell>
                                 <cell>15 August</cell>
-                                <cell><placeName ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName> </cell>
+                                <cell><placeName ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName>
+                                </cell>
                                 <cell>12 Sept.</cell>
                             </row>
                             <row>
@@ -79,27 +74,27 @@
                                 <cell>19 Sept.</cell>
                             </row>
                         </table>
-                        <p>The Brindisi Express Steamers leave <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> directly the Indian Mails arrive.
-                            Passengers can go on board the evening before. The Fare remains as usual. </p>
+                        <p>The Brindisi Express Steamers leave <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> directly the Indian Mails arrive. Passengers can go on board the evening before. The Fare remains as usual. </p>
                         <p>For all further information apply to the Company's Agents, </p>
                         <p>Messrs. THOS. COOK &amp; SON (Egypt) Ltd. <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> . </p>
                         <p>GEORGE ROYLE, Esq. <placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName> . </p>
                         <p>Messrs. HABELDEN &amp; Co. <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>. </p>
-                        <p> F. G. DAVIDSON, Superintendent P. &amp; O. S. N. Company in <placeName ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName> <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>. </p>
+                        <p> F. G. DAVIDSON, Superintendent P. &amp; O. S. N. Company in <placeName ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName>
+                            <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>. </p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-opl01">
                         <head>Orient-Pacific Line of Royal Mail Steamers.</head>
                         <p>REDUCED SUMMER FARES FROM MAY TO OCTOBER INCLUSIVE.</p>
                         <p>OUTWARDS to <placeName ref="https://www.wikidata.org/wiki/Q408">Australia</placeName> .</p>
-                        <p>R.M.S. “Orotava" will leave <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName> about July 28 | R.M.S "Ormuz" will leave <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>
-                            about August 11. </p>
-                        <p>HOMEWARDS to <placeName ref="https://www.wikidata.org/wiki/Q2634">Naples</placeName>  <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName>, GIBRALTAR, PLYMOUTH, <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName>, TILBURY</p>
-                        <p>R.M.S. "Oroya" will leave <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> about July 18 | R.M.S. “Ortona" will leave
-                            <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> about August 1</p>
+                        <p>R.M.S. “Orotava" will leave <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName> about July 28 | R.M.S "Ormuz" will leave <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName> about August 11. </p>
+                        <p>HOMEWARDS to <placeName ref="https://www.wikidata.org/wiki/Q2634">Naples</placeName>
+                            <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName>, GIBRALTAR, PLYMOUTH, <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName>, TILBURY</p>
+                        <p>R.M.S. "Oroya" will leave <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> about July 18 | R.M.S. “Ortona" will leave <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> about August 1</p>
                         <table>
                             <row>
                                 <cell rows="4">Reduced Summer Fares</cell>
-                                <cell><placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName>  to <placeName ref="https://www.wikidata.org/wiki/Q2634">Naples</placeName> </cell>
+                                <cell><placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName> to <placeName ref="https://www.wikidata.org/wiki/Q2634">Naples</placeName>
+                                </cell>
                                 <cell>1st Class</cell>
                                 <cell>£ 11</cell>
                                 <cell>2nd Class</cell>
@@ -108,7 +103,7 @@
                                 <cell>£ 4.8</cell>
                             </row>
                             <row>
-                                <cell><placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName>  to <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName></cell>
+                                <cell><placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName> to <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName></cell>
                                 <cell>1st Class</cell>
                                 <cell>£ 12.12</cell>
                                 <cell>2nd Class</cell>
@@ -117,7 +112,7 @@
                                 <cell>£ 5.10</cell>
                             </row>
                             <row>
-                                <cell><placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName>  to Gibraltar</cell>
+                                <cell><placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName> to Gibraltar</cell>
                                 <cell>1st Class</cell>
                                 <cell>£ 18.0</cell>
                                 <cell>2nd Class</cell>
@@ -126,7 +121,7 @@
                                 <cell>£ 5.10</cell>
                             </row>
                             <row>
-                                <cell><placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName>  to Plymouth or Tilbury</cell>
+                                <cell><placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName> to Plymouth or Tilbury</cell>
                                 <cell>1st Class</cell>
                                 <cell>£ 16.16</cell>
                                 <cell>2nd Class</cell>
@@ -136,13 +131,9 @@
                             </row>
                         </table>
                         <p>Egyptian Government Officials allowed a rebate of 15% off the above fares.</p>
-                        <p>Return tickets no longer issued, but passengers paying full fare in one direction
-                            allowed abatement of 1/3 fare back if return voyage be within 4 months of
-                            arrival, or abatement of 20 o/o if return voyage be made within 8 months of
-                            arrival.</p>
-                        <p>Agents. <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> :—Thos. Cook &amp; Son. <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> : —R. J. Moss &amp; Co.—For all
-                            information apply </p>
-                        <p>Wm. STAPLEDON &amp; Sons, <placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName>  &amp; PORT-TEWFIK (<placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>) 31-12-904</p>
+                        <p>Return tickets no longer issued, but passengers paying full fare in one direction allowed abatement of 1/3 fare back if return voyage be within 4 months of arrival, or abatement of 20 o/o if return voyage be made within 8 months of arrival.</p>
+                        <p>Agents. <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> :—Thos. Cook &amp; Son. <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> : —R. J. Moss &amp; Co.—For all information apply </p>
+                        <p>Wm. STAPLEDON &amp; Sons, <placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName> &amp; PORT-TEWFIK (<placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>) 31-12-904</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-blm01">
                         <head>BIBBY LINE MAIL STEAMERS.</head>
@@ -153,37 +144,30 @@
                         <p>HOMEWARDS to <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName> and <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName>. Departures from <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>.</p>
                         <p>S.S. Worcestershire 7,160 tons, leaves about July 26.</p>
                         <p>S.S. Yorkshire 4,196 tons leaves about August 9,</p>
-                        <p>FARES from <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> to <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName> £12.0.0, <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> £17.0.0, Colombo £32.10.0,
-                            Rangoon £37.10.0. </p>
-                        <p>Agents <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> : THOS. COOK &amp; SON. <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName> &amp; <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> : WM. STAPLEDON &amp; SONS,
-                            31-12-905</p>
+                        <p>FARES from <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> to <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName> £12.0.0, <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> £17.0.0, Colombo £32.10.0, Rangoon £37.10.0. </p>
+                        <p>Agents <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> : THOS. COOK &amp; SON. <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName> &amp; <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> : WM. STAPLEDON &amp; SONS, 31-12-905</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-kml01">
                         <head>KHEDIVIAL MAIL LINE.</head>
-                        <head type="sub">FAST BRITISH PASSENGER STEAMERS</head>
-                        <head type="sub"><placeName ref="https://www.wikidata.org/wiki/Q41">Greece</placeName> - <placeName ref="https://www.wikidata.org/wiki/Q43">Turkey</placeName> LINE.</head>
-                        <p>Express Steamers leave <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> every Wednesday at 4 p.m. for PIRAEUS, SMYRNA,
-                            MITYLENE, and CONSTANTINOPLE, in connection with Orient Express train-de-luxe
-                            for Vienna, <placeName ref="https://www.wikidata.org/wiki/Q90">Paris</placeName>, and <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName>.</p>
-                        <head type="sub">PALESTINE - SYRIA LINE.</head>
-                        <p>Fast steamers leave <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> every Saturday at 6 p.m., and <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> every
-                            Sunday at 6 p.m., for JAFFA (for Jerusalem), CAIFFA (for Nazareth), BEYROUT (for
-                            Damascus), TRIPOLI, ALEXANDRETTA, MESSINA, continuing in alternate weeks to
-                            LARNACA and LIMASSOL (Cyprus).</p>
-                        <head type="sub">RED SEA LINE.</head>
-                        <p>Steamers leave <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName> fortnightly on Wednesday at 6 p.m. for JEDDAH, SUAKIN,
-                            MASSOWAH, HODBIDAH, and ADEN ; and in the intervening weeks for PORT SUDAN and
-                            SUAKIN direct. Calls will be made at TOR (for Mount Sinai) as required.</p>
-                        <p>N.B.—Deck chairs provided for the use of passengers, excellent cuisine and table
-                            wine free.</p>
-                        <p>Steamer plans may be seen and passages booked at the Company’s Agencies at
-                            <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>, <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> , <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>, and <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>, or at THOS. COOK &amp; SON or other
-                            Tourist Agency. 31-12-904</p>
+                        <div type="subsection">
+                            <head type="sub">FAST BRITISH PASSENGER STEAMERS</head>
+                            <head type="sub"><placeName ref="https://www.wikidata.org/wiki/Q41">Greece</placeName> - <placeName ref="https://www.wikidata.org/wiki/Q43">Turkey</placeName> LINE.</head>
+                            <p>Express Steamers leave <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> every Wednesday at 4 p.m. for PIRAEUS, SMYRNA, MITYLENE, and CONSTANTINOPLE, in connection with Orient Express train-de-luxe for Vienna, <placeName ref="https://www.wikidata.org/wiki/Q90">Paris</placeName>, and <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName>.</p>
+                        </div>
+                        <div type="subsection">
+                            <head type="sub">PALESTINE - SYRIA LINE.</head>
+                            <p>Fast steamers leave <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> every Saturday at 6 p.m., and <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> every Sunday at 6 p.m., for JAFFA (for Jerusalem), CAIFFA (for Nazareth), BEYROUT (for Damascus), TRIPOLI, ALEXANDRETTA, MESSINA, continuing in alternate weeks to LARNACA and LIMASSOL (Cyprus).</p>
+                        </div>
+                        <div type="subsection">
+                            <head type="sub">RED SEA LINE.</head>
+                            <p>Steamers leave <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName> fortnightly on Wednesday at 6 p.m. for JEDDAH, SUAKIN, MASSOWAH, HODBIDAH, and ADEN ; and in the intervening weeks for PORT SUDAN and SUAKIN direct. Calls will be made at TOR (for Mount Sinai) as required.</p>
+                            <p>N.B.—Deck chairs provided for the use of passengers, excellent cuisine and table wine free.</p>
+                            <p>Steamer plans may be seen and passages booked at the Company’s Agencies at <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>, <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> , <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>, and <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>, or at THOS. COOK &amp; SON or other Tourist Agency. 31-12-904</p>
+                        </div>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-mss01">
                         <head>The Moss S.S. Company, Ltd.</head>
-                        <p>For <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName> calling at <placeName ref="https://www.wikidata.org/wiki/Q233">Malta</placeName> (Messrs. JAMES MOSS &amp; Co. 31, James St,
-                            <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName>, Managers.)</p>
+                        <p>For <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName> calling at <placeName ref="https://www.wikidata.org/wiki/Q233">Malta</placeName> (Messrs. JAMES MOSS &amp; Co. 31, James St, <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName>, Managers.)</p>
                         <table rows="3" cols="8">
                             <row>
                                 <cell>*Amasis</cell>
@@ -216,18 +200,11 @@
                                 <cell>(Building)</cell>
                             </row>
                         </table>
-                        <p>*Second class accommodation only, unless specially reserved.—Fares : <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>
-                            to <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName>, 1st, £14 Single, £25 Return. 2nd, £9 Single, £15 Return.—To <placeName ref="https://www.wikidata.org/wiki/Q233">Malta</placeName>,
-                            1st, £5 Single, £9 Return, 2nd, £3 Single, £5 Return.—Return tickets available
-                            for six months.</p>
-                        <p>S.S. Seti now on the berth, will sail on or about Monday, July 17, to be followed
-                            by S.S. Menes.</p>
+                        <p>*Second class accommodation only, unless specially reserved.—Fares : <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> to <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName>, 1st, £14 Single, £25 Return. 2nd, £9 Single, £15 Return.—To <placeName ref="https://www.wikidata.org/wiki/Q233">Malta</placeName>, 1st, £5 Single, £9 Return, 2nd, £3 Single, £5 Return.—Return tickets available for six months.</p>
+                        <p>S.S. Seti now on the berth, will sail on or about Monday, July 17, to be followed by S.S. Menes.</p>
                         <p>S.S Tabor for Havre via <placeName ref="https://www.wikidata.org/wiki/Q233">Malta</placeName> to sail about Saturday l5th inst.</p>
-                        <p>Through freight rates on cotton, etc., to Lancashire inland towns, Boston, New
-                            York and other U.S.A. towns, obtained on application. Cargo taken by special
-                            agreement only. </p>
-                        <p>Passenger Tickets also issued inclusive of Railway fare through to and from
-                            <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> . Particulars on application to </p>
+                        <p>Through freight rates on cotton, etc., to Lancashire inland towns, Boston, New York and other U.S.A. towns, obtained on application. Cargo taken by special agreement only. </p>
+                        <p>Passenger Tickets also issued inclusive of Railway fare through to and from <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> . Particulars on application to </p>
                         <p>R. J. MOSS &amp; Co., <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>, Agents. 26-12-905</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-mic01">
@@ -239,11 +216,8 @@
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-tce01">
                         <head>Telephone Company of Egypt, Limited.</head>
-                        <p><placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> -<placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> TELEPHONE.--Rates as follows P.T. 5 for each 3 minutes, or
-                            fraction of 3 minutes; P.T. 10 for over 3 up to 8 minutes communication.</p>
-                        <p>PUBLIC CALL-OFFICES : <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> , Central Office, Opera Square, and New Bar; Helouan,
-                            Central Office, Maison Purvis ; <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>, St Mark’s Buildings, Egyptian Bar,
-                            I. Castelli &amp; Co.; Ramleh, Central Office. San Stefano Casino 30.4.906</p>
+                        <p><placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> -<placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> TELEPHONE.--Rates as follows P.T. 5 for each 3 minutes, or fraction of 3 minutes; P.T. 10 for over 3 up to 8 minutes communication.</p>
+                        <p>PUBLIC CALL-OFFICES : <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> , Central Office, Opera Square, and New Bar; Helouan, Central Office, Maison Purvis ; <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>, St Mark’s Buildings, Egyptian Bar, I. Castelli &amp; Co.; Ramleh, Central Office. San Stefano Casino 30.4.906</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-phc01">
                         <head>P. HENDERSON &amp; CO’s LINE.</head>
@@ -253,8 +227,7 @@
                         <p>S.S. BURMA 5600 Tons will leave <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> about August 6 for <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName>.</p>
                         <p>S.S. ARRACAN 5800 Tons will leave <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> about 20 for <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName></p>
                         <p>Due in <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> or <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName> 12 days thereafter.</p>
-                        <p>Apply WORMS &amp; Co., <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> and <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>. THOS. COOK &amp; SON, (EGYPT) LD.,
-                            <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>  ;</p>
+                        <p>Apply WORMS &amp; Co., <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> and <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>. THOS. COOK &amp; SON, (EGYPT) LD., <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> ;</p>
                         <p>G. J. GRACE &amp; CO., <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>.</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-tcs01">
@@ -264,21 +237,11 @@
                         <p><placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>, <placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName> , <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>, Luxor, Assuan, Haifa, &amp; Khartum.</p>
                         <p>GENERAL RAILWAY AND STEAMSHIP AGENTS. BANKERS.</p>
                         <p>BAGGAGE AND FORWARDING AGENTS.</p>
-                        <p>Officially appointed &amp; Sole Agents in <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>  to the P.&amp;O. S.N. Co.</p>
-                        <p>RESIDENTS IN <placeName ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName> proceeding to Europe for the summer are requested to apply to
-                            our offices for information respecting their Passages, where steamer plans may
-                            be consulted and Berths secured by all Lines of Steamers to all parts of the
-                            Globe; arrangements can also be made for the collection and forwarding of their
-                            baggage and clearance at port of arrival.</p>
-                        <p>CIRCULAR NOTES issued payable at the current rate of exchange in all the
-                            principal cities of Europe. Cook’s Interpreters in uniform are present at the
-                            principal Railway stations and Landing-places in Europe to assist passengers
-                            holding their travelling tickets.</p>
-                        <p>Large and splendidly appointed steamers belonging to the Co. leave <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>  thrice
-                            weekly, between November and March, for Luxor, Assouan and Wady-Halfa in
-                            connection with trains de luxe to Khartoum. Moderate fares. </p>
-                        <p>FREIGHT SERVICE, Steamers leave <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>  every Saturday and Tuesday for Assouan and
-                            Halfa.</p>
+                        <p>Officially appointed &amp; Sole Agents in <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> to the P.&amp;O. S.N. Co.</p>
+                        <p>RESIDENTS IN <placeName ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName> proceeding to Europe for the summer are requested to apply to our offices for information respecting their Passages, where steamer plans may be consulted and Berths secured by all Lines of Steamers to all parts of the Globe; arrangements can also be made for the collection and forwarding of their baggage and clearance at port of arrival.</p>
+                        <p>CIRCULAR NOTES issued payable at the current rate of exchange in all the principal cities of Europe. Cook’s Interpreters in uniform are present at the principal Railway stations and Landing-places in Europe to assist passengers holding their travelling tickets.</p>
+                        <p>Large and splendidly appointed steamers belonging to the Co. leave <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> thrice weekly, between November and March, for Luxor, Assouan and Wady-Halfa in connection with trains de luxe to Khartoum. Moderate fares. </p>
+                        <p>FREIGHT SERVICE, Steamers leave <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> every Saturday and Tuesday for Assouan and Halfa.</p>
                         <p>Special Steamers and Dahabeahs for private parties.</p>
                         <p>Special arrangements for tour in PALESTINE, SYRIA and the DESERT, Lowest Rates.</p>
                         <p>Best camp equipment in the country! 10 12-904 </p>
@@ -288,10 +251,8 @@
                         <head>British <placeName ref="https://www.wikidata.org/wiki/Q668">India</placeName> S. N. Company, Limited.</head>
                         <p>MAIL AND PASSENGER STEAM SHIPS.</p>
                         <p>SAILINGS FROM <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>, <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> and CALCUTTA LINE.</p>
-                        <p>Calling at ADEN, COLOMBO and MADRAS Outward, and <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName> (GENOA and PLYMOUTH
-                            optional) Homeward. </p>
-                        <p>Fortnightly Service in connection with the Co's Indian Mail Lines and monthly
-                            with the East African Mail Line between ADEN, MOMBASSA and Zanzibar. </p>
+                        <p>Calling at ADEN, COLOMBO and MADRAS Outward, and <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName> (GENOA and PLYMOUTH optional) Homeward. </p>
+                        <p>Fortnightly Service in connection with the Co's Indian Mail Lines and monthly with the East African Mail Line between ADEN, MOMBASSA and Zanzibar. </p>
                         <p>OUTWARD.—S.S. Fazilka ... July 22 | HOMEWARD.—S.S. Mombassa ... July 21 </p>
                         <p>Queensland Line of Steamers Between <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> and Brisbane.</p>
                         <p>Calling at Colombo, Batavia, Cooktown, Townsville, and Rockhamptom.</p>
@@ -320,16 +281,11 @@
                                 <cell>£19. 0</cell>
                             </row>
                         </table>
-                        <p>From <placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName>  £2 less Homeward, and £2 more Outward. Second class, two thirds of
-                            1st Class Fares.</p>
-                        <p>Agents at <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>, for the <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName>, Calcutta and Persian Gulf Lines, Messrs.
-                            Worms &amp; Co.</p>
-                        <p>Agents at <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>, for the <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> and Queensland Line, Messrs. Wills &amp; Co.,
-                            Limited.</p>
-                        <p>Messrs. Thos. Cook &amp; Son and the Anglo-American Hotel &amp; Steamer Company,
-                            <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>  &amp; <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>.</p>
-                        <p>For further particulars. Freight and Passage apply to G. BEYTS &amp; Co. Agents,
-                            <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>. 31-12-905</p>
+                        <p>From <placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName> £2 less Homeward, and £2 more Outward. Second class, two thirds of 1st Class Fares.</p>
+                        <p>Agents at <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>, for the <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName>, Calcutta and Persian Gulf Lines, Messrs. Worms &amp; Co.</p>
+                        <p>Agents at <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>, for the <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> and Queensland Line, Messrs. Wills &amp; Co., Limited.</p>
+                        <p>Messrs. Thos. Cook &amp; Son and the Anglo-American Hotel &amp; Steamer Company, <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> &amp; <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>.</p>
+                        <p>For further particulars. Freight and Passage apply to G. BEYTS &amp; Co. Agents, <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>. 31-12-905</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-all01">
                         <head>ANCHOR LINE, LIMITED.</head>
@@ -354,23 +310,14 @@
                                 <cell>July 23</cell>
                             </row>
                         </table>
-                        <p>Saloon Fares: from <placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName> , to Gibraltar £9; <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName> £9: <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName> (all sea
-                            route) £15; <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> (all sea route) £ 12 <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> via <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName> £15.5.0.
-                            Passengers embarking at <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName> £2 more, 10 % reduction for officers of army of
-                            Occupation and Government employés. Through tickets issued to New-York (via
-                            Glasgow). Fares on application. </p>
-                        <p> Agents in <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> , Messrs. Thos. Cook &amp; Son. <placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName> , Messrs. Cory Brothers
-                            &amp; Co., Ltd.</p>
-                        <p>For further partienlan of Freight or Passage apply to G. BEYTS &amp; Co., <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>.
-                            31-12-905</p>
+                        <p>Saloon Fares: from <placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName> , to Gibraltar £9; <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName> £9: <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName> (all sea route) £15; <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> (all sea route) £ 12 <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> via <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName> £15.5.0. Passengers embarking at <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName> £2 more, 10 % reduction for officers of army of Occupation and Government employés. Through tickets issued to New-York (via Glasgow). Fares on application. </p>
+                        <p> Agents in <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> , Messrs. Thos. Cook &amp; Son. <placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName> , Messrs. Cory Brothers &amp; Co., Ltd.</p>
+                        <p>For further partienlan of Freight or Passage apply to G. BEYTS &amp; Co., <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>. 31-12-905</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-dll01">
                         <head>Deutsche Levante-Linie.</head>
-                        <p>Mail and Passenger Steamships. Regular three-weekly Service from <lb/> HAMBURG,
-                            via ANTWERP &amp; <placeName ref="https://www.wikidata.org/wiki/Q233">Malta</placeName>, to <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> and vice-versa, admitting<lb/> goods from
-                            all chief German Railway Stations on direct Bill of Landing to<lb/> <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>
-                            and all chief ports of Egypt, Syria, etc., at favourable through<lb/> rates of
-                            DEUTSCHE <lb/> VERKEHR (traffic).</p>
+                        <p>Mail and Passenger Steamships. Regular three-weekly Service from <lb/> HAMBURG, via ANTWERP &amp; <placeName ref="https://www.wikidata.org/wiki/Q233">Malta</placeName>, to <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> and vice-versa, admitting<lb/> goods from all chief German Railway Stations on direct Bill of Landing to<lb/>
+                            <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> and all chief ports of Egypt, Syria, etc., at favourable through<lb/> rates of DEUTSCHE <lb/> VERKEHR (traffic).</p>
                         <p>EXPECTED AT <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>.</p>
                         <p>S.S. Lesbos July 20 from Antwerp.</p>
                         <p>S.S. Androos July 20 from Hamburg bound for Beyrout.</p>
@@ -380,24 +327,19 @@
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-doa01">
                         <head>Deutsche Ost-Afrika Linie.</head>
-                        <p>GERMAN EAST-AFRICAN LINE - REGULAR MAIL-SERVICE FROM <placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName> </p>
+                        <p>GERMAN EAST-AFRICAN LINE - REGULAR MAIL-SERVICE FROM <placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName>
+                        </p>
                         <p>OUTWARDS. To ADEN, ZANZIBAR, DURBAN, CAPETOWN and intermediate Ports.</p>
                         <p>HOMEWARDS. To <placeName ref="https://www.wikidata.org/wiki/Q2634">Naples</placeName> , GENOA, <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName>, LISBON, ROTTERDAM, HAMBURG.</p>
-                        <p>Splendid accommodation for passengars of all classes.—First-class steamers,
-                            fitted with all recent improvements. stewardesses and doctor carried—Low passage
-                            rates.</p>
+                        <p>Splendid accommodation for passengars of all classes.—First-class steamers, fitted with all recent improvements. stewardesses and doctor carried—Low passage rates.</p>
                         <p>For all particulars, apply to FIX &amp; DAVID, <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> , Sharia Mansour Pacha</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-nkh01">
                         <head>NEW KHEDIVIAL HOTEL, <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>.</head>
-                        <p>First-class Hotel. Situated in Rosetta Avenue, the finest quarter in the Town.
-                            Two mintes from Railway Station. Close to Conservatory and the Opera House.
-                            Lift. Electric Light Throughout. Perfect Sanitary Arragnements. Magnificent
-                            Ball, Reception, Reading, and Music Rooms. Bar and Smoking Room.</p>
+                        <p>First-class Hotel. Situated in Rosetta Avenue, the finest quarter in the Town. Two mintes from Railway Station. Close to Conservatory and the Opera House. Lift. Electric Light Throughout. Perfect Sanitary Arragnements. Magnificent Ball, Reception, Reading, and Music Rooms. Bar and Smoking Room.</p>
                         <p> HENRI CHAMOULLEAU, Proprietor.</p>
                         <p>45</p>
-                        <p>FINE TERRACE ON THE AVENUE. - SPLENDID GARDEN. - OMNIBUS MEET ALL TRAINS AND
-                            STEAMERS. 28-26 </p>
+                        <p>FINE TERRACE ON THE AVENUE. - SPLENDID GARDEN. - OMNIBUS MEET ALL TRAINS AND STEAMERS. 28-26 </p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-pss01">
                         <head><placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>-SAVOY HOTEL.</head>
@@ -407,12 +349,9 @@
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-hbc01">
                         <head>HOTEL BRISTOL. <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> .</head>
-                        <p>Full South, Electric Light, opposite Esbekieh Gardens, Large Verandahs, Moderate
-                            Charges,</p>
+                        <p>Full South, Electric Light, opposite Esbekieh Gardens, Large Verandahs, Moderate Charges,</p>
                         <p>CHAS. BAUER, Proprietor.</p>
-                        <p>The Hotel is beautifully fitted up and is in the most central part of <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> .
-                            Terms for pension fare at the rate of ten shillings a day. Special terms for
-                            officers of Army of Occupation. 24,882-31-10-5</p>
+                        <p>The Hotel is beautifully fitted up and is in the most central part of <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> . Terms for pension fare at the rate of ten shillings a day. Special terms for officers of Army of Occupation. 24,882-31-10-5</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-gac01">
                         <head>GUARDIAN ASSURANCE COMPANY, LIMITED,</head>
@@ -430,10 +369,8 @@
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-nfl01">
                         <head>NORTHERN FIRE AND LIFE ASSURANCE Coy.</head>
-                        <p>The undersigned agents are authorised to issue policies on behalf of the above
-                            Company at moderate rates.</p>
-                        <p>IMPERIAL OTTOMAN BANK, <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>. OTTO STERZING, <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> . GEORG. MEINECKE, <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>.
-                            3112905</p>
+                        <p>The undersigned agents are authorised to issue policies on behalf of the above Company at moderate rates.</p>
+                        <p>IMPERIAL OTTOMAN BANK, <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>. OTTO STERZING, <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> . GEORG. MEINECKE, <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>. 3112905</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-sio01">
                         <head>Sun Insurance Office,</head>
@@ -455,7 +392,7 @@
                                 <cell><placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> … Mr. J. B. CAFFARI</cell>
                             </row>
                             <row>
-                                <cell><placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>  … Mr. J. B. CAFFARI</cell>
+                                <cell><placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> … Mr. J. B. CAFFARI</cell>
                                 <cell><placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName> … Mr. GEO. MEINECKE.</cell>
                             </row>
                         </table>
@@ -465,11 +402,11 @@
                         <head>INTERNATIONAL SLEEPING AND RESTAURANT CARS COMPANY.</head>
                         <table rows="2" cols="4">
                             <row role="label">
-                                <cell cols="4"><hi rend="italic">Restaurant Car runs every day between <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>
-                                        &amp; <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> &amp; vice-versa</hi>.</cell>
+                                <cell cols="4"><hi rend="italic">Restaurant Car runs every day between <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> &amp; <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> &amp; vice-versa</hi>.</cell>
                             </row>
                             <row>
-                                <cell>Depart. - <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> </cell>
+                                <cell>Depart. - <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>
+                                </cell>
                                 <cell>6.35 p.m.</cell>
                                 <cell>Arrival - <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName></cell>
                                 <cell>10.0 p.m.</cell>
@@ -477,19 +414,19 @@
                             <row>
                                 <cell>Depart. - <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName></cell>
                                 <cell>6. 0 p.m.</cell>
-                                <cell>Arrival - <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> </cell>
+                                <cell>Arrival - <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>
+                                </cell>
                                 <cell>9.20 p.m.</cell>
                             </row>
                         </table>
-                        <p>By the 10.15 p.m. train between <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>  and <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> and vice-versa a sleeping
-                            car is attached every night. Supplement 30 P.T. </p>
+                        <p>By the 10.15 p.m. train between <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> and <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> and vice-versa a sleeping car is attached every night. Supplement 30 P.T. </p>
                         <table rows="4" cols="4">
                             <row role="label">
-                                <cell cols="4"><hi rend="italic">Daily Restaurant Car Service between <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> ,
-                                        Ismailia, <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> &amp; vice-versa</hi>.</cell>
+                                <cell cols="4"><hi rend="italic">Daily Restaurant Car Service between <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> , Ismailia, <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> &amp; vice-versa</hi>.</cell>
                             </row>
                             <row>
-                                <cell>Depart. - <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> </cell>
+                                <cell>Depart. - <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>
+                                </cell>
                                 <cell>11 a.m. &amp; 6.15 p.m.</cell>
                                 <cell>Depart. - <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName></cell>
                                 <cell>11.55 a.m. &amp; 6.30 p.m.</cell>
@@ -509,48 +446,33 @@
                             <row>
                                 <cell>Arriv. - <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName></cell>
                                 <cell>5. 0 p.m. &amp; 11.10 p.m.</cell>
-                                <cell>Arriv. - <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> </cell>
+                                <cell>Arriv. - <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>
+                                </cell>
                                 <cell>5. 0 p.m. &amp; 11.25 p.m.</cell>
                             </row>
                         </table>
                         <p>Restaurant and Sleeping Cars on Luxor trains:</p>
-                        <p>A Restaurant car and a sleeping car are attached to the 8 p.m. train from <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>
-                            every Monday, Wednesday and Saturday and to the 5.30 p.m. train from Luxor every
-                            Tuesday, Thursday and Sunday.</p>
-                        <p>Railway and Sleeping Car tickets can be obtained any number of days ahead at the
-                            office of the International Sleeping Car Company in <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>  Station. 1st class
-                            <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> -Luxor P.T. 200. Sleeping Car supplement P.T. 75.</p>
+                        <p>A Restaurant car and a sleeping car are attached to the 8 p.m. train from <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> every Monday, Wednesday and Saturday and to the 5.30 p.m. train from Luxor every Tuesday, Thursday and Sunday.</p>
+                        <p>Railway and Sleeping Car tickets can be obtained any number of days ahead at the office of the International Sleeping Car Company in <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> Station. 1st class <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> -Luxor P.T. 200. Sleeping Car supplement P.T. 75.</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-ccc01">
-                        <p>The Cigarettes Manufactured by</p>
-                        <head>The Cleopatra Cigarette Co.</head>
+                        <head>The Cigarettes Manufactured by<lb/>The Cleopatra Cigarette Co.</head>
                         <p>G. NUNGOYICH</p>
-                        <p>are on sale at the Company's establishment by Grand Contental Hotel, <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> , and
-                            at Walker &amp; Meimarschi's, <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>.</p>
+                        <p>are on sale at the Company's establishment by Grand Contental Hotel, <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> , and at Walker &amp; Meimarschi's, <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>.</p>
                         <p>Purveyors to H. H. the KHEDIVE.</p>
-                        <p>35750 Patronized by the Duke of Connaught and the Archduke Otto and all the High
-                            Life of Egypt. 18-4-80</p>
+                        <p>35750 Patronized by the Duke of Connaught and the Archduke Otto and all the High Life of Egypt. 18-4-80</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-ncs01">
                         <head>NILE COLD STORAGE<lb/> COMPANY, LIMITED.</head>
-                        <p>PURVEYORS OF THE FINEST COLONIAL<lb/> MEAT, GAME, POULTRY, BUTTER, FISH, etc.,
-                            etc.</p>
-                        <p>The Company have opened a shop in the NEW MARKET, <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> , Nos. 39 &amp; 40, where
-                            the goods imported by them can be inspected and purchased.</p>
+                        <p>PURVEYORS OF THE FINEST COLONIAL<lb/> MEAT, GAME, POULTRY, BUTTER, FISH, etc., etc.</p>
+                        <p>The Company have opened a shop in the NEW MARKET, <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> , Nos. 39 &amp; 40, where the goods imported by them can be inspected and purchased.</p>
                         <p>Telephone No. 1. 5. xxx-xx-xx</p>
                     </div>
                     <cb n="3"/>
                     <div type="item" scope="advertisement" xml:id="deg-ad-aan01">
                         <head>Anglo-American Nile Steamer &amp; Hotel Coy.</head>
-                        <p>Weekly departure during Winter Season by the<lb/> Luxurious First Class Tourist
-                            Steamers VICTORIA, PURITAN &amp; MAYFLOWER.<lb/> Regular weekly Departures to
-                            the SECOND CATARACT by the S.S. IndianA.<lb/> THROUGH BOOKINGS TO KHARTOUM,
-                            GONDOKORO AND THE WHITE NILE.<lb/> Steamers and Dahabeahs for private charter.
-                            Steam Tugs and Steam Launches for hire.<lb/> FREIGHT SERVICE BY STEAM BARGES
-                            BETWEEN <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>  AND <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>.<lb/> Working in conjunction and under special
-                            arrangement with the<lb/> “Upper <placeName ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName> Hotels Company."</p>
-                        <p>For details and illustrated programmes apply to "THE ANGLO-AMERICAN NILE STEAMER
-                            and<lb/> HOTEL COMPANY."</p>
+                        <p>Weekly departure during Winter Season by the<lb/> Luxurious First Class Tourist Steamers VICTORIA, PURITAN &amp; MAYFLOWER.<lb/> Regular weekly Departures to the SECOND CATARACT by the S.S. IndianA.<lb/> THROUGH BOOKINGS TO KHARTOUM, GONDOKORO AND THE WHITE NILE.<lb/> Steamers and Dahabeahs for private charter. Steam Tugs and Steam Launches for hire.<lb/> FREIGHT SERVICE BY STEAM BARGES BETWEEN <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> AND <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>.<lb/> Working in conjunction and under special arrangement with the<lb/> “Upper <placeName ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName> Hotels Company."</p>
+                        <p>For details and illustrated programmes apply to "THE ANGLO-AMERICAN NILE STEAMER and<lb/> HOTEL COMPANY."</p>
                         <p> OFFICES IN <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> : Sharia Boulac, "Grand Continental Hotel Buildings.” 31-3-06</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-nll01">
@@ -560,8 +482,7 @@
                         <p>The following steamers are intended to leave <placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName> : </p>
                         <table rows="14" cols="3">
                             <row>
-                                <cell cols="3">HOMEWARD : for Bremen Hamburg via <placeName ref="https://www.wikidata.org/wiki/Q2634">Naples</placeName> , Genoa, (Gibraltar),
-                                    Southampton, Antwerp.</cell>
+                                <cell cols="3">HOMEWARD : for Bremen Hamburg via <placeName ref="https://www.wikidata.org/wiki/Q2634">Naples</placeName> , Genoa, (Gibraltar), Southampton, Antwerp.</cell>
                             </row>
                             <row>
                                 <cell>Zieten</cell>
@@ -589,8 +510,7 @@
                                 <cell>about 28 August</cell>
                             </row>
                             <row>
-                                <cell cols="3">OUTWARD: for <placeName ref="https://www.wikidata.org/wiki/Q148">China</placeName> and JAPAN via <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>, ADEN, COLOMBO, PENANG,
-                                    SINGAPORE.</cell>
+                                <cell cols="3">OUTWARD: for <placeName ref="https://www.wikidata.org/wiki/Q148">China</placeName> and JAPAN via <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>, ADEN, COLOMBO, PENANG, SINGAPORE.</cell>
                             </row>
                             <row>
                                 <cell>Prinz E. Friedrich</cell>
@@ -608,7 +528,7 @@
                                 <cell>about 7 August</cell>
                             </row>
                             <row>
-                                <cell cols="3">For <placeName ref="https://www.wikidata.org/wiki/Q408">Australia</placeName>  via <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>, ADEN, COLOMBO.</cell>
+                                <cell cols="3">For <placeName ref="https://www.wikidata.org/wiki/Q408">Australia</placeName> via <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>, ADEN, COLOMBO.</cell>
                             </row>
                             <row>
                                 <cell>Seydlitz</cell>
@@ -627,19 +547,15 @@
                             </row>
                         </table>
                         <p>FOR FURTHER PARTICULARS APPLY TO THE AGENTS OF THE </p>
-                        <p>NORDDEUTSCHER LLOYD at <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> , <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>, <placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName>  and <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>. </p>
+                        <p>NORDDEUTSCHER LLOYD at <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> , <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>, <placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName> and <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>. </p>
                         <p>OTTO STERZING, Agent In <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> , Opera Square. </p>
                         <p>C. H. SCHOELLER, Agent In <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>, Cleopatra Lane.</p>
-                        <p>Messrs. THOS. COOK &amp; SON (Egypt) LTD., and CARL STANGENS REISEBUREAN are
-                            anthorised to sell tickets in <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>  and <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>, 31-8-905</p>
+                        <p>Messrs. THOS. COOK &amp; SON (Egypt) LTD., and CARL STANGENS REISEBUREAN are anthorised to sell tickets in <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> and <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>, 31-8-905</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-als01">
                         <head>Austrian Lloyd’s Steam Navigation</head>
                         <p><placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>-Brindisi-Venice-Trieste.</p>
-                        <p>Weekly Express Mail Service. Steamers leave <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> every Saturday at 4 p.m.
-                            arrive at Brindisi, Tuesday a.m. in time for express to <placeName ref="https://www.wikidata.org/wiki/Q90">Paris</placeName>, <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName>, <placeName ref="https://www.wikidata.org/wiki/Q2634">Naples</placeName> ,
-                            Rome. Arrival Trieste Wednesday noon connecting with Vienna Express
-                            (Trieste-Ostende through carriage) and expresses to Italy and Germany.</p>
+                        <p>Weekly Express Mail Service. Steamers leave <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> every Saturday at 4 p.m. arrive at Brindisi, Tuesday a.m. in time for express to <placeName ref="https://www.wikidata.org/wiki/Q90">Paris</placeName>, <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName>, <placeName ref="https://www.wikidata.org/wiki/Q2634">Naples</placeName> , Rome. Arrival Trieste Wednesday noon connecting with Vienna Express (Trieste-Ostende through carriage) and expresses to Italy and Germany.</p>
                         <table rows="3" cols="8">
                             <row>
                                 <cell>July 8</cell>
@@ -685,36 +601,23 @@
                                 <cell>Capt. Knezevich</cell>
                             </row>
                         </table>
-                        <p>(Departures from <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>) To Aden, <placeName ref="https://www.wikidata.org/wiki/Q1156">Bombay</placeName>, Colombo, Penang, Singapore, Hong-Kong,
-                            Shanghai, Yokohama, Kobé about July 5 and August 4. To Aden, Karachi, and <placeName ref="https://www.wikidata.org/wiki/Q1156">Bombay</placeName>
-                            accelerated service about August 18. To Aden, Karachi, <placeName ref="https://www.wikidata.org/wiki/Q1156">Bombay</placeName>, Colombo, Madras,
-                            Rangoon, and Calcutta about July 20.</p>
+                        <p>(Departures from <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>) To Aden, <placeName ref="https://www.wikidata.org/wiki/Q1156">Bombay</placeName>, Colombo, Penang, Singapore, Hong-Kong, Shanghai, Yokohama, Kobé about July 5 and August 4. To Aden, Karachi, and <placeName ref="https://www.wikidata.org/wiki/Q1156">Bombay</placeName> accelerated service about August 18. To Aden, Karachi, <placeName ref="https://www.wikidata.org/wiki/Q1156">Bombay</placeName>, Colombo, Madras, Rangoon, and Calcutta about July 20.</p>
                         <p>East African Line.</p>
-                        <p>To Aden, Mombassa, Zanzibar, Beira, Delagoa Bay, Durban, about July 4 and August
-                            3.</p>
+                        <p>To Aden, Mombassa, Zanzibar, Beira, Delagoa Bay, Durban, about July 4 and August 3.</p>
                         <p>Syrian-Cyprus-Caramanian Line.</p>
                         <p>Steamers leaves <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> on or about July 3, 17 and 31.</p>
-                        <p>For information apply to the Agents, <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>, <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> and <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>, Thos. Cook
-                            &amp; Son, Ld., Leon Heller, <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>  Agent, 4, Sharia Maghraby, (Telephone 192),
-                            <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> ; F. Tedeschi, Helouan.</p>
-                        <p>Special passage rates granted to Egyptian Government officials, members of the
-                            Army of Occupation and their families. </p>
+                        <p>For information apply to the Agents, <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>, <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> and <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>, Thos. Cook &amp; Son, Ld., Leon Heller, <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> Agent, 4, Sharia Maghraby, (Telephone 192), <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> ; F. Tedeschi, Helouan.</p>
+                        <p>Special passage rates granted to Egyptian Government officials, members of the Army of Occupation and their families. </p>
                         <p>31-12-905</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-pap01">
                         <head>THE PAPAYANNI LINE.</head>
                         <head type="sub">(The Ellerman Lines, Ltd.)</head>
-                        <p>Frequent Sailings from <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> to <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName>, also Regular Services from
-                            <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName> to <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> and to ALGERIA, <placeName ref="https://www.wikidata.org/wiki/Q233">Malta</placeName>, LEVANT, BLACK SEA, and other
-                            Mediterranean Ports.</p>
-                        <p>Excellent Passenger Accommodation. Stewardess carried. Liberal table and Moderate
-                            Fares for single and retnrn tickets. </p>
-                        <p>The S S. SARDINIA will sail for <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName> (via Bona) on Friday, the 7th inst. at
-                            4 p.m.</p>
-                        <p>CARGO taken by special agreement only. Through Freights quoted for the UNITED
-                            STATES and INLAND TOWNS in GREAT BRITAIN.</p>
-                        <p>For passage or freight apply to the Agents, BARKER &amp; Co., <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>.
-                            2061-17-10-905 </p>
+                        <p>Frequent Sailings from <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> to <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName>, also Regular Services from <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName> to <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> and to ALGERIA, <placeName ref="https://www.wikidata.org/wiki/Q233">Malta</placeName>, LEVANT, BLACK SEA, and other Mediterranean Ports.</p>
+                        <p>Excellent Passenger Accommodation. Stewardess carried. Liberal table and Moderate Fares for single and retnrn tickets. </p>
+                        <p>The S S. SARDINIA will sail for <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName> (via Bona) on Friday, the 7th inst. at 4 p.m.</p>
+                        <p>CARGO taken by special agreement only. Through Freights quoted for the UNITED STATES and INLAND TOWNS in GREAT BRITAIN.</p>
+                        <p>For passage or freight apply to the Agents, BARKER &amp; Co., <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>. 2061-17-10-905 </p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-ell01">
                         <head>Ellerman Lines, Limited.</head>
@@ -722,16 +625,15 @@
                             <row>
                                 <cell cols="3">CITY LINE to <placeName ref="https://www.wikidata.org/wiki/Q233">Malta</placeName>, <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName>, COLOMBO &amp; CALCUTTA.</cell>
                                 <cell cols="3">
-                                    <p>CITY &amp; HALL LINES. Joint Service to <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName>, <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName>, <placeName ref="https://www.wikidata.org/wiki/Q1156">Bombay</placeName>
-                                        &amp; KARACHI.</p>
+                                    <p>CITY &amp; HALL LINES. Joint Service to <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName>, <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName>, <placeName ref="https://www.wikidata.org/wiki/Q1156">Bombay</placeName> &amp; KARACHI.</p>
                                 </cell>
                             </row>
                             <row>
-                                <cell cols="6">The undermentioned First Class Passenger Steamers will be
-                                    dispatched from <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> on or about the following dates for </cell>
+                                <cell cols="6">The undermentioned First Class Passenger Steamers will be dispatched from <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> on or about the following dates for </cell>
                             </row>
                             <row>
-                                <cell><placeName ref="https://www.wikidata.org/wiki/Q233">Malta</placeName> and <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> </cell>
+                                <cell><placeName ref="https://www.wikidata.org/wiki/Q233">Malta</placeName> and <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName>
+                                </cell>
                                 <cell>S.S. City of Corinth </cell>
                                 <cell>July 26</cell>
                                 <cell><placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName> and <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName></cell>
@@ -747,13 +649,8 @@
                                 <cell>July 13</cell>
                             </row>
                         </table>
-                        <p>SALOON FARES:—<placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> to <placeName ref="https://www.wikidata.org/wiki/Q233">Malta</placeName> £4.10.0. <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName>. £8.0.0. <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> or
-                            <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName>, £l2.l0.0. Colombo, Calcutta, <placeName ref="https://www.wikidata.org/wiki/Q1156">Bombay</placeName> or Karachi, £35.0.0. Special
-                            rates for steamers not carrying Doctor or Stewardess. For further particulars
-                            apply to </p>
-                        <p>CORY BROS. &amp; Co., Ltd., Agents for CITY Line, <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>: W. STAPLEDON &amp;
-                            SON, Agents for Hall Line, <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> ; or COOK &amp; SON (Egypt), Ltd., <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> .
-                            23788-28-8-905 </p>
+                        <p>SALOON FARES:—<placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> to <placeName ref="https://www.wikidata.org/wiki/Q233">Malta</placeName> £4.10.0. <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName>. £8.0.0. <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> or <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName>, £l2.l0.0. Colombo, Calcutta, <placeName ref="https://www.wikidata.org/wiki/Q1156">Bombay</placeName> or Karachi, £35.0.0. Special rates for steamers not carrying Doctor or Stewardess. For further particulars apply to </p>
+                        <p>CORY BROS. &amp; Co., Ltd., Agents for CITY Line, <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>: W. STAPLEDON &amp; SON, Agents for Hall Line, <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> ; or COOK &amp; SON (Egypt), Ltd., <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> . 23788-28-8-905 </p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-ngi01">
                         <head>Navigation Générale Italienne.</head>
@@ -795,22 +692,15 @@
                         <head>NATIONAL BANK OF EGYPT.</head>
                         <p>CAPITAL: L. 2,500,000. RESERVE (ENVIRON) : L. 862,000.</p>
                         <p>Gouverneur: Sir ELWIN PALMER, K.C.B., K.C.M.G.</p>
-                        <p>Siège Social au Caire, Succursale à <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>, Agence à Assiout, Assuoan, Benha,
-                            Beni-Suef, Chibin el Kom, Damanhour, Fayoum, Khartoum, Kéneh, Mansourah. Minieh,
-                            <placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName> , Suakin, Sohag, Tantah, Zagazig, Mouski (Caire) et Londres (4 et 5,
-                            King William Street).</p>
-                        <p>La National Bank of <placeName ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName> reçoit des dépots à termes fixes, fait des avances et
-                            ouvre des comptes courants sur titres, valeurs et marchandises. Elle s’occupe de
-                            l’achat et de la vente d'effets sur l’Etranger, de l'escompte, ainsi que de
-                            toutes opérations de Banque. 31-12-904</p>
+                        <p>Siège Social au Caire, Succursale à <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>, Agence à Assiout, Assuoan, Benha, Beni-Suef, Chibin el Kom, Damanhour, Fayoum, Khartoum, Kéneh, Mansourah. Minieh, <placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName> , Suakin, Sohag, Tantah, Zagazig, Mouski (Caire) et Londres (4 et 5, King William Street).</p>
+                        <p>La National Bank of <placeName ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName> reçoit des dépots à termes fixes, fait des avances et ouvre des comptes courants sur titres, valeurs et marchandises. Elle s’occupe de l’achat et de la vente d'effets sur l’Etranger, de l'escompte, ainsi que de toutes opérations de Banque. 31-12-904</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-abw01">
                         <head><placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> BONDED WAREHOUSE COMPANY, LTD.</head>
                         <p>(Société des Entrepôts d'Alexandrie)</p>
                         <p>Bonded Warehouses</p>
                         <p>IN <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>, <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> , <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>, AND <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>.</p>
-                        <p>Special Departments for clearing and forwarding and for a luggage and parcel
-                            Express Service.</p>
+                        <p>Special Departments for clearing and forwarding and for a luggage and parcel Express Service.</p>
                         <p>Goods delivered against cash for account of shippers. 1-6-906</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-ela01">
@@ -845,11 +735,9 @@
                     <div type="item" scope="advertisement" xml:id="deg-ad-eeh01">
                         <head>EASTERN EXCHANGE HOTEL, PORT SAID.</head>
                         <p>First Class Hotel. Modern in all respects.</p>
-                        <p>Fire-proof, Drained to the Sea, Lifts, Electric Light, English and French
-                              Billiards, Fresh and Salt Water Baths.</p>
+                        <p>Fire-proof, Drained to the Sea, Lifts, Electric Light, English and French Billiards, Fresh and Salt Water Baths.</p>
                         <p>The Coolest Summer Residence in Egypt.</p>
-                        <p>Special terms to Cairo Residents and their families desirous of enjoying the cool
-                              air and sea bathing during the summer months.</p>
+                        <p>Special terms to Cairo Residents and their families desirous of enjoying the cool air and sea bathing during the summer months.</p>
                         <p>Dragomans in Hotel Uniform Meet all Trains and Steamers.</p>
                         <p>22941-23-8-905</p>
                     </div>
@@ -861,10 +749,8 @@
                         <p>The most charming Sea-side Residence in Egypt.</p>
                         <p>First Class Family Hotel with Every Modern Comfort.</p>
                         <p>Unique Situation on the Beach.</p>
-                        <p>Lovely Garden. Lawn Tennis. Large Terrace. Electric Light. Sea Baths. Own
-                              springs. Perfect sanitary arrangements. Stables for horses and carriages.</p>
-                        <p>Moderate Charges. -- Special terms for Government Officials and Officers of the
-                              Army of Occupation.</p>
+                        <p>Lovely Garden. Lawn Tennis. Large Terrace. Electric Light. Sea Baths. Own springs. Perfect sanitary arrangements. Stables for horses and carriages.</p>
+                        <p>Moderate Charges. -- Special terms for Government Officials and Officers of the Army of Occupation.</p>
                         <p>252-17.1.906</p>
                         <p>G. RUNCKEWITZ, Proprietor.</p>
                     </div>
@@ -888,8 +774,7 @@
                     <div type="item" scope="advertisement" xml:id="deg-ad-spa01">
                         <head>Spathi's Grill Room.</head>
                         <p>Old Bourse St., Alexandria.</p>
-                        <p>Greatly enlarged and improved. New Chef. Unrivalled cooking. English specially
-                              catered for</p>
+                        <p>Greatly enlarged and improved. New Chef. Unrivalled cooking. English specially catered for</p>
                         <p>2063-14-1-906</p>
                     </div>
                     <!-- TODO Lancaster House, Cairo. -->
@@ -926,7 +811,7 @@
                         <p>Brewers, Burton-on-Trent and Romford.</p>
                         <p>Pale Ale &amp; Double Stout, specially brewed for export.</p>
                         <p>Agents: Messrs. John Ross &amp; Co., Alexandria &amp; Cairo:</p>
-                        <p>48047  30-2-904</p>
+                        <p>48047 30-2-904</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-jbc01">
                         <head>John B. Caffari's "Economical Stores"</head>
@@ -941,30 +826,18 @@
                         <head>Hall's Sanitary Washable Distemper</head>
                         <p>Made in 70 Colors</p>
                         <p>An artistic wall covering.</p>
-                        <p>This celebrated water paint is made in two qualities for Inside and Outside
-                              work</p>
-                        <p>HALL’S SANITARY WASHABLE DISTEMPER is rapidly superseding wall papers in all
-                              tastefully furnished homes. It is made in 70 artistic tints, and only requires
-                              the addition of water to make it ready for use. It is quickly and easily applied
-                              with a whitewash brush, with half the labour and at one third the cost of paint.
-                              HALL’S DISTEMPER ensures cleanliness, and is pleasing to the eye. It appeals
-                              alike to artistic and practical house decoration.</p>
-                        <p>HALL’S DISTEMPER is of special value in hot climates. Owing to its cool, pleasing
-                              colours, great weather-resisting and germ-destroying properties, it lends itself
-                              to every kind of wall, wood, brick or stone coating, possessing all the
-                              advantages of paint, colour- wash, and disinfectant at one third the cost of oil
-                              paint. It never blisters in the hottest sun, and the fact that it can be washed
-                              adds greatly to its sanitary advantages.</p>
+                        <p>This celebrated water paint is made in two qualities for Inside and Outside work</p>
+                        <p>HALL’S SANITARY WASHABLE DISTEMPER is rapidly superseding wall papers in all tastefully furnished homes. It is made in 70 artistic tints, and only requires the addition of water to make it ready for use. It is quickly and easily applied with a whitewash brush, with half the labour and at one third the cost of paint. HALL’S DISTEMPER ensures cleanliness, and is pleasing to the eye. It appeals alike to artistic and practical house decoration.</p>
+                        <p>HALL’S DISTEMPER is of special value in hot climates. Owing to its cool, pleasing colours, great weather-resisting and germ-destroying properties, it lends itself to every kind of wall, wood, brick or stone coating, possessing all the advantages of paint, colour- wash, and disinfectant at one third the cost of oil paint. It never blisters in the hottest sun, and the fact that it can be washed adds greatly to its sanitary advantages.</p>
                         <p>Supplied in Tins and Iron Kegs.</p>
                         <p>Sole Manufacturers :</p>
                         <p>SISSONS BROTHERS &amp; CO., LTD., HULL.</p>
-                        <p>Stocks are held In Cairo by Frank Ratcliffe, Sanitary Contractor and Engineer,
-                              Sharia Saptieh.</p>
+                        <p>Stocks are held In Cairo by Frank Ratcliffe, Sanitary Contractor and Engineer, Sharia Saptieh.</p>
                         <p>In Alexandria by Ramadan Youssef, Sanitary Contractor, Rue Sesostris.</p>
                         <p>General Agents: George Morris &amp; Co.. Alexandria &amp; Cairo.</p>
                     </div>
                     <!-- TODO The Old Blend Whiskey - Spathis -->
-                    <div type="item" scope="advertisement"  xml:id="deg-ad-bcp01">
+                    <div type="item" scope="advertisement" xml:id="deg-ad-bcp01">
                         <p>BECK &amp; CO’S PILSENER BEER</p>
                         <p>BREMEN.</p>
                         <p>Obtainable from every Respectable Firm In Cairo, Alexandria &amp; the Sudan.</p>
@@ -972,36 +845,27 @@
                         <p>V. J. FLEURENT, Cairo</p>
                         <p>F. MICALLEF, Sole Agent, 11 Bab Midan, Alexandria</p>
                     </div>
-                    <div type="item" scope="advertisement"  xml:id="deg-ad-aeb01">
+                    <div type="item" scope="advertisement" xml:id="deg-ad-aeb01">
                         <head>THE ANGLO-EGYPTIAN BANK, LIMITED.</head>
                         <p>LONDON, PARIS ALEXANDRIA, CAIRO MALTA, GIBRALTAR, TANTAH, AND PORT SAID.</p>
                         <p>Subscribed Capital JS1.500,000</p>
                         <p> Paid up '' £ 500,000</p>
                         <p>Reserve Fund... 500,000</p>
-                        <p>The Anglo-Egyptian Bank. Limited, undertakes every description of banking
-                              business on the most favourable conditions.</p>
-                        <p>Current accounts opened with commercial homes and private individuals in
-                              conformity with the custom of Bankers.</p>
-                        <p>Fixed deposits for one year certain received at 8 per cent. per annum. Deposits
-                              at interest for shorter periods are also received at rates to be agreed upon.</p>
-                        <p>Letters of Credit for the use of travellers are issued payable in all parts of
-                              the World.</p>
+                        <p>The Anglo-Egyptian Bank. Limited, undertakes every description of banking business on the most favourable conditions.</p>
+                        <p>Current accounts opened with commercial homes and private individuals in conformity with the custom of Bankers.</p>
+                        <p>Fixed deposits for one year certain received at 8 per cent. per annum. Deposits at interest for shorter periods are also received at rates to be agreed upon.</p>
+                        <p>Letters of Credit for the use of travellers are issued payable in all parts of the World.</p>
                         <p>Approved bills discounted.</p>
                         <p>Bills, documentary invoices, etc, collected.</p>
                         <p>Drafts and telegraphic transfers issued payable all over the World.</p>
                         <p>Foreign exchange bought and sold.</p>
-                        <p>Advances made upon approved securities and upon cotton, cotton-seed, sugar and
-                              other merchandise.</p>
-                        <p>The purchase and sale of stocks and shares on the London Stock Exchange; and on
-                              the local and Continental Bourses, undertaken.</p>
-                        <p>Customers can deposit their valuables, bonds, etc., for safe custody in the
-                              Bank's fire-proof strong-rooms, and the Bank will attend to the collection of
-                              the coupons and drawn bonds so deporited as they fall due.</p>
+                        <p>Advances made upon approved securities and upon cotton, cotton-seed, sugar and other merchandise.</p>
+                        <p>The purchase and sale of stocks and shares on the London Stock Exchange; and on the local and Continental Bourses, undertaken.</p>
+                        <p>Customers can deposit their valuables, bonds, etc., for safe custody in the Bank's fire-proof strong-rooms, and the Bank will attend to the collection of the coupons and drawn bonds so deporited as they fall due.</p>
                         <p>Mercantile credits issued.</p>
                         <p>Annuities, pensions, dividends, etc., collected.</p>
                         <p>All farther particulars and information can be obtained on application.</p>
-                        <p>The officers and clerks of the Bank are pledged to secrecy as to the transactions
-                              of customers. 18-9-905</p>
+                        <p>The officers and clerks of the Bank are pledged to secrecy as to the transactions of customers. 18-9-905</p>
                     </div>
                     <!-- TODO Surplus Drapery Stock of Magasins Victoria -->
                     <!-- TODO Howie and Co. The Hygenic Dairy -->
@@ -1219,23 +1083,12 @@
                 </div>
                 <div type="item" scope="newspaper">
                     <head>THE EGYPTIAN GAZETTE.</head>
-                    <p>SUBSCRIPTIONS.—Alexandria, Cairo, and the Interior of Egypt (including
-                        delivery in Alexandria or postage to subscriber’s address) P.T. 231½ per
-                        annum, P.T. 116 for six months, P.T. 80 for three months. To other countries
-                        in the Postal Union P.T. 273 (£2.16s.) per annum. Six months P.T. 136½
-                        (£1.8s.), three months P.T. 92 (£0.19s.) N.B.—Subscriptions commence from
-                        the 1st or 16th of any month. </p>
-                    <p>ADVERTISEMENTS.—P.T. 4 per line. Minimum charge P.T. 20. Births, Marriages,
-                        or Deaths, not exceeding three lines, P.T. 20. Every additional line P.T.
-                        10. Notices in news column P.T. 20 per line. Contracts entered into for
-                        standing advertisements. </p>
-                    <p>SUBSCRIPTIONS and ADVERTISEMENTS are due in advance. P.O. Orders and Cheques
-                        to be made payable to the Editor and Manager, Rowland Snelling, Alexandria. </p>
+                    <p>SUBSCRIPTIONS.—Alexandria, Cairo, and the Interior of Egypt (including delivery in Alexandria or postage to subscriber’s address) P.T. 231½ per annum, P.T. 116 for six months, P.T. 80 for three months. To other countries in the Postal Union P.T. 273 (£2.16s.) per annum. Six months P.T. 136½ (£1.8s.), three months P.T. 92 (£0.19s.) N.B.—Subscriptions commence from the 1st or 16th of any month. </p>
+                    <p>ADVERTISEMENTS.—P.T. 4 per line. Minimum charge P.T. 20. Births, Marriages, or Deaths, not exceeding three lines, P.T. 20. Every additional line P.T. 10. Notices in news column P.T. 20 per line. Contracts entered into for standing advertisements. </p>
+                    <p>SUBSCRIPTIONS and ADVERTISEMENTS are due in advance. P.O. Orders and Cheques to be made payable to the Editor and Manager, Rowland Snelling, Alexandria. </p>
                     <p>London Offices : 36, New Broad-street. B.C. </p>
-                    <p>THE EGYPTIAN GAZETTE can be obtained in London at our office, 36, New Broad
-                        Street, E.C., and also at Messrs. May &amp; Williams 160, Piccadilly, W. </p>
-                    <p>THE “EGYPTIAN GAZETTE” IS PRINTED ON PAPER MANUFACTURED AND SUPPLIED BY THE
-                        LONDON PAPER MILLS Co., LIMITED (SALES OFFICE: 27, CANNON STREET, E.C.) </p>
+                    <p>THE EGYPTIAN GAZETTE can be obtained in London at our office, 36, New Broad Street, E.C., and also at Messrs. May &amp; Williams 160, Piccadilly, W. </p>
+                    <p>THE “EGYPTIAN GAZETTE” IS PRINTED ON PAPER MANUFACTURED AND SUPPLIED BY THE LONDON PAPER MILLS Co., LIMITED (SALES OFFICE: 27, CANNON STREET, E.C.) </p>
                 </div>
                 <div type="item" scope="newspaper">
                     <p>The Egyptian Gazette </p>
@@ -1245,22 +1098,23 @@
                     <p>FRIDAY, OCTOBER 6, 1905.</p>
                 </div>
                 <!-- TODO Edhem Pasha -->
-                <div type="item" scope="calendar">
-                    <table cols="3" xml:id="CalendarOfTheWeek">
-                        <head>Calendar of Coming Events.</head>
-                        <div type="subsection">
+                <div type="item" scope="calendar" xml:id="CalendarOfTheWeek">
+                    <head>Calendar of Coming Events.</head>
+                    <div type="subsection">
+                        <table cols="3" xml:id="CalendarOfTheWeek-Alexandria">
                             <head>Alexandria</head>
                             <head type="sub">October</head>
+
                             <row>
                                 <cell>Fri.</cell>
                                 <cell>6</cell>
                                 <cell>
-                                    <p>Mex Casino.  Reunion des Familles 9.30 p.m.</p>
-                                    <p>Mex Prinea's Restaurant des Bains Roumanian orchestra, every afternoon.  Sundays, morning.</p>
-                                    <p>Windsor Hotel.  Orchestra.  6 to 11.30 p.m. every day.</p>
+                                    <p>Mex Casino. Reunion des Familles 9.30 p.m.</p>
+                                    <p>Mex Prinea's Restaurant des Bains Roumanian orchestra, every afternoon. Sundays, morning.</p>
+                                    <p>Windsor Hotel. Orchestra. 6 to 11.30 p.m. every day.</p>
                                     <p>Alhambra - Italian company. - 9.15 p.m.</p>
-                                    <p>Crown Casino.  Ibrahimieh. 9.30 p.m.</p>
-                                    <p>Tour Eiffel.  Variety Company. 9 p.m.</p>
+                                    <p>Crown Casino. Ibrahimieh. 9.30 p.m.</p>
+                                    <p>Tour Eiffel. Variety Company. 9 p.m.</p>
                                 </cell>
                             </row>
                             <row>
@@ -1268,7 +1122,7 @@
                                 <cell>7</cell>
                                 <cell>
                                     <p>Alex. Swimming Club. 3rd Annual<lb/>Aquatic Sports. New Graving<lb/>Dock, Gabbari. 3 p.m.</p>
-                                    <p>San Stefano Casino.  Telepathy Demonstration. 9.30 p.m.</p>
+                                    <p>San Stefano Casino. Telepathy Demonstration. 9.30 p.m.</p>
                                 </cell>
                             </row>
                             <row>
@@ -1279,16 +1133,18 @@
                                     <p>B.R.C. Mustapha Pasha Range.<lb/>Practice and Cup Compeittion.<lb/>3 p.m.</p>
                                 </cell>
                             </row>
-                        </div>
-                        <div type="subsection">
+                        </table>
+                    </div>
+                    <div type="subsection">
+                        <table cols="3" xml:id="CalendarOfTheWeek-Cairo">
                             <head>Cairo</head>
                             <head type="sub">October</head>
                             <row>
                                 <cell>Fri.</cell>
                                 <cell>6</cell>
                                 <cell>
-                                    <p>Esbekieh Gardens. Performances by<lb/>British Military Band. 9 to 11 p.m.</p>
-                                    <p>Esbekieh Theatre.  French Operetta Company.  9.15 p.m.</p>
+                                    <p>Esbekieh Gardens. Performances by<lb/>British MilitaryBand. 9 to 11 p.m.</p>
+                                    <p>Esbekieh Theatre. French Operetta Company. 9.15 p.m.</p>
                                     <p>Theatre des Nouveautes. 9.30 p.m.</p>
                                     <p>Alcasar Parisien. 9.30 p.m.</p>
                                 </cell>
@@ -1297,7 +1153,7 @@
                                 <cell>Tues.</cell>
                                 <cell>10</cell>
                                 <cell>
-                                    <p>Esbekieh Gardens.  performance by British Military Band. 9 to 11 p.m.</p>
+                                    <p>Esbekieh Gardens. performance by British Military Band. 9 to 11 p.m.</p>
                                 </cell>
                             </row>
                             <row>
@@ -1305,85 +1161,93 @@
                                 <cell>16</cell>
                                 <cell>Cairo Musical and Dramatic Society.<lb/>Concert in aid of Calabrian Victims.<lb/>Distinguished Patronage.</cell>
                             </row>
-                        </div>
-                    </table>
+                        </table>
+                    </div>
+
                 </div>
             </div>
             <div type="page" n="3">
                 <head>THE EGYPTIAN GAZETTE, FRIDAY, <date when="1905-10-06"><date when="1905-10-06">October 6</date> 1905</date></head>
-                <div type="article">
+                <div type="wireReport">
                     <head>TUBERCULOSIS PROFESSOR BEHRING’S CLAIM.</head>
                     <head>DISCOVERY OF REMEDY.</head>
-                    <dateline><placeName ref="https://www.wikidata.org/wiki/Q90">Paris</placeName>, <date when="1905-10-05">October 5</date>.</dateline>
-                    <p>At the great tuberculosis conference Professor Behring, the discoverer of the diphtheria serum, announced that he has discovered the remedy for tuberculosis. It is neither a serum nor vaccine, and he cannot explain his methods until next August, but from to day sufferers may recover hope.</p>
-                    <byline>(Reuter)</byline>
-                    <dateline><placeName ref="https://www.wikidata.org/wiki/Q90">Paris</placeName>, <date when="1905-10-05">October 5</date>.</dateline>
-                    <p>Professor Behring, who is taking part in the tuberculosis conference, has declared to the "Matin" that he has discovered the preventive and curative remedy for tuberculosis, and that he will reveal it in August next year. He will make a communication to that effect on Saturday.</p>
-                    <byline>(Havas)</byline>
+                    <div type="item">
+                        <dateline><placeName ref="https://www.wikidata.org/wiki/Q90">Paris</placeName>, <date when="1905-10-05">October 5</date>.</dateline>
+                        <p>At the great tuberculosis conference Professor Behring, the discoverer of the diphtheria serum, announced that he has discovered the remedy for tuberculosis. It is neither a serum nor vaccine, and he cannot explain his methods until next August, but from to day sufferers may recover hope.</p>
+                        <byline>(Reuter)</byline>
+                    </div>
+                    <div type="item">
+                        <dateline><placeName ref="https://www.wikidata.org/wiki/Q90">Paris</placeName>, <date when="1905-10-05">October 5</date>.</dateline>
+                        <p>Professor Behring, who is taking part in the tuberculosis conference, has declared to the "Matin" that he has discovered the preventive and curative remedy for tuberculosis, and that he will reveal it in August next year. He will make a communication to that effect on Saturday.</p>
+                        <byline>(Havas)</byline>
+                    </div>
                 </div>
-                <div type="article">
+                <div type="wireReport">
                     <head>GRAVE SITUATION IN BERLIN.</head>
                     <head><unclear>IsoToou</unclear> MEN RENDERED IDLE.</head>
                     <dateline>Berlin, <date when="1905-10-05">October 5</date>.</dateline>
                     <p>A grave situation is arising from the strike of all electrical workers, by which 50,000 men are rendered idle, including those indirectly effected. The metal manufacturers have now declared a lock out for the 4th inst. (sic) in sympathy with the electrical firms. The number of men idle will then bo 120,000, that is to say more than a twentieth of the population. The garrison has been reinforced.</p>
                     <byline>(R.)</byline>
                 </div>
-                <div type="article">
+                <div type="wireReport">
                     <head>AN IMPERIAL RESCRIPT.</head>
                     <head>THE REFORMED NAVY SCHEME</head>
                     <dateline>St. Petersburg, <date when="1905-10-05">October 5</date>.</dateline>
                     <p>A rescript of the Tsar orders the retirement of naval officers who are not able to satisfy the increased demands under the reformed navy scheme.</p>
                     <byline>(Renter)</byline>
                 </div>
-                <div type="article">
+                <div type="wireReport">
                     <head>RED SEA PIRACY.</head>
                     <head type="sub">PORTE GRANTS SATISFACTION.</head>
                     <dateline>Constantinople. <date when="1905-10-05">October 5</date>.</dateline>
                     <p>The Porte has agreed to all the demands of Great Britain for satisfaction on account of piracy in the Red 8ea.</p>
                     <byline>(Renter)</byline>
                 </div>
-                <div type="article">
+                <div type="wireReport">
                     <head>HONORS FOR KINO EDWARD.</head>
                     <dateline><placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName>, <date when="1905-10-05">October 5</date>.</dateline>
                     <p>The King has been gazetted Colonel in the Eighth Spanish Regiment.</p>
                     <byline>(Renter)</byline>
                 </div>
-                <div type="article">
+                <div type="wireReport">
                     <head>DEATH OF A TURKISH CAMPAIGNER.</head>
                     <dateline>Constantinople, <date when="1905-10-05">October 5</date>.</dateline>
                     <p>Edhem Pasha is dead.</p>
                     <byline>(Havas)</byline>
                 </div>
-                <div type="article">
+                <div type="wireReport">
                     <head>RACING.</head>
                     <dateline><placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName>, <date when="1905-10-05">October 5</date>.</dateline>
                     <p>Jockey Club Stakes. l.St. Amant ; 2. Polymelus ; 3. Mondamin.</p>
                     <byline>(Renter)</byline>
                 </div>
-                <div type="article">
+                <div type="item" scope="letters">
                     <head>LETTER TO THE EDITOR.</head>
                     <p>We do not bold ourselves responsible for the opinions expressed by car correspondents, but we wish, in a spirit of fair play to all to permit — within certain necessary limits — free</p>
                 </div>
-                <div type="article">
+                <div type="article" scope="letters">
                     <head>BOULOGNE TO <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>.</head>
+                    <!-- 
                     <quotedLetter>
                         <opener>
                             <p>To the Editor of the Egyptian Gazette.</p>
                             <salute>Dear Sir,</salute>
                         </opener>
-                        <p>The following criticisms passed on the Boulogne-<placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> route may interest your readers. The railway carriages from Boulogne to <placeName ref="https://www.wikidata.org/wiki/Q90">Paris</placeName> are of the old conventional type. There are no corridor carriages. The second class carriages are provided with lavatories, but not the first! Of course there is no communication between such carriages. The European edition the “New York Herald” can be bought at the station in <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName> at 11 p.m. on day of publication, but not the same edition of the "Daily Mail,” which cannot be had there till about 10 a.m. the following day. In the Messageries steamers, passengers have no opportunity of seeing a barometer, thermometer, or compass. These steamers have only one gangway (aft) for embarkation and disembarkation ; the result is utter confusion and noise on leaving and arriving. There ought to be two gangways, one forward and one aft, to relievo the congestion.</p>
+                        <p>The following criticisms passed on the Boulogne-<placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> route may interest your readers. The railway carriages from Boulogne to <placeName ref="https://www.wikidata.org/wiki/Q90">Paris</placeName> are of the old conventional type. There are no corridor carriages. The second class carriages are provided with lavatories, but not the first! Of course there is no communication between such carriages. The European edition the “New York Herald” can be bought at the station in <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName> at 11 p.m. on day of publication, but not the same edition of the "Daily Mail,” which cannot be had there till about 10 a.m. the following day. In the Messageries steamers, passengers have no opportunity of seeing a barometer, thermometer, or compass. These steamers have only one gangway (aft) for embarkation and disembarkation ; the result is utter
+                            confusion and noise on leaving and arriving. There ought to be two gangways, one forward and one aft, to relievo the congestion.</p>
                         <p>To an Englishman it seems strange that the P. and O. Company can run "through” trains from Calais to <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName>, whilst the Messageries Company,—a French concern—cannot, or does not do so through its own country for its own steamers. There is another matter which is worthy of note, namely in regard to baggage. Would it not be possible to send the baggage of passengers for places beyond France under bond in sealed waggons (small size for conveyance on deck of Channel steamers) from say Charing Cross to <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName>, and vice versa. If this were done it seems to me that there would be a great saving in time, trouble and expense, the last in the pay of Customs House officials. The searching of such baggage is after all a very perfunctory affair.</p>
                         <closer>
                             <salute>I am, Sir. etc, -</salute>
                             <dateline><placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>, October 4.</dateline>
                         </closer>
                     </quotedLetter>
+                    -->
                 </div>
                 <div type="section">
                     <head>LOCAL AND GENERAL.</head>
                     <div type="article">
                         <head>Ministry of Public Instruction</head>
-                        <p>Our <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>  contemporaries state that no less than fifty professors engaged by Mr. Douglas Dunlop for the Ministry of Public Instruction are expected to arrive at <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>  on the 10th inst Surely their number is slightly exaggerated.</p>
+                        <p>Our <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> contemporaries state that no less than fifty professors engaged by Mr. Douglas Dunlop for the Ministry of Public Instruction are expected to arrive at <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> on the 10th inst Surely their number is slightly exaggerated.</p>
                     </div>
                     <div type="article">
                         <head>New School Opened</head>
@@ -1415,8 +1279,9 @@
                     </div>
                     <div type="article">
                         <head>Unrequited Love Results in Murder</head>
-                        <p>After being betrothed for four years a young man of Rod-El-Farag (near <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> ) oonld not arrange to marry his fiance, and the girl’s mother requested him either to break off the engagement or to marry her daughter within a short time. Shortly afterwards another suitor for the girl's hand appeared and these two became engaged and were married. The thwarted lover was seized with jealousy and on Wednesday night, knowing that the young wife had gone to visit her parents, he broke into her old house, accompanied by two other men, with the intent to kill her whilst she was asleep, Taking with him a heavy stone he dropped it on the head of one whom he thought to be his quondam lover but who proved to be her brother. The weight of the stone and the force with which it was brought down crusheded in the head of the unfortunate man, who died in a very short time. The murderer and his two accomplices were discovered by the polioe and are now in prison.</p>
-                     </div>
+                        <p>After being betrothed for four years a young man of Rod-El-Farag (near <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> ) oonld not arrange to marry his fiance, and the girl’s mother requested him either to break off the engagement or to marry her daughter within a short time. Shortly afterwards another suitor for the girl's hand appeared and these two became engaged and were married. The thwarted lover was seized with jealousy and on Wednesday night, knowing that the young wife had gone to visit her parents, he broke into her old house, accompanied by two other men, with the intent to kill her whilst she was asleep, Taking with him a heavy stone he dropped it on the head of one whom he thought to be his quondam lover but who proved to be her brother. The weight of the stone and the force with which it was brought down crusheded in the head of the unfortunate man, who died in a very short time. The murderer and his two accomplices were
+                            discovered by the polioe and are now in prison.</p>
+                    </div>
                     <div type="article">
                         <head>QUARANTINE STATIONS.</head>
                         <head type="sub">NEW BUILDING FOR TOR.</head>
@@ -1424,7 +1289,7 @@
                     </div>
                     <div type="article">
                         <head>MR. DAVID LONGWORTH.</head>
-                        <p>Mr. David G. Longworth, the former proprietor and editor of the "Sphinx," the weekly paper published in <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>  during the winter season, is leaving by the P. &amp; 0. steamer Persia for Aden, and thence proceeds to British East Africa with the view of starting at Nairobi, the capital of the Protectorate, a weekly periodical entitled the "Globe Trotter.” Mr. Longworth, daring the many years that he has resided in <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> , contributed in a great measure in bringing to the notice of the American public, through the columns of his paper, the climatic and other advantages of our metropolis as a health resort, and succeded in a marked degree, as those who have noted the very large increase of American visitors to this country of recent years must admit</p>
+                        <p>Mr. David G. Longworth, the former proprietor and editor of the "Sphinx," the weekly paper published in <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> during the winter season, is leaving by the P. &amp; 0. steamer Persia for Aden, and thence proceeds to British East Africa with the view of starting at Nairobi, the capital of the Protectorate, a weekly periodical entitled the "Globe Trotter.” Mr. Longworth, daring the many years that he has resided in <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> , contributed in a great measure in bringing to the notice of the American public, through the columns of his paper, the climatic and other advantages of our metropolis as a health resort, and succeded in a marked degree, as those who have noted the very large increase of American visitors to this country of recent years must admit</p>
                         <p>Mr. Longworth is of the same conviction as Mr. McMillan, that there is a great future in store for the comparatively new British colony to which he is now turning his attention and energies, and we wish him every success in the new venture upon which he has now embarked.</p>
                     </div>
                     <div type="article">
@@ -1453,7 +1318,7 @@
                     <div type="article">
                         <head>KASSASSIN COLLISION.</head>
                         <head>ENGINE DRIVER RESPONSIBLE.</head>
-                        <p>The enquiry opened by Abd-el-Hamid Bey Ridha, Chief of the Native Parquet at Zagazig, has proved that the entire responsibility for this accident rests on the driver of goods train No. 331. It appears that on nearing Kassassin he took no notice of the signals, which were against him, and ran through the station. The station master and the pointsman called and signalled vigorously but vainly to him, and between Kassassin and Nefishe the goods train collided with train No. S.S. with disastrous consqeuences. According to one of our <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>  contemporaries, the ambulance van arrived from <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>  too late at the scene of the disaster to be of any service to the twenty-two victims of this accident, who had already been sent to Ismailia. -</p>
+                        <p>The enquiry opened by Abd-el-Hamid Bey Ridha, Chief of the Native Parquet at Zagazig, has proved that the entire responsibility for this accident rests on the driver of goods train No. 331. It appears that on nearing Kassassin he took no notice of the signals, which were against him, and ran through the station. The station master and the pointsman called and signalled vigorously but vainly to him, and between Kassassin and Nefishe the goods train collided with train No. S.S. with disastrous consqeuences. According to one of our <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> contemporaries, the ambulance van arrived from <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> too late at the scene of the disaster to be of any service to the twenty-two victims of this accident, who had already been sent to Ismailia. -</p>
                     </div>
                     <div type="article">
                         <head>PRINCE BUELOW’S INTERVIEW.</head>
@@ -1477,7 +1342,8 @@
                         <p>Among the latest arrivals at the Savoy Hotel, <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>, we notice Miss A. Spencer, Mr. Petrovich, Colonel T.R.P. Gordon, Mrs. Sardon, Mr. F. B. Tacomb, Mr P. Schulze Berge and family, Mr. Seton Karr, Mr. T. Hicks Paull, Mr. W. T. Wayle, Mr. W. R Field, the Hon and Lady Barrington, Major. Le Breton, Mrs. and Miss Le Breton, Mr. and Mrs. A. F. Bronn, Miss K. Mosley.</p>
                         <p>The following visitors are staying at the Beau-Rivage Hotel, Ramleh. Mr. and Mrs. C. Davacos H. E. Abbate Pasha, Mrs. M. Young, Mr. and Mrs. L. Thomas, Mr. and Mrs. Marins Berlioz, Dr. Kautsky Bey and family, Mr. W. Cohle, Mme Rhallic, Mr. and Mrs. F. Davey, Mr. G. Metral, Mr. W. Romances, Mr. and Master Delanoy, Mr. and Mrs. V. Cadoyan, Mr. and Mrs. W. Firth.</p>
                     </div>
-                    <div type="article"><!-- TODO replace with advertisement boilerplate-->
+                    <div type="article">
+                        <!-- TODO replace with advertisement boilerplate-->
                         <head>BECK &amp; C0’8 PILSENER BEER</head>
                         <head>BREMEN.</head>
                         <p>Fears no honest competition for quality.</p>
@@ -1488,12 +1354,15 @@
                         <head>A HISTORY OF EGYPT.</head>
                         <head type="sub">XIXTH TO XXXTH DYNASTIES.</head>
                         <p>The Athenaeum gives the following interesting criticism of Professor Petrie's latest work : —</p>
-                        <p>The concluding volume of Prof. Petrie's part of this history of <placeName ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName> is out at last, and certainly does not err on the side of verbosity. The complaint that has been brought against it by foreign critics, to the effect that it is not so much a history as a catalogue of monuments, is here more justified than ever, a period of more than a thousand years - neither the least eventful nor the worst documented in Egypts history-being jammed into a small volume of 400 pages. The delay in its appearance is, we are told in the text, almost entirely due to the groat quantity of monuments remaining to us from the reign of Rameses II., which apparently made it necessary for Prof. Petrie to go carefully through the list and to throw out such as he considered either appropriations of the works of earlier kings, or for some other reason unworthy of note. In this, as in some other matters, he apparently thinks that bis ipse dixit must be taken as settling the question.</p>
+                        <p>The concluding volume of Prof. Petrie's part of this history of <placeName ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName> is out at last, and certainly does not err on the side of verbosity. The complaint that has been brought against it by foreign critics, to the effect that it is not so much a history as a catalogue of monuments, is here more justified than ever, a period of more than a thousand years - neither the least eventful nor the worst documented in Egypts history-being jammed into a small volume of 400 pages. The delay in its appearance is, we are told in the text, almost entirely due to the groat quantity of monuments remaining to us from the reign of Rameses II., which apparently made it necessary for Prof. Petrie to go carefully through the list and to throw out such as he considered either appropriations of the works of earlier kings, or for some other reason unworthy of note. In this, as in some other matters, he apparently thinks
+                            that bis ipse dixit must be taken as settling the question.</p>
                         <p>The same feature is noticeable in his preface, where he tells us that</p>
                         <q>
                             <p>"as some persons still continue to quote Dr. Brcgsch's chronology, I ought, perhaps, to point out that it entirely rests on two certainly false assumptions, and [that] it is only rendered possible by freely making any number of arbitrary omissions. In short it is no system and has no reason” ;</p>
-                            <p>while, after discussing the two assumptions in question, he concludes that “no one who uses it can be supposed to know of the facts of the history which are stated in this volume.” There have been nearly as many systems of chronology in Egyptian history as historians, and Brugsch's system" is, like all the others, in great measure a system of inferences from rather slender foundations. But Brugsch was a man of deep and wide learning, as well as an Egyptologist who had spent has life in the study of his subject; and as the founder of demotic studies he possessed a knowledge of the language of the monuments for greater than any of which Prof. Petrie can boast We think, therefore, that his theories should be treated with respect and that it will require something more than Prof. Petrie’s pronouncements ex cathedra to dispossess a system which still has much to reccommend it This apart, Prof. Petrie is, in other respects, unusually tolerant of the opinions of other in this volume, and it is good to find him actually referring with courtesy and even with approbation to the works of those whom he is pleased to consider his rivals. Thus he not only speaks with approval of certain work of Mr. H. R. Hall, but also says, with regard to the supposed route of the Exodus, that “the result of Naville's discussion of it is reasonable and generally accepted.” We think, however, that he might have devoted a little more space to Dr. Breasted's very clear and careful account of the battle of Kadesh.</p>
-                            <p>From its extremely condensed form it is impossible to review the book in detail, bat it may be said that the evidence quoted is fairly up to date, although Prof. Petrie does not seem to have examined M. Legrain's discoveries at Karnak. Had he done so, we fancy he would have found it necessary to make a considerable change in his genealogy of the Sheshonkide kings. Yet, on the whole, he seems to have chosen the facts recorded with care, and we are glad to see that he will have nothing to do with Prof. Winkler’s Masri theory. He takes, perhaps, too professional a view of ethics when he tells us that Seti I.’s character was one of the best in history, because, apparently, he left monuments in honor of bis predecessors and usurped no monuments without recording the name of the king under whom they were originally inscribed. Later, he characteristically uses the reputation with which Seti is thus generously presented in favor of his own arguments, saying that “the general character of this king is so honorable in his works, that we are bound to credit his statements if we cannot show them to be wrong.” We do not think that Prof. Petrie’s identification of place and other names shows much acquaintance with the Semitic, or, for that matter, with the Aryan languages, and we have noticed some mistakes, such as “cieling” for ceiling, "Revillont” for Revillout and a Greek pi for an eta. His English is still slipshod The lists of the monuments of every king, with provenance and abiding place, that he gives, will be extremely useful to students ; and for the care and pains that he has bestowed on their compilation all Egyptologists should be grateful.</p>
+                            <p>while, after discussing the two assumptions in question, he concludes that “no one who uses it can be supposed to know of the facts of the history which are stated in this volume.” There have been nearly as many systems of chronology in Egyptian history as historians, and Brugsch's system" is, like all the others, in great measure a system of inferences from rather slender foundations. But Brugsch was a man of deep and wide learning, as well as an Egyptologist who had spent has life in the study of his subject; and as the founder of demotic studies he possessed a knowledge of the language of the monuments for greater than any of which Prof. Petrie can boast We think, therefore, that his theories should be treated with respect and that it will require something more than Prof. Petrie’s pronouncements ex cathedra to dispossess a system which still has much to reccommend it This apart, Prof. Petrie is, in other respects, unusually tolerant of the opinions of
+                                other in this volume, and it is good to find him actually referring with courtesy and even with approbation to the works of those whom he is pleased to consider his rivals. Thus he not only speaks with approval of certain work of Mr. H. R. Hall, but also says, with regard to the supposed route of the Exodus, that “the result of Naville's discussion of it is reasonable and generally accepted.” We think, however, that he might have devoted a little more space to Dr. Breasted's very clear and careful account of the battle of Kadesh.</p>
+                            <p>From its extremely condensed form it is impossible to review the book in detail, bat it may be said that the evidence quoted is fairly up to date, although Prof. Petrie does not seem to have examined M. Legrain's discoveries at Karnak. Had he done so, we fancy he would have found it necessary to make a considerable change in his genealogy of the Sheshonkide kings. Yet, on the whole, he seems to have chosen the facts recorded with care, and we are glad to see that he will have nothing to do with Prof. Winkler’s Masri theory. He takes, perhaps, too professional a view of ethics when he tells us that Seti I.’s character was one of the best in history, because, apparently, he left monuments in honor of bis predecessors and usurped no monuments without recording the name of the king under whom they were originally inscribed. Later, he characteristically uses the reputation with which Seti is thus generously presented in favor of his own arguments, saying that
+                                “the general character of this king is so honorable in his works, that we are bound to credit his statements if we cannot show them to be wrong.” We do not think that Prof. Petrie’s identification of place and other names shows much acquaintance with the Semitic, or, for that matter, with the Aryan languages, and we have noticed some mistakes, such as “cieling” for ceiling, "Revillont” for Revillout and a Greek pi for an eta. His English is still slipshod The lists of the monuments of every king, with provenance and abiding place, that he gives, will be extremely useful to students ; and for the care and pains that he has bestowed on their compilation all Egyptologists should be grateful.</p>
                         </q>
                         <p>A History of <placeName ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName> from the XIXth to the XXXth Dynasties. By IF. M. Flinders Petrie. </p>
                         <byline>(Methuen).</byline>
@@ -1506,7 +1375,8 @@
                     </div>
                     <div type="article">
                         <head>ST. ANDREW'S CHURCH.</head>
-                        <head><placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> </head>
+                        <head><placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>
+                        </head>
                         <p>Services</p>
                         <p>Beginning Sunday, 8th October.</p>
                         <p>MW</p>
@@ -1521,7 +1391,7 @@
                         <p>The first event, for which there are 19 competitors, will be the 60 yards club run in four heats, and the winner will secure H. E. Sir Reginald Wingate Pasha's Sirdar Medal”, presented as a perpetual trophy, upon which the winner's name of each year will be engraved; the club also offers three prizes for this event, the first of which is a miniature in silver in the Sirdar’s prize.</p>
                         <p>Event II. will be the 60 yards juniors' handicap, for which there are six entries and three prizes presented by the club, and then will come a 60 yards handicap for members of 35 years of age or more, for which then are nine entries and three prizes, and this will be followed by the final race for the "Sirdar Medal."</p>
                         <p>The junior’s diving championship comes next, in which we will see nine boys vying with each other in graceful dives from three, five, and eight feet Take note, youthful competition, that while the "swallow" is permitted, the “book” must be avoided on penalty of disqualification. For this event a silver cup has been presented by the Hon. Secretary and three club prizes will also bo given.</p>
-                        <p>For the plunging championship, which whill  follow 17 members will compete for a cup and three prises, presented by the <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> and Ramleh Railway Co., Ltd., and there will then be a polo match between the Eastern Tele graph and the <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> Swimming Club; each member of the winning team will secure a prize, for which they will be indebted to the dub. This event will conclude the first part of the programme.</p>
+                        <p>For the plunging championship, which whill follow 17 members will compete for a cup and three prises, presented by the <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> and Ramleh Railway Co., Ltd., and there will then be a polo match between the Eastern Tele graph and the <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> Swimming Club; each member of the winning team will secure a prize, for which they will be indebted to the dub. This event will conclude the first part of the programme.</p>
                         <p>The second part of the programme will commence with a blindfold race for three prizes presented by the dub, and will be followed by an open diving competition; the rules of this competition are the same as for the junior competition, with the exception of the heights which will 3, 8, and 15 feet, and there are three prizes presented by the club.</p>
                         <p>Event X takes the form of an obstacle race for which there are 15 entries, and the for this race are presented by the staff of the Eastern Telegraph Co., Ltd. Than comes a military polo match, with a prise for each member of the winning team, and the junior members will then “walk the pole”, after whisk the seniors will follow their example; for each of these two races only one prise will be given.</p>
                         <p>A military tug of war and than a military team race follow, and each member of the winning teams will secure a prise, and the programme will then be concluded with a cock fight for which the dab ‘offer one prise.</p>
@@ -1530,34 +1400,42 @@
                     <div type="article">
                         <head>A POEM.</head>
                         <p>We reproduoe ( unedited ) the following poem sent us by a native reader :—</p>
-                        <q>
+                        <div type="item">
                             <head>LIFE, A BAZAR.</head>
-                            <lg>
-                                <l>The slothful laws of meager life,</l>
-                                <l>Are but marital fare.</l>
-                                <l>The universe that rolls about,</l>
-                                <l>Whose trend la ever change.</l>
-                                <l>Is but a public bazar free.</l>
-                                <l>When all is bought for sale.</l>
-                                <l>Man is the price that's freely paid To buy the lady sought,</l>
-                                <l>For woman an the; things for sale To him who highest pay.</l>
-                                <l>They're trained to this as they are born,</l>
-                                <l>For man is but their dice.</l>
-                                <l>Their fickle heart doth seek anew For change to others win.</l>
-                                <l>The one who flees their subtle snare,</l>
-                                <l>They ever seek to how.</l>
-                                <l>They always train themsleves to show For sale within the fare.</l>
-                            </lg>
-                        </q>
+                            <q>
+                                <lg>
+                                    <l>The slothful laws of meager life,</l>
+                                    <l>Are but marital fare.</l>
+                                    <l>The universe that rolls about,</l>
+                                    <l>Whose trend la ever change.</l>
+                                    <l>Is but a public bazar free.</l>
+                                    <l>When all is bought for sale.</l>
+                                    <l>Man is the price that's freely paid To buy the lady sought,</l>
+                                    <l>For woman an the; things for sale To him who highest pay.</l>
+                                    <l>They're trained to this as they are born,</l>
+                                    <l>For man is but their dice.</l>
+                                    <l>Their fickle heart doth seek anew For change to others win.</l>
+                                    <l>The one who flees their subtle snare,</l>
+                                    <l>They ever seek to how.</l>
+                                    <l>They always train themsleves to show For sale within the fare.</l>
+                                </lg>
+                            </q>
+                        </div>
                     </div>
                     <div type="article">
                         <head>PASSENGER LIST.</head>
-                        <head>ARRIVALS.</head><!-- TODO Figure out how to best represent the data -->
-                        <p>Le paquebot Nilo de la Cie Florio Rubattino arrive de Venire avait a bord :</p>
-                        <p>MM. N. Jacovelli, Mme Maocari, M. et Mme Balestrieri, Jabes, S<placeName ref="https://www.wikidata.org/wiki/Q148">China</placeName>ri et fam., Klatengue, G. Drosso, Vais, Reas et fam., Wamhe, Av. et Mme Cuzzer, Antranikian et fam., Uliedes et fam., Dr. Rossi, Alessandrini, Terni, P. Milk, Rodriguez, Hermann, D. Sebton, M. et Mme Pugnaletto, Vuta et fam., Warn, fam. Luochess et 100 autres passagers.</p>
-                        <head>DEPARTURES.</head><!-- TODO Figure out how to best represent the data -->
-                        <p>Le paquebot Eona de la Cie Florio Rubat tino parti hier pour Genes avait a bord.</p>
-                        <p>MM. Chidiao. Terranova, Mlle Con Van Camp, A. Franck, M. et Mme Bahadurgi, Mme R. Fichelett, Duchesse d’Andria, P. Dablis, Ah. Zeki, Barotti, Hanna Bassombay, lieut. Eloseda, Cap. B. Dalle Piane, Mme Femallah et bebe, lieut comte Belisario, M. et Maw V. La Piassa et 2 fils, Lafsovish et fam, et 25 passagers de 3e classe.</p>
+                        <div type="subsection">
+                            <head>ARRIVALS.</head>
+                            <!-- TODO Figure out how to best represent the data -->
+                            <p>Le paquebot Nilo de la Cie Florio Rubattino arrive de Venire avait a bord :</p>
+                            <p>MM. N. Jacovelli, Mme Maocari, M. et Mme Balestrieri, Jabes, S<placeName ref="https://www.wikidata.org/wiki/Q148">China</placeName>ri et fam., Klatengue, G. Drosso, Vais, Reas et fam., Wamhe, Av. et Mme Cuzzer, Antranikian et fam., Uliedes et fam., Dr. Rossi, Alessandrini, Terni, P. Milk, Rodriguez, Hermann, D. Sebton, M. et Mme Pugnaletto, Vuta et fam., Warn, fam. Luochess et 100 autres passagers.</p>
+                        </div>
+                        <div type="subsection">
+                            <head>DEPARTURES.</head>
+                            <!-- TODO Figure out how to best represent the data -->
+                            <p>Le paquebot Eona de la Cie Florio Rubat tino parti hier pour Genes avait a bord.</p>
+                            <p>MM. Chidiao. Terranova, Mlle Con Van Camp, A. Franck, M. et Mme Bahadurgi, Mme R. Fichelett, Duchesse d’Andria, P. Dablis, Ah. Zeki, Barotti, Hanna Bassombay, lieut. Eloseda, Cap. B. Dalle Piane, Mme Femallah et bebe, lieut comte Belisario, M. et Maw V. La Piassa et 2 fils, Lafsovish et fam, et 25 passagers de 3e classe.</p>
+                        </div>
                     </div>
                 </div>
             </div>

--- a/1905-10-07.xml
+++ b/1905-10-07.xml
@@ -30,36 +30,17 @@
         <body>
             <div type="page" n="1">
                 <head>THE EGYPTIAN GAZETTE</head>
-                <head type="sub">No. 7239] <placeName ref="https://www.wikidata.org/wiki/Q87"
-                        >Alexandria</placeName>, Saturday, October 7, 1905. [SIX PAGES P.T.
-                    1.</head>
+                <head type="sub">No. 7239] <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>, Saturday, October 7, 1905. [SIX PAGES P.T. 1.</head>
                 <div type="section" scope="advertisement">
                     <cb n="1"/>
                     <div type="item" scope="advertisement" xml:id="deg-ad-pos01">
                         <head>Peninsular and Oriental S. N. Company.</head>
                         <p>Summer Rates will be charged from 2 May to 31 October. </p>
-                        <p>For the convenience of families and others, a large portion of each
-                            ship’s accommodation has been reserved for Egypt, so that Berths can be
-                            definitely engaged at once, as if the voyage were commencing at
-                                <placeName ref="https://www.wikidata.org/wiki/Q134509">Port
-                                Said</placeName>. Plans can be seen at the Offices of the Company’s
-                            Agents. </p>
-                        <p>The through Steamers for <placeName
-                                ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName>
-                            and <placeName ref="https://www.wikidata.org/wiki/Q84"
-                                >London</placeName> are intended to leave <placeName
-                                ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>
-                            after the arrival of the 11 a.m. train from <placeName
-                                ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> , every
-                            Tuesday for the present except the MONGOLIA, which is taking passengers
-                            to the Anglo-French Naval Review, and will not wait at <placeName
-                                ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName> on
-                            24/25 July. A steam tender will meet the train to convey passengers to
-                            the ship. </p>
+                        <p>For the convenience of families and others, a large portion of each ship’s accommodation has been reserved for Egypt, so that Berths can be definitely engaged at once, as if the voyage were commencing at <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>. Plans can be seen at the Offices of the Company’s Agents. </p>
+                        <p>The through Steamers for <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName> and <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> are intended to leave <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> after the arrival of the 11 a.m. train from <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> , every Tuesday for the present except the MONGOLIA, which is taking passengers to the Anglo-French Naval Review, and will not wait at <placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName> on 24/25 July. A steam tender will meet the train to convey passengers to the ship. </p>
                         <table>
                             <row>
-                                <cell><placeName ref="https://www.wikidata.org/wiki/Q79"
-                                        >Egypt</placeName>
+                                <cell><placeName ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName>
                                 </cell>
                                 <cell>4 July</cell>
                                 <cell>Arcadia </cell>
@@ -80,64 +61,39 @@
                                 <cell>18 July</cell>
                                 <cell>Arabia </cell>
                                 <cell>15 August</cell>
-                                <cell><placeName ref="https://www.wikidata.org/wiki/Q79"
-                                        >Egypt</placeName>
+                                <cell><placeName ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName>
                                 </cell>
                                 <cell>12 Sept.</cell>
                             </row>
                             <row>
                                 <cell>Mongolia</cell>
                                 <cell>25 July</cell>
-                                <cell><placeName ref="https://www.wikidata.org/wiki/Q148"
-                                        >China</placeName></cell>
+                                <cell><placeName ref="https://www.wikidata.org/wiki/Q148">China</placeName></cell>
                                 <cell>22 August</cell>
                                 <cell>Macedonia</cell>
                                 <cell>19 Sept.</cell>
                             </row>
                         </table>
-                        <p>The Brindisi Express Steamers leave <placeName
-                                ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>
-                            directly the Indian Mails arrive. Passengers can go on board the evening
-                            before. The Fare remains as usual. </p>
+                        <p>The Brindisi Express Steamers leave <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> directly the Indian Mails arrive. Passengers can go on board the evening before. The Fare remains as usual. </p>
                         <p>For all further information apply to the Company's Agents, </p>
-                        <p>Messrs. THOS. COOK &amp; SON (Egypt) Ltd. <placeName
-                                ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> . </p>
-                        <p>GEORGE ROYLE, Esq. <placeName ref="https://www.wikidata.org/wiki/Q134509"
-                                >Port-Said</placeName> . </p>
-                        <p>Messrs. HABELDEN &amp; Co. <placeName
-                                ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>. </p>
-                        <p> F. G. DAVIDSON, Superintendent P. &amp; O. S. N. Company in <placeName
-                                ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName>
-                            <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>.
-                        </p>
+                        <p>Messrs. THOS. COOK &amp; SON (Egypt) Ltd. <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> . </p>
+                        <p>GEORGE ROYLE, Esq. <placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName> . </p>
+                        <p>Messrs. HABELDEN &amp; Co. <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>. </p>
+                        <p> F. G. DAVIDSON, Superintendent P. &amp; O. S. N. Company in <placeName ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName>
+                            <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>. </p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-opl01">
                         <head>Orient-Pacific Line of Royal Mail Steamers.</head>
                         <p>REDUCED SUMMER FARES FROM MAY TO OCTOBER INCLUSIVE.</p>
-                        <p>OUTWARDS to <placeName ref="https://www.wikidata.org/wiki/Q408"
-                                >Australia</placeName> .</p>
-                        <p>R.M.S. “Orotava" will leave <placeName
-                                ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName> about
-                            July 28 | R.M.S "Ormuz" will leave <placeName
-                                ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName> about
-                            August 11. </p>
-                        <p>HOMEWARDS to <placeName ref="https://www.wikidata.org/wiki/Q2634"
-                                >Naples</placeName>
-                            <placeName ref="https://www.wikidata.org/wiki/Q579613"
-                                >Marseilles</placeName>, GIBRALTAR, PLYMOUTH, <placeName
-                                ref="https://www.wikidata.org/wiki/Q84">London</placeName>,
-                            TILBURY</p>
-                        <p>R.M.S. "Oroya" will leave <placeName
-                                ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>
-                            about July 18 | R.M.S. “Ortona" will leave <placeName
-                                ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>
-                            about August 1</p>
+                        <p>OUTWARDS to <placeName ref="https://www.wikidata.org/wiki/Q408">Australia</placeName> .</p>
+                        <p>R.M.S. “Orotava" will leave <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName> about July 28 | R.M.S "Ormuz" will leave <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName> about August 11. </p>
+                        <p>HOMEWARDS to <placeName ref="https://www.wikidata.org/wiki/Q2634">Naples</placeName>
+                            <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName>, GIBRALTAR, PLYMOUTH, <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName>, TILBURY</p>
+                        <p>R.M.S. "Oroya" will leave <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> about July 18 | R.M.S. “Ortona" will leave <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> about August 1</p>
                         <table>
                             <row>
                                 <cell rows="4">Reduced Summer Fares</cell>
-                                <cell><placeName ref="https://www.wikidata.org/wiki/Q134509"
-                                        >Port-Said</placeName> to <placeName
-                                        ref="https://www.wikidata.org/wiki/Q2634">Naples</placeName>
+                                <cell><placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName> to <placeName ref="https://www.wikidata.org/wiki/Q2634">Naples</placeName>
                                 </cell>
                                 <cell>1st Class</cell>
                                 <cell>£ 11</cell>
@@ -147,10 +103,7 @@
                                 <cell>£ 4.8</cell>
                             </row>
                             <row>
-                                <cell><placeName ref="https://www.wikidata.org/wiki/Q134509"
-                                        >Port-Said</placeName> to <placeName
-                                        ref="https://www.wikidata.org/wiki/Q579613"
-                                        >Marseilles</placeName></cell>
+                                <cell><placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName> to <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName></cell>
                                 <cell>1st Class</cell>
                                 <cell>£ 12.12</cell>
                                 <cell>2nd Class</cell>
@@ -159,8 +112,7 @@
                                 <cell>£ 5.10</cell>
                             </row>
                             <row>
-                                <cell><placeName ref="https://www.wikidata.org/wiki/Q134509"
-                                        >Port-Said</placeName> to Gibraltar</cell>
+                                <cell><placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName> to Gibraltar</cell>
                                 <cell>1st Class</cell>
                                 <cell>£ 18.0</cell>
                                 <cell>2nd Class</cell>
@@ -169,8 +121,7 @@
                                 <cell>£ 5.10</cell>
                             </row>
                             <row>
-                                <cell><placeName ref="https://www.wikidata.org/wiki/Q134509"
-                                        >Port-Said</placeName> to Plymouth or Tilbury</cell>
+                                <cell><placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName> to Plymouth or Tilbury</cell>
                                 <cell>1st Class</cell>
                                 <cell>£ 16.16</cell>
                                 <cell>2nd Class</cell>
@@ -179,94 +130,44 @@
                                 <cell>£ 8.16</cell>
                             </row>
                         </table>
-                        <p>Egyptian Government Officials allowed a rebate of 15% off the above
-                            fares.</p>
-                        <p>Return tickets no longer issued, but passengers paying full fare in one
-                            direction allowed abatement of 1/3 fare back if return voyage be within
-                            4 months of arrival, or abatement of 20 o/o if return voyage be made
-                            within 8 months of arrival.</p>
-                        <p>Agents. <placeName ref="https://www.wikidata.org/wiki/Q85"
-                                >Cairo</placeName> :—Thos. Cook &amp; Son. <placeName
-                                ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> : —R.
-                            J. Moss &amp; Co.—For all information apply </p>
-                        <p>Wm. STAPLEDON &amp; Sons, <placeName
-                                ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName>
-                            &amp; PORT-TEWFIK (<placeName
-                                ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>)
-                            31-12-904</p>
+                        <p>Egyptian Government Officials allowed a rebate of 15% off the above fares.</p>
+                        <p>Return tickets no longer issued, but passengers paying full fare in one direction allowed abatement of 1/3 fare back if return voyage be within 4 months of arrival, or abatement of 20 o/o if return voyage be made within 8 months of arrival.</p>
+                        <p>Agents. <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> :—Thos. Cook &amp; Son. <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> : —R. J. Moss &amp; Co.—For all information apply </p>
+                        <p>Wm. STAPLEDON &amp; Sons, <placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName> &amp; PORT-TEWFIK (<placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>) 31-12-904</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-blm01">
                         <head>BIBBY LINE MAIL STEAMERS.</head>
                         <p>Special Reduced Rates During Summer Season,</p>
-                        <p>OUTWARDS to COLOMBO, TUTICORIN, etc., and RANGOON. Departures from
-                                <placeName ref="https://www.wikidata.org/wiki/Q134514"
-                                >Suez</placeName>.</p>
+                        <p>OUTWARDS to COLOMBO, TUTICORIN, etc., and RANGOON. Departures from <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>.</p>
                         <p>S.S. Derbyshire 6,635 tons, leaves about July 20.</p>
                         <p>S.S. Lancashire 4,244 tons, leaves about August 3.</p>
-                        <p>HOMEWARDS to <placeName ref="https://www.wikidata.org/wiki/Q579613"
-                                >Marseilles</placeName> and <placeName
-                                ref="https://www.wikidata.org/wiki/Q84">London</placeName>.
-                            Departures from <placeName ref="https://www.wikidata.org/wiki/Q134509"
-                                >Port Said</placeName>.</p>
+                        <p>HOMEWARDS to <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName> and <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName>. Departures from <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>.</p>
                         <p>S.S. Worcestershire 7,160 tons, leaves about July 26.</p>
                         <p>S.S. Yorkshire 4,196 tons leaves about August 9,</p>
-                        <p>FARES from <placeName ref="https://www.wikidata.org/wiki/Q134509">Port
-                                Said</placeName> to <placeName
-                                ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName>
-                            £12.0.0, <placeName ref="https://www.wikidata.org/wiki/Q84"
-                                >London</placeName> £17.0.0, Colombo £32.10.0, Rangoon £37.10.0. </p>
-                        <p>Agents <placeName ref="https://www.wikidata.org/wiki/Q85"
-                                >Cairo</placeName> : THOS. COOK &amp; SON. <placeName
-                                ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName> &amp;
-                                <placeName ref="https://www.wikidata.org/wiki/Q134509">Port
-                                Said</placeName> : WM. STAPLEDON &amp; SONS, 31-12-905</p>
+                        <p>FARES from <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> to <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName> £12.0.0, <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> £17.0.0, Colombo £32.10.0, Rangoon £37.10.0. </p>
+                        <p>Agents <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> : THOS. COOK &amp; SON. <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName> &amp; <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> : WM. STAPLEDON &amp; SONS, 31-12-905</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-kml01">
                         <head>KHEDIVIAL MAIL LINE.</head>
-                        <head type="sub">FAST BRITISH PASSENGER STEAMERS</head>
-                        <head type="sub"><placeName ref="https://www.wikidata.org/wiki/Q41"
-                                >Greece</placeName> - <placeName
-                                ref="https://www.wikidata.org/wiki/Q43">Turkey</placeName>
-                            LINE.</head>
-                        <p>Express Steamers leave <placeName ref="https://www.wikidata.org/wiki/Q87"
-                                >Alexandria</placeName> every Wednesday at 4 p.m. for PIRAEUS,
-                            SMYRNA, MITYLENE, and CONSTANTINOPLE, in connection with Orient Express
-                            train-de-luxe for Vienna, <placeName
-                                ref="https://www.wikidata.org/wiki/Q90">Paris</placeName>, and
-                                <placeName ref="https://www.wikidata.org/wiki/Q84"
-                                >London</placeName>.</p>
-                        <head type="sub">PALESTINE - SYRIA LINE.</head>
-                        <p>Fast steamers leave <placeName ref="https://www.wikidata.org/wiki/Q87"
-                                >Alexandria</placeName> every Saturday at 6 p.m., and <placeName
-                                ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>
-                            every Sunday at 6 p.m., for JAFFA (for Jerusalem), CAIFFA (for
-                            Nazareth), BEYROUT (for Damascus), TRIPOLI, ALEXANDRETTA, MESSINA,
-                            continuing in alternate weeks to LARNACA and LIMASSOL (Cyprus).</p>
-                        <head type="sub">RED SEA LINE.</head>
-                        <p>Steamers leave <placeName ref="https://www.wikidata.org/wiki/Q134514"
-                                >Suez</placeName> fortnightly on Wednesday at 6 p.m. for JEDDAH,
-                            SUAKIN, MASSOWAH, HODBIDAH, and ADEN ; and in the intervening weeks for
-                            PORT SUDAN and SUAKIN direct. Calls will be made at TOR (for Mount
-                            Sinai) as required.</p>
-                        <p>N.B.—Deck chairs provided for the use of passengers, excellent cuisine
-                            and table wine free.</p>
-                        <p>Steamer plans may be seen and passages booked at the Company’s Agencies
-                            at <placeName ref="https://www.wikidata.org/wiki/Q87"
-                                >Alexandria</placeName>, <placeName
-                                ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> ,
-                                <placeName ref="https://www.wikidata.org/wiki/Q134509">Port
-                                Said</placeName>, and <placeName
-                                ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>, or at
-                            THOS. COOK &amp; SON or other Tourist Agency. 31-12-904</p>
+                        <div type="subsection">
+                            <head type="sub">FAST BRITISH PASSENGER STEAMERS</head>
+                            <head type="sub"><placeName ref="https://www.wikidata.org/wiki/Q41">Greece</placeName> - <placeName ref="https://www.wikidata.org/wiki/Q43">Turkey</placeName> LINE.</head>
+                            <p>Express Steamers leave <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> every Wednesday at 4 p.m. for PIRAEUS, SMYRNA, MITYLENE, and CONSTANTINOPLE, in connection with Orient Express train-de-luxe for Vienna, <placeName ref="https://www.wikidata.org/wiki/Q90">Paris</placeName>, and <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName>.</p>
+                        </div>
+                        <div type="subsection">
+                            <head type="sub">PALESTINE - SYRIA LINE.</head>
+                            <p>Fast steamers leave <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> every Saturday at 6 p.m., and <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> every Sunday at 6 p.m., for JAFFA (for Jerusalem), CAIFFA (for Nazareth), BEYROUT (for Damascus), TRIPOLI, ALEXANDRETTA, MESSINA, continuing in alternate weeks to LARNACA and LIMASSOL (Cyprus).</p>
+                        </div>
+                        <div type="subsection">
+                            <head type="sub">RED SEA LINE.</head>
+                            <p>Steamers leave <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName> fortnightly on Wednesday at 6 p.m. for JEDDAH, SUAKIN, MASSOWAH, HODBIDAH, and ADEN ; and in the intervening weeks for PORT SUDAN and SUAKIN direct. Calls will be made at TOR (for Mount Sinai) as required.</p>
+                            <p>N.B.—Deck chairs provided for the use of passengers, excellent cuisine and table wine free.</p>
+                            <p>Steamer plans may be seen and passages booked at the Company’s Agencies at <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>, <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> , <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>, and <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>, or at THOS. COOK &amp; SON or other Tourist Agency. 31-12-904</p>
+                        </div>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-mss01">
                         <head>The Moss S.S. Company, Ltd.</head>
-                        <p>For <placeName ref="https://www.wikidata.org/wiki/Q24826"
-                                >Liverpool</placeName> calling at <placeName
-                                ref="https://www.wikidata.org/wiki/Q233">Malta</placeName> (Messrs.
-                            JAMES MOSS &amp; Co. 31, James St, <placeName
-                                ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName>,
-                            Managers.)</p>
+                        <p>For <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName> calling at <placeName ref="https://www.wikidata.org/wiki/Q233">Malta</placeName> (Messrs. JAMES MOSS &amp; Co. 31, James St, <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName>, Managers.)</p>
                         <table rows="3" cols="8">
                             <row>
                                 <cell>*Amasis</cell>
@@ -299,217 +200,101 @@
                                 <cell>(Building)</cell>
                             </row>
                         </table>
-                        <p>*Second class accommodation only, unless specially reserved.—Fares :
-                                <placeName ref="https://www.wikidata.org/wiki/Q87"
-                                >Alexandria</placeName> to <placeName
-                                ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName>,
-                            1st, £14 Single, £25 Return. 2nd, £9 Single, £15 Return.—To <placeName
-                                ref="https://www.wikidata.org/wiki/Q233">Malta</placeName>, 1st, £5
-                            Single, £9 Return, 2nd, £3 Single, £5 Return.—Return tickets available
-                            for six months.</p>
-                        <p>S.S. Seti now on the berth, will sail on or about Monday, July 17, to be
-                            followed by S.S. Menes.</p>
-                        <p>S.S Tabor for Havre via <placeName
-                                ref="https://www.wikidata.org/wiki/Q233">Malta</placeName> to sail
-                            about Saturday l5th inst.</p>
-                        <p>Through freight rates on cotton, etc., to Lancashire inland towns,
-                            Boston, New York and other U.S.A. towns, obtained on application. Cargo
-                            taken by special agreement only. </p>
-                        <p>Passenger Tickets also issued inclusive of Railway fare through to and
-                            from <placeName ref="https://www.wikidata.org/wiki/Q85"
-                                >Cairo</placeName> . Particulars on application to </p>
-                        <p>R. J. MOSS &amp; Co., <placeName ref="https://www.wikidata.org/wiki/Q87"
-                                >Alexandria</placeName>, Agents. 26-12-905</p>
+                        <p>*Second class accommodation only, unless specially reserved.—Fares : <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> to <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName>, 1st, £14 Single, £25 Return. 2nd, £9 Single, £15 Return.—To <placeName ref="https://www.wikidata.org/wiki/Q233">Malta</placeName>, 1st, £5 Single, £9 Return, 2nd, £3 Single, £5 Return.—Return tickets available for six months.</p>
+                        <p>S.S. Seti now on the berth, will sail on or about Monday, July 17, to be followed by S.S. Menes.</p>
+                        <p>S.S Tabor for Havre via <placeName ref="https://www.wikidata.org/wiki/Q233">Malta</placeName> to sail about Saturday l5th inst.</p>
+                        <p>Through freight rates on cotton, etc., to Lancashire inland towns, Boston, New York and other U.S.A. towns, obtained on application. Cargo taken by special agreement only. </p>
+                        <p>Passenger Tickets also issued inclusive of Railway fare through to and from <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> . Particulars on application to </p>
+                        <p>R. J. MOSS &amp; Co., <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>, Agents. 26-12-905</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-mic01">
                         <head>MARINE INSURANCE COMPANY, LIMITED.</head>
                         <p>Established 1836. Capital £1,000,000. Reserve Fund £650,000. </p>
-                        <p>THE IMPERIAL FIRE OFFICE united with THE ALLIANCE ASSURANCE, Co.,
-                            Ltd.</p>
-                        <p>1, Old Broad Street, <placeName ref="https://www.wikidata.org/wiki/Q84"
-                                >London</placeName>—Estabished 1806.—Total Funds exceed
-                            £10,000,000.</p>
-                        <p>31-12-905. Policies issued at <placeName
-                                ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName> by G.
-                            BEYTS &amp; Co., Agents.</p>
+                        <p>THE IMPERIAL FIRE OFFICE united with THE ALLIANCE ASSURANCE, Co., Ltd.</p>
+                        <p>1, Old Broad Street, <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName>—Estabished 1806.—Total Funds exceed £10,000,000.</p>
+                        <p>31-12-905. Policies issued at <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName> by G. BEYTS &amp; Co., Agents.</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-tce01">
                         <head>Telephone Company of Egypt, Limited.</head>
-                        <p><placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>
-                                -<placeName ref="https://www.wikidata.org/wiki/Q87"
-                                >Alexandria</placeName> TELEPHONE.--Rates as follows P.T. 5 for each
-                            3 minutes, or fraction of 3 minutes; P.T. 10 for over 3 up to 8 minutes
-                            communication.</p>
-                        <p>PUBLIC CALL-OFFICES : <placeName ref="https://www.wikidata.org/wiki/Q85"
-                                >Cairo</placeName> , Central Office, Opera Square, and New Bar;
-                            Helouan, Central Office, Maison Purvis ; <placeName
-                                ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>, St
-                            Mark’s Buildings, Egyptian Bar, I. Castelli &amp; Co.; Ramleh, Central
-                            Office. San Stefano Casino 30.4.906</p>
+                        <p><placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> -<placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> TELEPHONE.--Rates as follows P.T. 5 for each 3 minutes, or fraction of 3 minutes; P.T. 10 for over 3 up to 8 minutes communication.</p>
+                        <p>PUBLIC CALL-OFFICES : <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> , Central Office, Opera Square, and New Bar; Helouan, Central Office, Maison Purvis ; <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>, St Mark’s Buildings, Egyptian Bar, I. Castelli &amp; Co.; Ramleh, Central Office. San Stefano Casino 30.4.906</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-phc01">
                         <head>P. HENDERSON &amp; CO’s LINE.</head>
-                        <p>Steamers leave <placeName ref="https://www.wikidata.org/wiki/Q134514"
-                                >Suez</placeName> and <placeName
-                                ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>
-                            fortnightly for <placeName ref="https://www.wikidata.org/wiki/Q84"
-                                >London</placeName> or <placeName
-                                ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName>
-                            direct.</p>
+                        <p>Steamers leave <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName> and <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> fortnightly for <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> or <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName> direct.</p>
                         <p>(Electric Light.) SALOON (Amidships) FARE £12. (Latest improvements.)</p>
-                        <p>S.S. RANGOON 6000 Tons will leave <placeName
-                                ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>
-                            about July 23 for <placeName ref="https://www.wikidata.org/wiki/Q84"
-                                >London</placeName>.</p>
-                        <p>S.S. BURMA 5600 Tons will leave <placeName
-                                ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>
-                            about August 6 for <placeName ref="https://www.wikidata.org/wiki/Q84"
-                                >London</placeName>.</p>
-                        <p>S.S. ARRACAN 5800 Tons will leave <placeName
-                                ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>
-                            about 20 for <placeName ref="https://www.wikidata.org/wiki/Q24826"
-                                >Liverpool</placeName></p>
-                        <p>Due in <placeName ref="https://www.wikidata.org/wiki/Q84"
-                                >London</placeName> or <placeName
-                                ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName> 12
-                            days thereafter.</p>
-                        <p>Apply WORMS &amp; Co., <placeName
-                                ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>
-                            and <placeName ref="https://www.wikidata.org/wiki/Q134514"
-                                >Suez</placeName>. THOS. COOK &amp; SON, (EGYPT) LD., <placeName
-                                ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> ;</p>
-                        <p>G. J. GRACE &amp; CO., <placeName ref="https://www.wikidata.org/wiki/Q87"
-                                >Alexandria</placeName>.</p>
+                        <p>S.S. RANGOON 6000 Tons will leave <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> about July 23 for <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName>.</p>
+                        <p>S.S. BURMA 5600 Tons will leave <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> about August 6 for <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName>.</p>
+                        <p>S.S. ARRACAN 5800 Tons will leave <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> about 20 for <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName></p>
+                        <p>Due in <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> or <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName> 12 days thereafter.</p>
+                        <p>Apply WORMS &amp; Co., <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> and <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>. THOS. COOK &amp; SON, (EGYPT) LD., <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> ;</p>
+                        <p>G. J. GRACE &amp; CO., <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>.</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-tcs01">
                         <head>Thos. Cook &amp; Son,</head>
-                        <p>(EGYPT), LIMITED, HEAD OFFICE—LUDGATE CIRCUS—<placeName
-                                ref="https://www.wikidata.org/wiki/Q84">London</placeName>.</p>
-                        <p>CHIEF EGYPTIAN OFFICE — <placeName
-                                ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> , near
-                            SHEPHEARD'S HOTEL. </p>
-                        <p><placeName ref="https://www.wikidata.org/wiki/Q87"
-                            >Alexandria</placeName>, <placeName
-                                ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName> ,
-                                <placeName ref="https://www.wikidata.org/wiki/Q134514"
-                                >Suez</placeName>, Luxor, Assuan, Haifa, &amp; Khartum.</p>
+                        <p>(EGYPT), LIMITED, HEAD OFFICE—LUDGATE CIRCUS—<placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName>.</p>
+                        <p>CHIEF EGYPTIAN OFFICE — <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> , near SHEPHEARD'S HOTEL. </p>
+                        <p><placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>, <placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName> , <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>, Luxor, Assuan, Haifa, &amp; Khartum.</p>
                         <p>GENERAL RAILWAY AND STEAMSHIP AGENTS. BANKERS.</p>
                         <p>BAGGAGE AND FORWARDING AGENTS.</p>
-                        <p>Officially appointed &amp; Sole Agents in <placeName
-                                ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> to the
-                            P.&amp;O. S.N. Co.</p>
-                        <p>RESIDENTS IN <placeName ref="https://www.wikidata.org/wiki/Q79"
-                                >Egypt</placeName> proceeding to Europe for the summer are requested
-                            to apply to our offices for information respecting their Passages, where
-                            steamer plans may be consulted and Berths secured by all Lines of
-                            Steamers to all parts of the Globe; arrangements can also be made for
-                            the collection and forwarding of their baggage and clearance at port of
-                            arrival.</p>
-                        <p>CIRCULAR NOTES issued payable at the current rate of exchange in all the
-                            principal cities of Europe. Cook’s Interpreters in uniform are present
-                            at the principal Railway stations and Landing-places in Europe to assist
-                            passengers holding their travelling tickets.</p>
-                        <p>Large and splendidly appointed steamers belonging to the Co. leave
-                                <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>
-                            thrice weekly, between November and March, for Luxor, Assouan and
-                            Wady-Halfa in connection with trains de luxe to Khartoum. Moderate
-                            fares. </p>
-                        <p>FREIGHT SERVICE, Steamers leave <placeName
-                                ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> every
-                            Saturday and Tuesday for Assouan and Halfa.</p>
+                        <p>Officially appointed &amp; Sole Agents in <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> to the P.&amp;O. S.N. Co.</p>
+                        <p>RESIDENTS IN <placeName ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName> proceeding to Europe for the summer are requested to apply to our offices for information respecting their Passages, where steamer plans may be consulted and Berths secured by all Lines of Steamers to all parts of the Globe; arrangements can also be made for the collection and forwarding of their baggage and clearance at port of arrival.</p>
+                        <p>CIRCULAR NOTES issued payable at the current rate of exchange in all the principal cities of Europe. Cook’s Interpreters in uniform are present at the principal Railway stations and Landing-places in Europe to assist passengers holding their travelling tickets.</p>
+                        <p>Large and splendidly appointed steamers belonging to the Co. leave <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> thrice weekly, between November and March, for Luxor, Assouan and Wady-Halfa in connection with trains de luxe to Khartoum. Moderate fares. </p>
+                        <p>FREIGHT SERVICE, Steamers leave <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> every Saturday and Tuesday for Assouan and Halfa.</p>
                         <p>Special Steamers and Dahabeahs for private parties.</p>
-                        <p>Special arrangements for tour in PALESTINE, SYRIA and the DESERT, Lowest
-                            Rates.</p>
+                        <p>Special arrangements for tour in PALESTINE, SYRIA and the DESERT, Lowest Rates.</p>
                         <p>Best camp equipment in the country! 10 12-904 </p>
                     </div>
                     <cb n="2"/>
                     <div type="item" scope="advertisement" xml:id="deg-ad-bis01">
-                        <head>British <placeName ref="https://www.wikidata.org/wiki/Q668"
-                                >India</placeName> S. N. Company, Limited.</head>
+                        <head>British <placeName ref="https://www.wikidata.org/wiki/Q668">India</placeName> S. N. Company, Limited.</head>
                         <p>MAIL AND PASSENGER STEAM SHIPS.</p>
-                        <p>SAILINGS FROM <placeName ref="https://www.wikidata.org/wiki/Q134514"
-                                >Suez</placeName>, <placeName
-                                ref="https://www.wikidata.org/wiki/Q84">London</placeName> and
-                            CALCUTTA LINE.</p>
-                        <p>Calling at ADEN, COLOMBO and MADRAS Outward, and <placeName
-                                ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName>
-                            (GENOA and PLYMOUTH optional) Homeward. </p>
-                        <p>Fortnightly Service in connection with the Co's Indian Mail Lines and
-                            monthly with the East African Mail Line between ADEN, MOMBASSA and
-                            Zanzibar. </p>
+                        <p>SAILINGS FROM <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>, <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> and CALCUTTA LINE.</p>
+                        <p>Calling at ADEN, COLOMBO and MADRAS Outward, and <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName> (GENOA and PLYMOUTH optional) Homeward. </p>
+                        <p>Fortnightly Service in connection with the Co's Indian Mail Lines and monthly with the East African Mail Line between ADEN, MOMBASSA and Zanzibar. </p>
                         <p>OUTWARD.—S.S. Fazilka ... July 22 | HOMEWARD.—S.S. Mombassa ... July 21 </p>
-                        <p>Queensland Line of Steamers Between <placeName
-                                ref="https://www.wikidata.org/wiki/Q84">London</placeName> and
-                            Brisbane.</p>
+                        <p>Queensland Line of Steamers Between <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> and Brisbane.</p>
                         <p>Calling at Colombo, Batavia, Cooktown, Townsville, and Rockhamptom.</p>
-                        <p>The S.S. .................. will sail from <placeName
-                                ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName> on
-                            about ..................</p>
+                        <p>The S.S. .................. will sail from <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName> on about ..................</p>
                         <table rows="2" cols="9">
                             <row>
-                                <cell>First Class Fares from <placeName
-                                        ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>
-                                    to</cell>
+                                <cell>First Class Fares from <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName> to</cell>
                                 <cell>Aden</cell>
                                 <cell>£11. 8</cell>
                                 <cell>Colombo</cell>
                                 <cell>£14.14</cell>
                                 <cell>Calcutta</cell>
                                 <cell>£31. 0</cell>
-                                <cell><placeName ref="https://www.wikidata.org/wiki/Q579613"
-                                        >Marseilles</placeName></cell>
+                                <cell><placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName></cell>
                                 <cell>£15.12</cell>
                             </row>
                             <row>
                                 <cell/>
-                                <cell><placeName ref="https://www.wikidata.org/wiki/Q1156"
-                                        >Bombay</placeName></cell>
+                                <cell><placeName ref="https://www.wikidata.org/wiki/Q1156">Bombay</placeName></cell>
                                 <cell>£31.10</cell>
                                 <cell>Madras</cell>
                                 <cell>£xx.11</cell>
                                 <cell>Genoa</cell>
                                 <cell>£13.10</cell>
-                                <cell><placeName ref="https://www.wikidata.org/wiki/Q84"
-                                        >London</placeName></cell>
+                                <cell><placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName></cell>
                                 <cell>£19. 0</cell>
                             </row>
                         </table>
-                        <p>From <placeName ref="https://www.wikidata.org/wiki/Q134509"
-                                >Port-Said</placeName> £2 less Homeward, and £2 more Outward. Second
-                            class, two thirds of 1st Class Fares.</p>
-                        <p>Agents at <placeName ref="https://www.wikidata.org/wiki/Q134509">Port
-                                Said</placeName>, for the <placeName
-                                ref="https://www.wikidata.org/wiki/Q84">London</placeName>, Calcutta
-                            and Persian Gulf Lines, Messrs. Worms &amp; Co.</p>
-                        <p>Agents at <placeName ref="https://www.wikidata.org/wiki/Q134509">Port
-                                Said</placeName>, for the <placeName
-                                ref="https://www.wikidata.org/wiki/Q84">London</placeName> and
-                            Queensland Line, Messrs. Wills &amp; Co., Limited.</p>
-                        <p>Messrs. Thos. Cook &amp; Son and the Anglo-American Hotel &amp; Steamer
-                            Company, <placeName ref="https://www.wikidata.org/wiki/Q85"
-                                >Cairo</placeName> &amp; <placeName
-                                ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>.</p>
-                        <p>For further particulars. Freight and Passage apply to G. BEYTS &amp; Co.
-                            Agents, <placeName ref="https://www.wikidata.org/wiki/Q134514"
-                                >Suez</placeName>. 31-12-905</p>
+                        <p>From <placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName> £2 less Homeward, and £2 more Outward. Second class, two thirds of 1st Class Fares.</p>
+                        <p>Agents at <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>, for the <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName>, Calcutta and Persian Gulf Lines, Messrs. Worms &amp; Co.</p>
+                        <p>Agents at <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>, for the <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> and Queensland Line, Messrs. Wills &amp; Co., Limited.</p>
+                        <p>Messrs. Thos. Cook &amp; Son and the Anglo-American Hotel &amp; Steamer Company, <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> &amp; <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>.</p>
+                        <p>For further particulars. Freight and Passage apply to G. BEYTS &amp; Co. Agents, <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>. 31-12-905</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-all01">
                         <head>ANCHOR LINE, LIMITED.</head>
-                        <p>(HENDERSON BROTHERS,) <placeName ref="https://www.wikidata.org/wiki/Q84"
-                                >London</placeName>, <placeName
-                                ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName> AND
-                            GLASGOW.</p>
-                        <p>Booking Passengers and Cargo through to Ports in <placeName
-                                ref="https://www.wikidata.org/wiki/Q668">India</placeName>, Europe
-                            &amp; America</p>
-                        <p>First class passengers steamers. Sailing fortnightly from <placeName
-                                ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>.</p>
+                        <p>(HENDERSON BROTHERS,) <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName>, <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName> AND GLASGOW.</p>
+                        <p>Booking Passengers and Cargo through to Ports in <placeName ref="https://www.wikidata.org/wiki/Q668">India</placeName>, Europe &amp; America</p>
+                        <p>First class passengers steamers. Sailing fortnightly from <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>.</p>
                         <table rows="2" cols="6">
                             <row>
-                                <cell>For <placeName ref="https://www.wikidata.org/wiki/Q579613"
-                                        >Marseilles</placeName> &amp; <placeName
-                                        ref="https://www.wikidata.org/wiki/Q24826"
-                                        >Liverpool</placeName></cell>
+                                <cell>For <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName> &amp; <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName></cell>
                                 <cell>S.S. “Bohemia”</cell>
                                 <cell>July 26</cell>
                                 <cell>For CALCUTTA</cell>
@@ -517,73 +302,36 @@
                                 <cell>August 3</cell>
                             </row>
                             <row>
-                                <cell>For <placeName ref="https://www.wikidata.org/wiki/Q84"
-                                        >London</placeName></cell>
+                                <cell>For <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName></cell>
                                 <cell>S.S. “Persia"</cell>
                                 <cell>July 28</cell>
-                                <cell>For <placeName ref="https://www.wikidata.org/wiki/Q1156"
-                                        >Bombay</placeName></cell>
-                                <cell>S.S. "<placeName ref="https://www.wikidata.org/wiki/Q408"
-                                        >Australia</placeName> "</cell>
+                                <cell>For <placeName ref="https://www.wikidata.org/wiki/Q1156">Bombay</placeName></cell>
+                                <cell>S.S. "<placeName ref="https://www.wikidata.org/wiki/Q408">Australia</placeName> "</cell>
                                 <cell>July 23</cell>
                             </row>
                         </table>
-                        <p>Saloon Fares: from <placeName ref="https://www.wikidata.org/wiki/Q134509"
-                                >Port-Said</placeName> , to Gibraltar £9; <placeName
-                                ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName>
-                            £9: <placeName ref="https://www.wikidata.org/wiki/Q24826"
-                                >Liverpool</placeName> (all sea route) £15; <placeName
-                                ref="https://www.wikidata.org/wiki/Q84">London</placeName> (all sea
-                            route) £ 12 <placeName ref="https://www.wikidata.org/wiki/Q84"
-                                >London</placeName> via <placeName
-                                ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName>
-                            £15.5.0. Passengers embarking at <placeName
-                                ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName> £2
-                            more, 10 % reduction for officers of army of Occupation and Government
-                            employés. Through tickets issued to New-York (via Glasgow). Fares on
-                            application. </p>
-                        <p> Agents in <placeName ref="https://www.wikidata.org/wiki/Q85"
-                                >Cairo</placeName> , Messrs. Thos. Cook &amp; Son. <placeName
-                                ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName> ,
-                            Messrs. Cory Brothers &amp; Co., Ltd.</p>
-                        <p>For further partienlan of Freight or Passage apply to G. BEYTS &amp; Co.,
-                                <placeName ref="https://www.wikidata.org/wiki/Q134514"
-                                >Suez</placeName>. 31-12-905</p>
+                        <p>Saloon Fares: from <placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName> , to Gibraltar £9; <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName> £9: <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName> (all sea route) £15; <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> (all sea route) £ 12 <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> via <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName> £15.5.0. Passengers embarking at <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName> £2 more, 10 % reduction for officers of army of Occupation and Government employés. Through tickets issued to New-York (via Glasgow). Fares on application. </p>
+                        <p> Agents in <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> , Messrs. Thos. Cook &amp; Son. <placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName> , Messrs. Cory Brothers &amp; Co., Ltd.</p>
+                        <p>For further partienlan of Freight or Passage apply to G. BEYTS &amp; Co., <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>. 31-12-905</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-dll01">
                         <head>Deutsche Levante-Linie.</head>
-                        <p>Mail and Passenger Steamships. Regular three-weekly Service from <lb/>
-                            HAMBURG, via ANTWERP &amp; <placeName
-                                ref="https://www.wikidata.org/wiki/Q233">Malta</placeName>, to
-                                <placeName ref="https://www.wikidata.org/wiki/Q87"
-                                >Alexandria</placeName> and vice-versa, admitting<lb/> goods from
-                            all chief German Railway Stations on direct Bill of Landing to<lb/>
-                            <placeName ref="https://www.wikidata.org/wiki/Q87"
-                                >Alexandria</placeName> and all chief ports of Egypt, Syria, etc.,
-                            at favourable through<lb/> rates of DEUTSCHE <lb/> VERKEHR
-                            (traffic).</p>
-                        <p>EXPECTED AT <placeName ref="https://www.wikidata.org/wiki/Q87"
-                                >Alexandria</placeName>.</p>
+                        <p>Mail and Passenger Steamships. Regular three-weekly Service from <lb/> HAMBURG, via ANTWERP &amp; <placeName ref="https://www.wikidata.org/wiki/Q233">Malta</placeName>, to <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> and vice-versa, admitting<lb/> goods from all chief German Railway Stations on direct Bill of Landing to<lb/>
+                            <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> and all chief ports of Egypt, Syria, etc., at favourable through<lb/> rates of DEUTSCHE <lb/> VERKEHR (traffic).</p>
+                        <p>EXPECTED AT <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>.</p>
                         <p>S.S. Lesbos July 20 from Antwerp.</p>
                         <p>S.S. Androos July 20 from Hamburg bound for Beyrout.</p>
                         <p>S.S. Lemnos July 31 from Hamburg bound for Beyrout.</p>
-                        <p>For tariff and particulars apply to ADOLPHE STROSS, <placeName
-                                ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>,
-                            Agent. </p>
+                        <p>For tariff and particulars apply to ADOLPHE STROSS, <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>, Agent. </p>
                         <p>15-2-905 </p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-mma01">
                         <head>Messageries Maritimes.</head>
-                        <p>From <placeName ref="https://www.wikidata.org/wiki/Q87"
-                                >Alexandria</placeName></p>
+                        <p>From <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName></p>
                         <table rows="12" cols="6">
-                            <head><hi rend="bold">Sailing from <placeName
-                                        ref="https://www.wikidata.org/wiki/Q87"
-                                        >Alexandria</placeName> in July, 1905.</hi></head>
+                            <head><hi rend="bold">Sailing from <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> in July, 1905.</hi></head>
                             <row>
-                                <cell cols="6"><hi rend="bold">For <placeName
-                                            ref="https://www.wikidata.org/wiki/Q579613"
-                                            >Marseilles</placeName> direct</hi></cell>
+                                <cell cols="6"><hi rend="bold">For <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName> direct</hi></cell>
                             </row>
                             <row>
                                 <cell>Friday</cell>
@@ -626,9 +374,7 @@
                                 <cell>Capt. Vincenti</cell>
                             </row>
                             <row>
-                                <cell cols="6"><hi rend="bold">For <placeName
-                                            ref="https://www.wikidata.org/wiki/Q134509">Port
-                                            Said</placeName> and Beyrouth</hi></cell>
+                                <cell cols="6"><hi rend="bold">For <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> and Beyrouth</hi></cell>
                             </row>
                             <row>
                                 <cell>Thursday</cell>
@@ -647,9 +393,7 @@
                                 <cell>Capt. Aillaud</cell>
                             </row>
                             <row>
-                                <cell cols="6"><hi rend="bold">For <placeName
-                                            ref="https://www.wikidata.org/wiki/Q134509">Port
-                                            Said</placeName>, Jaffa and Beyrouth</hi></cell>
+                                <cell cols="6"><hi rend="bold">For <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>, Jaffa and Beyrouth</hi></cell>
                             </row>
                             <row>
                                 <cell>Thursday</cell>
@@ -677,97 +421,57 @@
                                 <cell>2nd Class</cell>
                             </row>
                             <row>
-                                <cell>From <placeName ref="https://www.wikidata.org/wiki/Q87"
-                                        >Alexandria</placeName> or <placeName
-                                        ref="https://www.wikidata.org/wiki/Q134509">Port
-                                        Said</placeName> (directly or via <placeName
-                                        ref="https://www.wikidata.org/wiki/Q87"
-                                        >Alexandria</placeName>) To <placeName
-                                        ref="https://www.wikidata.org/wiki/Q579613"
-                                        >Marseilles</placeName></cell>
+                                <cell>From <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> or <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> (directly or via <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>) To <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName></cell>
                                 <cell>£12.9.8 </cell>
                                 <cell>£9.10.3</cell>
                             </row>
                             <row>
-                                <cell>From <placeName ref="https://www.wikidata.org/wiki/Q87"
-                                        >Alexandria</placeName> To <placeName
-                                        ref="https://www.wikidata.org/wiki/Q134509">Port
-                                        Said</placeName></cell>
+                                <cell>From <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> To <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName></cell>
                                 <cell>£1.15.10</cell>
                                 <cell>£1.7.10</cell>
                             </row>
                             <row>
-                                <cell>From <placeName ref="https://www.wikidata.org/wiki/Q87"
-                                        >Alexandria</placeName> to Jaffa</cell>
+                                <cell>From <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> to Jaffa</cell>
                                 <cell>£3.3.5</cell>
                                 <cell>£2.2.5</cell>
                             </row>
                             <row>
-                                <cell>From <placeName ref="https://www.wikidata.org/wiki/Q87"
-                                        >Alexandria</placeName> to Beyrouth</cell>
+                                <cell>From <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> to Beyrouth</cell>
                                 <cell>£4.7.2</cell>
                                 <cell>£3.3.2.</cell>
                             </row>
                             <row>
-                                <cell>Through tickets for <placeName
-                                        ref="https://www.wikidata.org/wiki/Q90">Paris</placeName>
-                                    (via <placeName ref="https://www.wikidata.org/wiki/Q579613"
-                                        >Marseilles</placeName> from <placeName
-                                        ref="https://www.wikidata.org/wiki/Q87"
-                                        >Alexandria</placeName>) </cell>
+                                <cell>Through tickets for <placeName ref="https://www.wikidata.org/wiki/Q90">Paris</placeName> (via <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName> from <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>) </cell>
                                 <cell>£15.12.1</cell>
                                 <cell>£10.12.5</cell>
                             </row>
                             <row>
-                                <cell>Through tickets for <placeName
-                                        ref="https://www.wikidata.org/wiki/Q90">Paris</placeName>
-                                    (via <placeName ref="https://www.wikidata.org/wiki/Q579613"
-                                        >Marseilles</placeName>) from <placeName
-                                        ref="https://www.wikidata.org/wiki/Q134509">Port
-                                        Said</placeName> (directly or via <placeName
-                                        ref="https://www.wikidata.org/wiki/Q87"
-                                        >Alexandria</placeName>) </cell>
+                                <cell>Through tickets for <placeName ref="https://www.wikidata.org/wiki/Q90">Paris</placeName> (via <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName>) from <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> (directly or via <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>) </cell>
                                 <cell>£16.5.11</cell>
                                 <cell>£12.1.5</cell>
                             </row>
                             <row>
-                                <cell>Through tickets for <placeName
-                                        ref="https://www.wikidata.org/wiki/Q84">London</placeName>
-                                    (via <placeName ref="https://www.wikidata.org/wiki/Q579613"
-                                        >Marseilles</placeName>) (Calais-Douvree) from <placeName
-                                        ref="https://www.wikidata.org/wiki/Q87"
-                                        >Alexandria</placeName> or <placeName
-                                        ref="https://www.wikidata.org/wiki/Q134509">Port
-                                        Said</placeName> (directly or via <placeName
-                                        ref="https://www.wikidata.org/wiki/Q87"
-                                        >Alexandria</placeName>)</cell>
+                                <cell>Through tickets for <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> (via <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName>) (Calais-Douvree) from <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> or <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> (directly or via <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>)</cell>
                                 <cell>£16.12.10</cell>
                                 <cell>£12.9.8</cell>
                             </row>
                             <row>
-                                <cell>Interchangeable return tickets with the Austrian Lloyd Cy.
-                                    (available one way by Messageries</cell>
+                                <cell>Interchangeable return tickets with the Austrian Lloyd Cy. (available one way by Messageries</cell>
                                 <cell>£21.11.10</cell>
                                 <cell>£15.11.2</cell>
                             </row>
                         </table>
                         <table rend="frame" xml:id="SailingfromPortSaid">
-                            <head><hi rend="bold">Sailing from <placeName
-                                        ref="https://www.wikidata.org/wiki/Q134509">Port
-                                        Said</placeName> in July, 1905</hi></head>
+                            <head><hi rend="bold">Sailing from <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> in July, 1905</hi></head>
                             <row>
-                                <cell rows="5">For <placeName
-                                        ref="https://www.wikidata.org/wiki/Q579613"
-                                        >Marseilles</placeName> Direct</cell>
+                                <cell rows="5">For <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName> Direct</cell>
                                 <cell>Probably on</cell>
                                 <cell>Thursday</cell>
                                 <cell>6</cell>
                                 <cell>July</cell>
                                 <cell>Polynesien</cell>
                                 <cell>Capt. Broc</cell>
-                                <cell>returning from <placeName
-                                        ref="https://www.wikidata.org/wiki/Q1239">Indian
-                                        Ocean</placeName></cell>
+                                <cell>returning from <placeName ref="https://www.wikidata.org/wiki/Q1239">Indian Ocean</placeName></cell>
                             </row>
                             <row>
                                 <cell>Probably on</cell>
@@ -776,9 +480,7 @@
                                 <cell>July</cell>
                                 <cell>Iraouaddy</cell>
                                 <cell>Capt. Riquier</cell>
-                                <cell>returning from <placeName
-                                        ref="https://www.wikidata.org/wiki/Q148"
-                                    >China</placeName></cell>
+                                <cell>returning from <placeName ref="https://www.wikidata.org/wiki/Q148">China</placeName></cell>
                             </row>
                             <row>
                                 <cell>Probably on</cell>
@@ -787,9 +489,7 @@
                                 <cell>July</cell>
                                 <cell>Caledonian</cell>
                                 <cell>Capt. Grégory</cell>
-                                <cell>returning from <placeName
-                                        ref="https://www.wikidata.org/wiki/Q1239">Indian
-                                        Ocean</placeName></cell>
+                                <cell>returning from <placeName ref="https://www.wikidata.org/wiki/Q1239">Indian Ocean</placeName></cell>
                             </row>
                             <row>
                                 <cell>Probably on</cell>
@@ -798,9 +498,7 @@
                                 <cell>July</cell>
                                 <cell>Natal</cell>
                                 <cell>Capt. Fabre</cell>
-                                <cell>returning from <placeName
-                                        ref="https://www.wikidata.org/wiki/Q148"
-                                    >China</placeName></cell>
+                                <cell>returning from <placeName ref="https://www.wikidata.org/wiki/Q148">China</placeName></cell>
                             </row>
                             <row>
                                 <cell>Probably on</cell>
@@ -809,19 +507,14 @@
                                 <cell>July</cell>
                                 <cell>Ville de la Ciatat</cell>
                                 <cell>Capt. Etienne</cell>
-                                <cell>returning from <placeName
-                                        ref="https://www.wikidata.org/wiki/Q408"
-                                        >Australia</placeName>
+                                <cell>returning from <placeName ref="https://www.wikidata.org/wiki/Q408">Australia</placeName>
                                 </cell>
                             </row>
                         </table>
                         <table rend="frame" xml:id="SailingFromSuez">
-                            <head><hi rend="bold">Sailing from <placeName
-                                        ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>
-                                    in July, 1905</hi></head>
+                            <head><hi rend="bold">Sailing from <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName> in July, 1905</hi></head>
                             <row>
-                                <cell rows="2">For Aden, Colombo, Singapore, Saigon, Hong-Kong,
-                                    Shanghai, Kobe and Yokohama</cell>
+                                <cell rows="2">For Aden, Colombo, Singapore, Saigon, Hong-Kong, Shanghai, Kobe and Yokohama</cell>
                                 <cell>Saturday</cell>
                                 <cell>1</cell>
                                 <cell>July</cell>
@@ -836,8 +529,7 @@
                                 <cell>Capt. Bourdon</cell>
                             </row>
                             <row>
-                                <cell>For Djibouti, Colombo, Singapore, Saigon, Hong-Kong, Shanghai,
-                                    Kobe and Yokohama</cell>
+                                <cell>For Djibouti, Colombo, Singapore, Saigon, Hong-Kong, Shanghai, Kobe and Yokohama</cell>
                                 <cell>Saturday</cell>
                                 <cell>15</cell>
                                 <cell>July</cell>
@@ -845,8 +537,7 @@
                                 <cell>Capt. Guionnet</cell>
                             </row>
                             <row>
-                                <cell>For Djibouti, Zanzibar, Mutsamudu, Mayotte, Majunga, Nossi-Bé,
-                                    D. Suares, Tamatave, La Réunion and Maurice</cell>
+                                <cell>For Djibouti, Zanzibar, Mutsamudu, Mayotte, Majunga, Nossi-Bé, D. Suares, Tamatave, La Réunion and Maurice</cell>
                                 <cell>Sunday</cell>
                                 <cell>16</cell>
                                 <cell>July</cell>
@@ -854,8 +545,7 @@
                                 <cell>Capt. Jourdan</cell>
                             </row>
                             <row>
-                                <cell rows="2">For Djibouti, Aden, Mabé Diego-Suares, Ste. Marie,
-                                    Tamatave, La Réunion and Maurice</cell>
+                                <cell rows="2">For Djibouti, Aden, Mabé Diego-Suares, Ste. Marie, Tamatave, La Réunion and Maurice</cell>
                                 <cell>Saturday</cell>
                                 <cell>1</cell>
                                 <cell>July</cell>
@@ -870,9 +560,7 @@
                                 <cell>Capt. Riquier</cell>
                             </row>
                             <row>
-                                <cell>For Aden, <placeName ref="https://www.wikidata.org/wiki/Q1156"
-                                        >Bombay</placeName>, Colombo, Freemantle, Adelaide,
-                                    Melbourne, Sidney, and Noumes</cell>
+                                <cell>For Aden, <placeName ref="https://www.wikidata.org/wiki/Q1156">Bombay</placeName>, Colombo, Freemantle, Adelaide, Melbourne, Sidney, and Noumes</cell>
                                 <cell>Monday</cell>
                                 <cell>10</cell>
                                 <cell>July</cell>
@@ -880,8 +568,7 @@
                                 <cell>Capt. Boyer</cell>
                             </row>
                         </table>
-                        <p><placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>
-                            Agency (Shepheard's Hotel) 28-2-905</p>
+                        <p><placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> Agency (Shepheard's Hotel) 28-2-905</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-pri01">
                         <head>Prince Line.</head>
@@ -1016,13 +703,7 @@
                             </row>
                         </table>
                         <p>Good Accommodation for Passengers.</p>
-                        <p>Sailings every 10 days from Manchester and <placeName
-                                ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName> and
-                            fortnightly from Antwerp and <placeName
-                                ref="https://www.wikidata.org/wiki/Q84">London</placeName> to
-                                <placeName ref="https://www.wikidata.org/wiki/Q87"
-                                >Alexandria</placeName> and Syrian Coast. The dates are
-                            approximate</p>
+                        <p>Sailings every 10 days from Manchester and <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName> and fortnightly from Antwerp and <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> to <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> and Syrian Coast. The dates are approximate</p>
                         <table rows="4" cols="8">
                             <row>
                                 <cell>OCEAN PRINCE</cell>
@@ -1037,15 +718,11 @@
                             <row>
                                 <cell>PERSIAN PRINCE</cell>
                                 <cell>due from</cell>
-                                <cell>Antwerp &amp; <placeName
-                                        ref="https://www.wikidata.org/wiki/Q84"
-                                    >London</placeName></cell>
+                                <cell>Antwerp &amp; <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName></cell>
                                 <cell>July 23</cell>
                                 <cell>CARIB PRINCE</cell>
                                 <cell>due from</cell>
-                                <cell>Antwerp &amp; <placeName
-                                        ref="https://www.wikidata.org/wiki/Q84"
-                                    >London</placeName></cell>
+                                <cell>Antwerp &amp; <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName></cell>
                                 <cell>August 15</cell>
                             </row>
                             <row>
@@ -1061,23 +738,16 @@
                             <row>
                                 <cell>TROJAN PRINCE</cell>
                                 <cell>due from</cell>
-                                <cell>Antwerp &amp; <placeName
-                                        ref="https://www.wikidata.org/wiki/Q84"
-                                    >London</placeName></cell>
+                                <cell>Antwerp &amp; <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName></cell>
                                 <cell>July 31</cell>
                                 <cell>CREOLE PRINCE</cell>
                                 <cell>due from</cell>
-                                <cell>Antwerp &amp; <placeName
-                                        ref="https://www.wikidata.org/wiki/Q84"
-                                    >London</placeName></cell>
+                                <cell>Antwerp &amp; <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName></cell>
                                 <cell>August 29</cell>
                             </row>
                         </table>
-                        <p>HOMEWARD SAILINGS: -- The S.S. SPARTAN PRINCE is now loading for
-                            Manchester.</p>
-                        <p>For terms of freight or passage apply to C. J. Grace &amp; Co.,
-                                <placeName ref="https://www.wikidata.org/wiki/Q87"
-                                >Alexandria</placeName>, Agents. 31-12-904</p>
+                        <p>HOMEWARD SAILINGS: -- The S.S. SPARTAN PRINCE is now loading for Manchester.</p>
+                        <p>For terms of freight or passage apply to C. J. Grace &amp; Co., <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>, Agents. 31-12-904</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-nml01">
                         <head>THE NATIONAL MUTUAL LIFE ASSOCIATION OF AUSTRALASIA, LIMITED.</head>
@@ -1085,8 +755,7 @@
                         <p>With Profits Distributed every 3 Years. </p>
                         <p>Nearest Age 30.-Sun Assured £1,000.-Payable at age 50.</p>
                         <p>ANNUAL PREMIUM £47:18:4 TOTAL COST £958:6:8</p>
-                        <p>Minimum Return Over Cost exclusive of Bonuses £41:13:4. Several options
-                            at the end of 20 years. Guaranteed benefits during 20 years.</p>
+                        <p>Minimum Return Over Cost exclusive of Bonuses £41:13:4. Several options at the end of 20 years. Guaranteed benefits during 20 years.</p>
                         <table rend="frame">
                             <row>
                                 <cell/>
@@ -1125,8 +794,7 @@
                             </row>
                         </table>
                         <p>Full particulars on application to</p>
-                        <p>AGENTS IN <placeName ref="https://www.wikidata.org/wiki/Q85"
-                                >Cairo</placeName> :</p>
+                        <p>AGENTS IN <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> :</p>
                         <p>S. &amp; A. DE BILINSKI,</p>
                         <p>Khedivial Bourse Court.</p>
                         <p>LOW RATES. LIBERAL CONTRACTS. LARGE BONUSES.</p>
@@ -1134,65 +802,36 @@
                     <div type="item" scope="advertisement" xml:id="deg-ad-bal01">
                         <head>BANK OF ATHENS, LIMITED.</head>
                         <p><hi rend="bold">Capital 20,000,000 (Fully paid up).</hi></p>
-                        <p>BRANCHES: <placeName ref="https://www.wikidata.org/wiki/Q84"
-                                >London</placeName> 55-56 Bishops gate-street Within-<placeName
-                                ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>,
-                                <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>
-                            , Constantinople, Smyrna, At Candia and throughout <placeName
-                                ref="https://www.wikidata.org/wiki/Q41">Greece</placeName>.</p>
-                        <p>The Bank undertakes all banking business in Egypt, <placeName
-                                ref="https://www.wikidata.org/wiki/Q41">Greece</placeName>,<lb/>
-                            etc. Interest, on cash deposits: 3 0/0 per ann. at sight; 3 1/2 0/0
-                            <lb/> per ann. for 6 months ; 4 0/0 per ann. for 12 months ; 5 0/0
-                            per<lb/> ann. for 3 years and over. Savings Bank Branch receives
-                            de-<lb/>posits at 3 1/2 0/0 per ann., from P.T. 30 to P.T. 10,000.
-                            23538-19-1.905</p>
+                        <p>BRANCHES: <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> 55-56 Bishops gate-street Within-<placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>, <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> , Constantinople, Smyrna, At Candia and throughout <placeName ref="https://www.wikidata.org/wiki/Q41">Greece</placeName>.</p>
+                        <p>The Bank undertakes all banking business in Egypt, <placeName ref="https://www.wikidata.org/wiki/Q41">Greece</placeName>,<lb/> etc. Interest, on cash deposits: 3 0/0 per ann. at sight; 3 1/2 0/0 <lb/> per ann. for 6 months ; 4 0/0 per ann. for 12 months ; 5 0/0 per<lb/> ann. for 3 years and over. Savings Bank Branch receives de-<lb/>posits at 3 1/2 0/0 per ann., from P.T. 30 to P.T. 10,000. 23538-19-1.905</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-bam01">
                         <head>Bell's Asia Minor Steamship Co. </head>
-                        <p>Despatch weekly a steamer with good passenger accommodation carrying
-                            Mails from <placeName ref="https://www.wikidata.org/wiki/Q87"
-                                >Alexandria</placeName> to Cyrpus and the Syrian Coast and
-                            vice-versa.</p>
-                        <p>For particulars of freight, passage, etc., apply to the Agent Ed. A.
-                            Minotte. 1099-25.2.905</p>
+                        <p>Despatch weekly a steamer with good passenger accommodation carrying Mails from <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> to Cyrpus and the Syrian Coast and vice-versa.</p>
+                        <p>For particulars of freight, passage, etc., apply to the Agent Ed. A. Minotte. 1099-25.2.905</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-iob01">
                         <head>IMPERIAL OTTOMAN BANK.</head>
                         <p>CAPITAL: £10,000,000.</p>
-                        <p>HEAD OFFIOE IN CONSTANTINOPLE. CHIEF AGENCIES: <placeName
-                                ref="https://www.wikidata.org/wiki/Q84">London</placeName> &amp;
-                                <placeName ref="https://www.wikidata.org/wiki/Q90"
-                            >Paris</placeName>.</p>
-                        <p>BRANCHES IN ALL THE PRINCIPAL TOWNS IN <placeName
-                                ref="https://www.wikidata.org/wiki/Q43">Turkey</placeName>.</p>
-                        <p>Agencies in <placeName ref="https://www.wikidata.org/wiki/Q79"
-                                >Egypt</placeName> : <placeName
-                                ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>,
-                                <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>
-                            , &amp; <placeName ref="https://www.wikidata.org/wiki/Q134509">Port
-                                Said</placeName>.</p>
-                        <p>Advances on Merchandise and Securities in current account and for fixed
-                            periods. Purchase and sale of stocks and Shares on the <placeName
-                                ref="https://www.wikidata.org/wiki/Q84">London</placeName> and
-                            Continental exchanges, letters of credit issued, valuables reoeived in
-                            safe custody. Drafts, cheques and telegraphic transfers issued on the
-                            principal towns of the world. Foreign exchange purchased, bills
-                            discounted, bills, invoices, annuities and dividends collected and every
-                            description of banking business transacted. 18-4-906</p>
+                        <p>HEAD OFFIOE IN CONSTANTINOPLE. CHIEF AGENCIES: <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> &amp; <placeName ref="https://www.wikidata.org/wiki/Q90">Paris</placeName>.</p>
+                        <p>BRANCHES IN ALL THE PRINCIPAL TOWNS IN <placeName ref="https://www.wikidata.org/wiki/Q43">Turkey</placeName>.</p>
+                        <p>Agencies in <placeName ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName> : <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>, <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> , &amp; <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>.</p>
+                        <p>Advances on Merchandise and Securities in current account and for fixed periods. Purchase and sale of stocks and Shares on the <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> and Continental exchanges, letters of credit issued, valuables reoeived in safe custody. Drafts, cheques and telegraphic transfers issued on the principal towns of the world. Foreign exchange purchased, bills discounted, bills, invoices, annuities and dividends collected and every description of banking business transacted. 18-4-906</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-sgr01">
                         <head>SUDAN GOVERNMENT RAILWAYS.</head>
-                        <p><placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>
-                            -KHARTOUM SUMMER MAIL SERVICE.</p>
+                        <p><placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> -KHARTOUM SUMMER MAIL SERVICE.</p>
+
+
+
+
 
                         <table rows="3" cols="7">
                             <row>
                                 <cell>Wednesday and *Saturday</cell>
                                 <cell>8 p.m.</cell>
                                 <cell>depart</cell>
-                                <cell><placeName ref="https://www.wikidata.org/wiki/Q85"
-                                        >Cairo</placeName>
+                                <cell><placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>
                                 </cell>
                                 <cell>arrive</cell>
                                 <cell>*Monday and *Friday</cell>
@@ -1226,64 +865,30 @@
                                 <cell>12 noon</cell>
                             </row>
                         </table>
-                        <p>Mail delivered Khartoum, Sun. and Wednesday evening, and <placeName
-                                ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> , Mon. and
-                            Friday evening. *Dining and Sleeping Cars.</p>
+                        <p>Mail delivered Khartoum, Sun. and Wednesday evening, and <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> , Mon. and Friday evening. *Dining and Sleeping Cars.</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-sde01">
                         <head>SUDAN DEVELOPMENT &amp; EXPLORATION COMPANY, LIMITED</head>
-                        <p>KHARTOUM: <placeName ref="https://www.wikidata.org/wiki/Q85"
-                                >Cairo</placeName> Office, Sharia Kasr-el-Nil.</p>
-                        <p>TRANSPORT DEPARTMENT. Six days White Nile Tourist Trip dep. Khartoum
-                            Tuesdays. Steamer plans may be seen and passages booked at all
-                                <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>
-                            Tourist Agents. - Special Steamers for private charter. - Trips arranged
-                            and transport of goods undertaken to all places on White and Blue Niles
-                            within navigation limits.</p>
-                        <p>ENGINEERING DEPARTMENT. Shipyard for construction of sternwheel steamers,
-                            barges, stream, motor launches, etc. Contractors for supply and erection
-                            of all classes of machinery, buildings, irrigation pumps, etc.</p>
-                        <p>SOLE AGENTS FOR Dudbridges Oil Engines from 1 to 25 B.H.P. as supplied to
-                            Sudan Government. Seamless xxxxxxxxxxxxxxxxxxxxx</p>
+                        <p>KHARTOUM: <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> Office, Sharia Kasr-el-Nil.</p>
+                        <p>TRANSPORT DEPARTMENT. Six days White Nile Tourist Trip dep. Khartoum Tuesdays. Steamer plans may be seen and passages booked at all <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> Tourist Agents. - Special Steamers for private charter. - Trips arranged and transport of goods undertaken to all places on White and Blue Niles within navigation limits.</p>
+                        <p>ENGINEERING DEPARTMENT. Shipyard for construction of sternwheel steamers, barges, stream, motor launches, etc. Contractors for supply and erection of all classes of machinery, buildings, irrigation pumps, etc.</p>
+                        <p>SOLE AGENTS FOR Dudbridges Oil Engines from 1 to 25 B.H.P. as supplied to Sudan Government. Seamless xxxxxxxxxxxxxxxxxxxxx</p>
                     </div>
                     <cb n="3"/>
                     <div type="item" scope="advertisement" xml:id="deg-ad-aan01">
                         <head>Anglo-American Nile Steamer &amp; Hotel Coy.</head>
-                        <p>Weekly departure during Winter Season by the<lb/> Luxurious First Class
-                            Tourist Steamers VICTORIA, PURITAN &amp; MAYFLOWER.<lb/> Regular weekly
-                            Departures to the SECOND CATARACT by the S.S. IndianA.<lb/> THROUGH
-                            BOOKINGS TO KHARTOUM, GONDOKORO AND THE WHITE NILE.<lb/> Steamers and
-                            Dahabeahs for private charter. Steam Tugs and Steam Launches for
-                            hire.<lb/> FREIGHT SERVICE BY STEAM BARGES BETWEEN <placeName
-                                ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> AND
-                                <placeName ref="https://www.wikidata.org/wiki/Q87"
-                                >Alexandria</placeName>.<lb/> Working in conjunction and under
-                            special arrangement with the<lb/> “Upper <placeName
-                                ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName> Hotels
-                            Company."</p>
-                        <p>For details and illustrated programmes apply to "THE ANGLO-AMERICAN NILE
-                            STEAMER and<lb/> HOTEL COMPANY."</p>
-                        <p> OFFICES IN <placeName ref="https://www.wikidata.org/wiki/Q85"
-                                >Cairo</placeName> : Sharia Boulac, "Grand Continental Hotel
-                            Buildings.” 31-3-06</p>
+                        <p>Weekly departure during Winter Season by the<lb/> Luxurious First Class Tourist Steamers VICTORIA, PURITAN &amp; MAYFLOWER.<lb/> Regular weekly Departures to the SECOND CATARACT by the S.S. IndianA.<lb/> THROUGH BOOKINGS TO KHARTOUM, GONDOKORO AND THE WHITE NILE.<lb/> Steamers and Dahabeahs for private charter. Steam Tugs and Steam Launches for hire.<lb/> FREIGHT SERVICE BY STEAM BARGES BETWEEN <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> AND <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>.<lb/> Working in conjunction and under special arrangement with the<lb/> “Upper <placeName ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName> Hotels Company."</p>
+                        <p>For details and illustrated programmes apply to "THE ANGLO-AMERICAN NILE STEAMER and<lb/> HOTEL COMPANY."</p>
+                        <p> OFFICES IN <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> : Sharia Boulac, "Grand Continental Hotel Buildings.” 31-3-06</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-nll02">
                         <head>NORDDEUTSCHER LLOYD.</head>
-                        <p>Regular Service from <placeName ref="https://www.wikidata.org/wiki/Q87"
-                                >Alexandria</placeName> (Passenger and Freight) to <placeName
-                                ref="https://www.wikidata.org/wiki/Q2634">Naples</placeName>
-                                -<placeName ref="https://www.wikidata.org/wiki/Q579613"
-                                >Marseilles</placeName>.</p>
-                        <p> SCHLESWIG will leave <placeName ref="https://www.wikidata.org/wiki/Q87"
-                                >Alexandria</placeName> at 4 p.m. July 26, August 30, September 20,
-                            etc. </p>
-                        <p>The following steamers are intended to leave <placeName
-                                ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName> : </p>
+                        <p>Regular Service from <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> (Passenger and Freight) to <placeName ref="https://www.wikidata.org/wiki/Q2634">Naples</placeName> -<placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName>.</p>
+                        <p> SCHLESWIG will leave <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> at 4 p.m. July 26, August 30, September 20, etc. </p>
+                        <p>The following steamers are intended to leave <placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName> : </p>
                         <table rows="14" cols="3">
                             <row>
-                                <cell cols="3">HOMEWARD : for Bremen Hamburg via <placeName
-                                        ref="https://www.wikidata.org/wiki/Q2634">Naples</placeName>
-                                    , Genoa, (Gibraltar), Southampton, Antwerp.</cell>
+                                <cell cols="3">HOMEWARD : for Bremen Hamburg via <placeName ref="https://www.wikidata.org/wiki/Q2634">Naples</placeName> , Genoa, (Gibraltar), Southampton, Antwerp.</cell>
                             </row>
                             <row>
                                 <cell>Zieten</cell>
@@ -1311,11 +916,7 @@
                                 <cell>about 28 August</cell>
                             </row>
                             <row>
-                                <cell cols="3">OUTWARD: for <placeName
-                                        ref="https://www.wikidata.org/wiki/Q148">China</placeName>
-                                    and JAPAN via <placeName
-                                        ref="https://www.wikidata.org/wiki/Q134514"
-                                    >Suez</placeName>, ADEN, COLOMBO, PENANG, SINGAPORE.</cell>
+                                <cell cols="3">OUTWARD: for <placeName ref="https://www.wikidata.org/wiki/Q148">China</placeName> and JAPAN via <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>, ADEN, COLOMBO, PENANG, SINGAPORE.</cell>
                             </row>
                             <row>
                                 <cell>Prinz E. Friedrich</cell>
@@ -1333,11 +934,7 @@
                                 <cell>about 7 August</cell>
                             </row>
                             <row>
-                                <cell cols="3">For <placeName
-                                        ref="https://www.wikidata.org/wiki/Q408"
-                                        >Australia</placeName> via <placeName
-                                        ref="https://www.wikidata.org/wiki/Q134514"
-                                    >Suez</placeName>, ADEN, COLOMBO.</cell>
+                                <cell cols="3">For <placeName ref="https://www.wikidata.org/wiki/Q408">Australia</placeName> via <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>, ADEN, COLOMBO.</cell>
                             </row>
                             <row>
                                 <cell>Seydlitz</cell>
@@ -1356,38 +953,15 @@
                             </row>
                         </table>
                         <p>FOR FURTHER PARTICULARS APPLY TO THE AGENTS OF THE </p>
-                        <p>NORDDEUTSCHER LLOYD at <placeName ref="https://www.wikidata.org/wiki/Q85"
-                                >Cairo</placeName> , <placeName
-                                ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>,
-                                <placeName ref="https://www.wikidata.org/wiki/Q134509"
-                                >Port-Said</placeName> and <placeName
-                                ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>. </p>
-                        <p>OTTO STERZING, Agent In <placeName
-                                ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> , Opera
-                            Square. </p>
-                        <p>C. H. SCHOELLER, Agent In <placeName
-                                ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>,
-                            Cleopatra Lane.</p>
-                        <p>Messrs. THOS. COOK &amp; SON (Egypt) LTD., and CARL STANGENS REISEBUREAN
-                            are anthorised to sell tickets in <placeName
-                                ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> and
-                                <placeName ref="https://www.wikidata.org/wiki/Q87"
-                                >Alexandria</placeName>, 31-8-905</p>
+                        <p>NORDDEUTSCHER LLOYD at <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> , <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>, <placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName> and <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>. </p>
+                        <p>OTTO STERZING, Agent In <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> , Opera Square. </p>
+                        <p>C. H. SCHOELLER, Agent In <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>, Cleopatra Lane.</p>
+                        <p>Messrs. THOS. COOK &amp; SON (Egypt) LTD., and CARL STANGENS REISEBUREAN are anthorised to sell tickets in <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> and <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>, 31-8-905</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-als01">
                         <head>Austrian Lloyd’s Steam Navigation</head>
-                        <p><placeName ref="https://www.wikidata.org/wiki/Q87"
-                            >Alexandria</placeName>-Brindisi-Venice-Trieste.</p>
-                        <p>Weekly Express Mail Service. Steamers leave <placeName
-                                ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> every
-                            Saturday at 4 p.m. arrive at Brindisi, Tuesday a.m. in time for express
-                            to <placeName ref="https://www.wikidata.org/wiki/Q90">Paris</placeName>,
-                                <placeName ref="https://www.wikidata.org/wiki/Q84"
-                                >London</placeName>, <placeName
-                                ref="https://www.wikidata.org/wiki/Q2634">Naples</placeName> , Rome.
-                            Arrival Trieste Wednesday noon connecting with Vienna Express
-                            (Trieste-Ostende through carriage) and expresses to Italy and
-                            Germany.</p>
+                        <p><placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>-Brindisi-Venice-Trieste.</p>
+                        <p>Weekly Express Mail Service. Steamers leave <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> every Saturday at 4 p.m. arrive at Brindisi, Tuesday a.m. in time for express to <placeName ref="https://www.wikidata.org/wiki/Q90">Paris</placeName>, <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName>, <placeName ref="https://www.wikidata.org/wiki/Q2634">Naples</placeName> , Rome. Arrival Trieste Wednesday noon connecting with Vienna Express (Trieste-Ostende through carriage) and expresses to Italy and Germany.</p>
                         <table rows="3" cols="8">
                             <row>
                                 <cell>July 8</cell>
@@ -1420,8 +994,7 @@
                                 <cell/>
                             </row>
                         </table>
-                        <p>Fortnightly Service: <placeName ref="https://www.wikidata.org/wiki/Q87"
-                                >Alexandria</placeName>-Brindisi-Venice-Trieste </p>
+                        <p>Fortnightly Service: <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>-Brindisi-Venice-Trieste </p>
                         <table rows="1" cols="8">
                             <row>
                                 <cell>June 21</cell>
@@ -1434,47 +1007,21 @@
                                 <cell>Capt. Knezevich</cell>
                             </row>
                         </table>
-                        <p>(Departures from <placeName ref="https://www.wikidata.org/wiki/Q134514"
-                                >Suez</placeName>) To Aden, <placeName
-                                ref="https://www.wikidata.org/wiki/Q1156">Bombay</placeName>,
-                            Colombo, Penang, Singapore, Hong-Kong, Shanghai, Yokohama, Kobé about
-                            July 5 and August 4. To Aden, Karachi, and <placeName
-                                ref="https://www.wikidata.org/wiki/Q1156">Bombay</placeName>
-                            accelerated service about August 18. To Aden, Karachi, <placeName
-                                ref="https://www.wikidata.org/wiki/Q1156">Bombay</placeName>,
-                            Colombo, Madras, Rangoon, and Calcutta about July 20.</p>
+                        <p>(Departures from <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>) To Aden, <placeName ref="https://www.wikidata.org/wiki/Q1156">Bombay</placeName>, Colombo, Penang, Singapore, Hong-Kong, Shanghai, Yokohama, Kobé about July 5 and August 4. To Aden, Karachi, and <placeName ref="https://www.wikidata.org/wiki/Q1156">Bombay</placeName> accelerated service about August 18. To Aden, Karachi, <placeName ref="https://www.wikidata.org/wiki/Q1156">Bombay</placeName>, Colombo, Madras, Rangoon, and Calcutta about July 20.</p>
                         <p>East African Line.</p>
-                        <p>To Aden, Mombassa, Zanzibar, Beira, Delagoa Bay, Durban, about July 4 and
-                            August 3.</p>
+                        <p>To Aden, Mombassa, Zanzibar, Beira, Delagoa Bay, Durban, about July 4 and August 3.</p>
                         <p>Syrian-Cyprus-Caramanian Line.</p>
-                        <p>Steamers leaves <placeName ref="https://www.wikidata.org/wiki/Q87"
-                                >Alexandria</placeName> on or about July 3, 17 and 31.</p>
-                        <p>For information apply to the Agents, <placeName
-                                ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>,
-                                <placeName ref="https://www.wikidata.org/wiki/Q134509">Port
-                                Said</placeName> and <placeName
-                                ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>, Thos.
-                            Cook &amp; Son, Ld., Leon Heller, <placeName
-                                ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> Agent, 4,
-                            Sharia Maghraby, (Telephone 192), <placeName
-                                ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> ; F.
-                            Tedeschi, Helouan.</p>
-                        <p>Special passage rates granted to Egyptian Government officials, members
-                            of the Army of Occupation and their families. </p>
+                        <p>Steamers leaves <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> on or about July 3, 17 and 31.</p>
+                        <p>For information apply to the Agents, <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>, <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> and <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>, Thos. Cook &amp; Son, Ld., Leon Heller, <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> Agent, 4, Sharia Maghraby, (Telephone 192), <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> ; F. Tedeschi, Helouan.</p>
+                        <p>Special passage rates granted to Egyptian Government officials, members of the Army of Occupation and their families. </p>
                         <p>31-12-905</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-cun01">
                         <head>Cunard Line.</head>
                         <table rows="4" cols="6">
-                            <head><placeName ref="https://www.wikidata.org/wiki/Q87"
-                                    >Alexandria</placeName> to New-York and Boston via the Continent
-                                and <placeName ref="https://www.wikidata.org/wiki/Q24826"
-                                    >Liverpool</placeName></head>
+                            <head><placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> to New-York and Boston via the Continent and <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName></head>
                             <row>
-                                <cell cols="6">Sailings from <placeName
-                                        ref="https://www.wikidata.org/wiki/Q24826"
-                                        >Liverpool</placeName> on Saturdays and Tuesdays. Royal Mail
-                                    Steamers:</cell>
+                                <cell cols="6">Sailings from <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName> on Saturdays and Tuesdays. Royal Mail Steamers:</cell>
                             </row>
                             <row>
                                 <cell>Caronia</cell>
@@ -1502,12 +1049,9 @@
                             </row>
                         </table>
                         <table rows="3" cols="4">
-                            <head><placeName ref="https://www.wikidata.org/wiki/Q87"
-                                    >Alexandria</placeName> to New-York via Trieste, Fiume or
-                                Palermo</head>
+                            <head><placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> to New-York via Trieste, Fiume or Palermo</head>
                             <row>
-                                <cell cols="4">Regular twin-screw Passenger Service from the
-                                    Adriatic. Excellent accommodation.</cell>
+                                <cell cols="4">Regular twin-screw Passenger Service from the Adriatic. Excellent accommodation.</cell>
                             </row>
                             <row>
                                 <cell>Carpathia</cell>
@@ -1522,73 +1066,36 @@
                                 <cell>10,402 tons</cell>
                             </row>
                         </table>
-                        <p>All steamers fitted with Marconi's wireless telegraphy. For through
-                            tickets from Egypt, and particulars aply to the Agents Rodacanachi &amp;
-                            Co., <placeName ref="https://www.wikidata.org/wiki/Q87"
-                                >Alexandria</placeName>; Nic. Kerzis, <placeName
-                                ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> ; R.
-                            Broadbent, <placeName ref="https://www.wikidata.org/wiki/Q134509">Port
-                                Said</placeName>. 19-1-905</p>
+                        <p>All steamers fitted with Marconi's wireless telegraphy. For through tickets from Egypt, and particulars aply to the Agents Rodacanachi &amp; Co., <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>; Nic. Kerzis, <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> ; R. Broadbent, <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>. 19-1-905</p>
                     </div>
                     <!-- TODO Russian Steam Navigation -->
                     <div type="item" scope="advertisement" xml:id="deg-ad-pap01">
                         <head>THE PAPAYANNI LINE.</head>
                         <head type="sub">(The Ellerman Lines, Ltd.)</head>
-                        <p>Frequent Sailings from <placeName ref="https://www.wikidata.org/wiki/Q87"
-                                >Alexandria</placeName> to <placeName
-                                ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName>,
-                            also Regular Services from <placeName
-                                ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName> to
-                                <placeName ref="https://www.wikidata.org/wiki/Q87"
-                                >Alexandria</placeName> and to ALGERIA, <placeName
-                                ref="https://www.wikidata.org/wiki/Q233">Malta</placeName>, LEVANT,
-                            BLACK SEA, and other Mediterranean Ports.</p>
-                        <p>Excellent Passenger Accommodation. Stewardess carried. Liberal table and
-                            Moderate Fares for single and retnrn tickets. </p>
-                        <p>The S S. SARDINIA will sail for <placeName
-                                ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName>
-                            (via Bona) on Friday, the 7th inst. at 4 p.m.</p>
-                        <p>CARGO taken by special agreement only. Through Freights quoted for the
-                            UNITED STATES and INLAND TOWNS in GREAT BRITAIN.</p>
-                        <p>For passage or freight apply to the Agents, BARKER &amp; Co., <placeName
-                                ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>.
-                            2061-17-10-905 </p>
+                        <p>Frequent Sailings from <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> to <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName>, also Regular Services from <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName> to <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> and to ALGERIA, <placeName ref="https://www.wikidata.org/wiki/Q233">Malta</placeName>, LEVANT, BLACK SEA, and other Mediterranean Ports.</p>
+                        <p>Excellent Passenger Accommodation. Stewardess carried. Liberal table and Moderate Fares for single and retnrn tickets. </p>
+                        <p>The S S. SARDINIA will sail for <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName> (via Bona) on Friday, the 7th inst. at 4 p.m.</p>
+                        <p>CARGO taken by special agreement only. Through Freights quoted for the UNITED STATES and INLAND TOWNS in GREAT BRITAIN.</p>
+                        <p>For passage or freight apply to the Agents, BARKER &amp; Co., <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>. 2061-17-10-905 </p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-ell01">
                         <head>Ellerman Lines, Limited.</head>
                         <table rows="3" cols="6">
                             <row>
-                                <cell cols="3">CITY LINE to <placeName
-                                        ref="https://www.wikidata.org/wiki/Q233">Malta</placeName>,
-                                        <placeName ref="https://www.wikidata.org/wiki/Q84"
-                                        >London</placeName>, COLOMBO &amp; CALCUTTA.</cell>
+                                <cell cols="3">CITY LINE to <placeName ref="https://www.wikidata.org/wiki/Q233">Malta</placeName>, <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName>, COLOMBO &amp; CALCUTTA.</cell>
                                 <cell cols="3">
-                                    <p>CITY &amp; HALL LINES. Joint Service to <placeName
-                                            ref="https://www.wikidata.org/wiki/Q579613"
-                                            >Marseilles</placeName>, <placeName
-                                            ref="https://www.wikidata.org/wiki/Q24826"
-                                            >Liverpool</placeName>, <placeName
-                                            ref="https://www.wikidata.org/wiki/Q1156"
-                                            >Bombay</placeName> &amp; KARACHI.</p>
+                                    <p>CITY &amp; HALL LINES. Joint Service to <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName>, <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName>, <placeName ref="https://www.wikidata.org/wiki/Q1156">Bombay</placeName> &amp; KARACHI.</p>
                                 </cell>
                             </row>
                             <row>
-                                <cell cols="6">The undermentioned First Class Passenger Steamers
-                                    will be dispatched from <placeName
-                                        ref="https://www.wikidata.org/wiki/Q134509">Port
-                                        Said</placeName> on or about the following dates for </cell>
+                                <cell cols="6">The undermentioned First Class Passenger Steamers will be dispatched from <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> on or about the following dates for </cell>
                             </row>
                             <row>
-                                <cell><placeName ref="https://www.wikidata.org/wiki/Q233"
-                                        >Malta</placeName> and <placeName
-                                        ref="https://www.wikidata.org/wiki/Q84">London</placeName>
+                                <cell><placeName ref="https://www.wikidata.org/wiki/Q233">Malta</placeName> and <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName>
                                 </cell>
                                 <cell>S.S. City of Corinth </cell>
                                 <cell>July 26</cell>
-                                <cell><placeName ref="https://www.wikidata.org/wiki/Q579613"
-                                        >Marseilles</placeName> and <placeName
-                                        ref="https://www.wikidata.org/wiki/Q24826"
-                                        >Liverpool</placeName></cell>
+                                <cell><placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName> and <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName></cell>
                                 <cell/>
                                 <cell/>
                             </row>
@@ -1596,102 +1103,60 @@
                                 <cell>Colombo and Calcutta</cell>
                                 <cell>S.S. City of Manchester</cell>
                                 <cell>July 12</cell>
-                                <cell><placeName ref="https://www.wikidata.org/wiki/Q1156"
-                                        >Bombay</placeName></cell>
+                                <cell><placeName ref="https://www.wikidata.org/wiki/Q1156">Bombay</placeName></cell>
                                 <cell>S.S. Anton Hall</cell>
                                 <cell>July 13</cell>
                             </row>
                         </table>
-                        <p>SALOON FARES:—<placeName ref="https://www.wikidata.org/wiki/Q134509">Port
-                                Said</placeName> to <placeName
-                                ref="https://www.wikidata.org/wiki/Q233">Malta</placeName> £4.10.0.
-                                <placeName ref="https://www.wikidata.org/wiki/Q579613"
-                                >Marseilles</placeName>. £8.0.0. <placeName
-                                ref="https://www.wikidata.org/wiki/Q84">London</placeName> or
-                                <placeName ref="https://www.wikidata.org/wiki/Q24826"
-                                >Liverpool</placeName>, £l2.l0.0. Colombo, Calcutta, <placeName
-                                ref="https://www.wikidata.org/wiki/Q1156">Bombay</placeName> or
-                            Karachi, £35.0.0. Special rates for steamers not carrying Doctor or
-                            Stewardess. For further particulars apply to </p>
-                        <p>CORY BROS. &amp; Co., Ltd., Agents for CITY Line, <placeName
-                                ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>:
-                            W. STAPLEDON &amp; SON, Agents for Hall Line, <placeName
-                                ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> ;
-                            or COOK &amp; SON (Egypt), Ltd., <placeName
-                                ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> .
-                            23788-28-8-905 </p>
+                        <p>SALOON FARES:—<placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> to <placeName ref="https://www.wikidata.org/wiki/Q233">Malta</placeName> £4.10.0. <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName>. £8.0.0. <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> or <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName>, £l2.l0.0. Colombo, Calcutta, <placeName ref="https://www.wikidata.org/wiki/Q1156">Bombay</placeName> or Karachi, £35.0.0. Special rates for steamers not carrying Doctor or Stewardess. For further particulars apply to </p>
+                        <p>CORY BROS. &amp; Co., Ltd., Agents for CITY Line, <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>: W. STAPLEDON &amp; SON, Agents for Hall Line, <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> ; or COOK &amp; SON (Egypt), Ltd., <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> . 23788-28-8-905 </p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-ell02">
                         <head>The Ellerman Lines, Limited.</head>
                         <head type="sub">(Including Westcott &amp; Laurance Line.)</head>
-                        <p>Regular sailings from <placeName
-                                ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName>,
-                            Glasgow, Antwerp and <placeName ref="https://www.wikidata.org/wiki/Q84"
-                                >London</placeName> to <placeName
-                                ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>.
-                            Frequent sailings from <placeName
-                                ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> to
-                                <placeName ref="https://www.wikidata.org/wiki/Q24826"
-                                >Liverpool</placeName> and <placeName
-                                ref="https://www.wikidata.org/wiki/Q84">London</placeName>. Through
-                            freight rates to Inland towns in Great Britain also to the U.S.A</p>
+                        <p>Regular sailings from <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName>, Glasgow, Antwerp and <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> to <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>. Frequent sailings from <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> to <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName> and <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName>. Through freight rates to Inland towns in Great Britain also to the U.S.A</p>
                         <table rows="4" cols="5">
                             <row>
                                 <cell>Westcott S.S. Joshua Nicholson</cell>
                                 <cell>expected from</cell>
-                                <cell>Antwerp, <placeName ref="https://www.wikidata.org/wiki/Q84"
-                                        >London</placeName> &amp; <placeName
-                                        ref="https://www.wikidata.org/wiki/Q233"
-                                    >Malta</placeName></cell>
+                                <cell>Antwerp, <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> &amp; <placeName ref="https://www.wikidata.org/wiki/Q233">Malta</placeName></cell>
                                 <cell>is due on or about</cell>
                                 <cell>July 16</cell>
                             </row>
                             <row>
                                 <cell>Ellerman S.S. City of Dundee</cell>
                                 <cell>expected from</cell>
-                                <cell>Glasgow, Gibraltar &amp; <placeName
-                                        ref="https://www.wikidata.org/wiki/Q233"
-                                    >Malta</placeName></cell>
+                                <cell>Glasgow, Gibraltar &amp; <placeName ref="https://www.wikidata.org/wiki/Q233">Malta</placeName></cell>
                                 <cell>is due on or about</cell>
                                 <cell>July 25</cell>
                             </row>
                             <row>
                                 <cell>Westcott S.S. Plymothian</cell>
                                 <cell>expected from</cell>
-                                <cell>Antwerp, <placeName ref="https://www.wikidata.org/wiki/Q84"
-                                        >London</placeName> &amp; <placeName
-                                        ref="https://www.wikidata.org/wiki/Q233"
-                                    >Malta</placeName></cell>
+                                <cell>Antwerp, <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> &amp; <placeName ref="https://www.wikidata.org/wiki/Q233">Malta</placeName></cell>
                                 <cell>is due on or about</cell>
                                 <cell>July 25</cell>
                             </row>
                             <row>
                                 <cell>Ellerman S.S. City of Oxford</cell>
                                 <cell>expected from</cell>
-                                <cell><placeName ref="https://www.wikidata.org/wiki/Q24826"
-                                        >Liverpool</placeName> &amp; Melta</cell>
+                                <cell><placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName> &amp; Melta</cell>
                                 <cell>is due on or about</cell>
                                 <cell>July 30</cell>
                             </row>
                         </table>
-                        <p>Ellerman S.S. Britannia now on the berth for <placeName
-                                ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName> is
-                            expected to sail about the 25th inst.</p>
-                        <p>N. E. TAMVACO <placeName ref="https://www.wikidata.org/wiki/Q87"
-                                >Alexandria</placeName> agents 23186-20-3-3</p>
+                        <p>Ellerman S.S. Britannia now on the berth for <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName> is expected to sail about the 25th inst.</p>
+                        <p>N. E. TAMVACO <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> agents 23186-20-3-3</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-ngi01">
                         <head>Navigation Générale Italienne.</head>
-                        <p>Societes Reunies Florio-Rubattino. - Services Postaux. - Departs de
-                            Juillet.</p>
+                        <p>Societes Reunies Florio-Rubattino. - Services Postaux. - Departs de Juillet.</p>
                         <table rows="5" cols="4">
                             <row>
                                 <cell>Les Jeudis</cell>
                                 <cell>6, 13, 20, et 27</cell>
                                 <cell>à 3 h. p.m.</cell>
-                                <cell>direct pour Messine, <placeName
-                                        ref="https://www.wikidata.org/wiki/Q2634">Naples</placeName>
-                                    , Livourne et Gênes.</cell>
+                                <cell>direct pour Messine, <placeName ref="https://www.wikidata.org/wiki/Q2634">Naples</placeName> , Livourne et Gênes.</cell>
                             </row>
                             <row>
                                 <cell>Les Samedis</cell>
@@ -1709,9 +1174,7 @@
                                 <cell>Le Lundi</cell>
                                 <cell>24</cell>
                                 <cell>à 4 h. p.m.</cell>
-                                <cell>pour Port-Saïd, <placeName
-                                        ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>
-                                    et Massawah.</cell>
+                                <cell>pour Port-Saïd, <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName> et Massawah.</cell>
                             </row>
                             <row>
                                 <cell>Le Vendredi</cell>
@@ -1723,18 +1186,13 @@
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-sio01">
                         <head>Sun Insurance Office,</head>
-                        <p><placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName>.
-                            Founded 1710.-Total sum insured in 1902 £487,600,000.</p>
-                        <p>Agents : LEON HELLER, <placeName ref="https://www.wikidata.org/wiki/Q85"
-                                >Cairo</placeName> , and BEHREND &amp; Co., <placeName
-                                ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>.
-                            16-1-906</p>
+                        <p><placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName>. Founded 1710.-Total sum insured in 1902 £487,600,000.</p>
+                        <p>Agents : LEON HELLER, <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> , and BEHREND &amp; Co., <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>. 16-1-906</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-rea01">
                         <head>ROYAL EXCHANGE ASSURANCE.</head>
                         <p>Incorporated A. D. 1720.</p>
-                        <p>Chief Office: ROYAL EXCHANGE, <placeName
-                                ref="https://www.wikidata.org/wiki/Q84">London</placeName>, E.C.</p>
+                        <p>Chief Office: ROYAL EXCHANGE, <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName>, E.C.</p>
                         <p>FUNDS IN HAND EXCEED £4,500,000 CLAIMS PAID £40,000,000</p>
                         <table rows="2" cols="2">
                             <row role="label">
@@ -1742,16 +1200,12 @@
                                 <cell>MARINE</cell>
                             </row>
                             <row>
-                                <cell><placeName ref="https://www.wikidata.org/wiki/Q87"
-                                        >Alexandria</placeName> … ANGLO-EGYPTIAN BANK.</cell>
-                                <cell><placeName ref="https://www.wikidata.org/wiki/Q87"
-                                        >Alexandria</placeName> … Mr. J. B. CAFFARI</cell>
+                                <cell><placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> … ANGLO-EGYPTIAN BANK.</cell>
+                                <cell><placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> … Mr. J. B. CAFFARI</cell>
                             </row>
                             <row>
-                                <cell><placeName ref="https://www.wikidata.org/wiki/Q85"
-                                        >Cairo</placeName> … Mr. J. B. CAFFARI</cell>
-                                <cell><placeName ref="https://www.wikidata.org/wiki/Q134514"
-                                        >Suez</placeName> … Mr. GEO. MEINECKE.</cell>
+                                <cell><placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> … Mr. J. B. CAFFARI</cell>
+                                <cell><placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName> … Mr. GEO. MEINECKE.</cell>
                             </row>
                         </table>
                         <p>21281-216905</p>
@@ -1779,20 +1233,13 @@
                         <p>Codes-- ABC, 4th and 5th Editions, A1.</p>
                         <p>MORNING &amp; NEAL'S.</p>
                         <p>Trade Mark — “INVINCIBLE."</p>
-                        <p>MANUFACTURERS OF THE LARGEST AND MOST EFFICIENT Centrifugal Pumping
-                            Machinery In the world, suitable fcr all purposes, including
-                            RECLAMATION, DRAINAGE, IRRIGATION, SEWAGE WORKS, GRAVING &amp; FLOATING
-                            DOCKS, MINES, &amp; ALL MANUFACTURING PURPOSES.</p>
-                        <p>These Pumps can be driven by Steam, Gas, Oil, Water, Electricity, or
-                            other power, for Lifts of from 1 ft. to 500ft., and from 5 to 500,000
-                            Gallons a Minute. Makers of the Mex Pumps.</p>
+                        <p>MANUFACTURERS OF THE LARGEST AND MOST EFFICIENT Centrifugal Pumping Machinery In the world, suitable fcr all purposes, including RECLAMATION, DRAINAGE, IRRIGATION, SEWAGE WORKS, GRAVING &amp; FLOATING DOCKS, MINES, &amp; ALL MANUFACTURING PURPOSES.</p>
+                        <p>These Pumps can be driven by Steam, Gas, Oil, Water, Electricity, or other power, for Lifts of from 1 ft. to 500ft., and from 5 to 500,000 Gallons a Minute. Makers of the Mex Pumps.</p>
                         <p>Results Guaranteed.</p>
                         <p>Over 50 Years' Practical Experience.</p>
-                        <p>All kinds of Pumping and Irrigation Machinery specially designed to meet
-                            Egyptian requirements.</p>
+                        <p>All kinds of Pumping and Irrigation Machinery specially designed to meet Egyptian requirements.</p>
                         <p>London Offices— 81, Cannon Street, London, E.C.</p>
-                        <p>The British Engineering Company of Egypt, Ltd: Rue de la Gare du Caire,
-                            Alexandria.</p>
+                        <p>The British Engineering Company of Egypt, Ltd: Rue de la Gare du Caire, Alexandria.</p>
                         <p>Works- Hammersmith, London, W</p>
                         <p>23362-11-12-904</p>
                     </div>
@@ -1800,48 +1247,33 @@
                         <head>THE ARTESIAN BORING AND PROSPECTING COMPANY.</head>
                         <p>(SOCIÉTÉ ANONYME)</p>
                         <p>CAIRO, 28, SHARIA-EL-MANAKH,<lb/> (OPPOSITE IMPERIAL OTTOMAN BANK).</p>
-                        <p>I. —Installation of complete Water supplies for drinking, agricultural,
-                            and<lb/> industrial purposes by means of artesian wells.</p>
-                        <p>II. - Deep borings for prospecting purposes in all conditions of soil by
-                            means of the<lb/> “Express Boring System."</p>
+                        <p>I. —Installation of complete Water supplies for drinking, agricultural, and<lb/> industrial purposes by means of artesian wells.</p>
+                        <p>II. - Deep borings for prospecting purposes in all conditions of soil by means of the<lb/> “Express Boring System."</p>
                         <p>24,437-12-1-905</p>
                     </div>
                     <cols n="2"/>
                     <cb n="1"/>
                     <div type="item" scope="advertisement" xml:id="deg-ad-aeb01">
                         <head>THE ANGLO-EGYPTIAN BANK, LIMITED.</head>
-                        <p>LONDON, PARIS ALEXANDRIA, CAIRO MALTA, GIBRALTAR, TANTAH, AND PORT
-                            SAID.</p>
+                        <p>LONDON, PARIS ALEXANDRIA, CAIRO MALTA, GIBRALTAR, TANTAH, AND PORT SAID.</p>
                         <p>Subscribed Capital JS1.500,000</p>
                         <p> Paid up '' £ 500,000</p>
                         <p>Reserve Fund... 500,000</p>
-                        <p>The Anglo-Egyptian Bank. Limited, undertakes every description of banking
-                            business on the most favourable conditions.</p>
-                        <p>Current accounts opened with commercial homes and private individuals in
-                            conformity with the custom of Bankers.</p>
-                        <p>Fixed deposits for one year certain received at 8 per cent. per annum.
-                            Deposits at interest for shorter periods are also received at rates to
-                            be agreed upon.</p>
-                        <p>Letters of Credit for the use of travellers are issued payable in all
-                            parts of the World.</p>
+                        <p>The Anglo-Egyptian Bank. Limited, undertakes every description of banking business on the most favourable conditions.</p>
+                        <p>Current accounts opened with commercial homes and private individuals in conformity with the custom of Bankers.</p>
+                        <p>Fixed deposits for one year certain received at 8 per cent. per annum. Deposits at interest for shorter periods are also received at rates to be agreed upon.</p>
+                        <p>Letters of Credit for the use of travellers are issued payable in all parts of the World.</p>
                         <p>Approved bills discounted.</p>
                         <p>Bills, documentary invoices, etc, collected.</p>
                         <p>Drafts and telegraphic transfers issued payable all over the World.</p>
                         <p>Foreign exchange bought and sold.</p>
-                        <p>Advances made upon approved securities and upon cotton, cotton-seed,
-                            sugar and other merchandise.</p>
-                        <p>The purchase and sale of stocks and shares on the London Stock Exchange;
-                            and on the local and Continental Bourses, undertaken.</p>
-                        <p>Customers can deposit their valuables, bonds, etc., for safe custody in
-                            the Bank's fire-proof strong-rooms, and the Bank will attend to the
-                            collection of the coupons and drawn bonds so deporited as they fall
-                            due.</p>
+                        <p>Advances made upon approved securities and upon cotton, cotton-seed, sugar and other merchandise.</p>
+                        <p>The purchase and sale of stocks and shares on the London Stock Exchange; and on the local and Continental Bourses, undertaken.</p>
+                        <p>Customers can deposit their valuables, bonds, etc., for safe custody in the Bank's fire-proof strong-rooms, and the Bank will attend to the collection of the coupons and drawn bonds so deporited as they fall due.</p>
                         <p>Mercantile credits issued.</p>
                         <p>Annuities, pensions, dividends, etc., collected.</p>
-                        <p>All farther particulars and information can be obtained on
-                            application.</p>
-                        <p>The officers and clerks of the Bank are pledged to secrecy as to the
-                            transactions of customers. 18-9-905</p>
+                        <p>All farther particulars and information can be obtained on application.</p>
+                        <p>The officers and clerks of the Bank are pledged to secrecy as to the transactions of customers. 18-9-905</p>
                     </div>
                     <!-- TODO Surplus Drapery Stock -->
                     <!-- TODO Howie & Co, The Hygenic Dairy -->
@@ -1867,8 +1299,7 @@
                         <p>de provenance directe et de toutes les meilleures marques</p>
                         <p>Nicolas G Sabbag</p>
                         <p>IMPORTATEUR GENERAL</p>
-                        <p>FOURNISSIUR DE S A LE KHEDIVE et de tous les grands Clubs et Hôtels
-                            d'Egypte.</p>
+                        <p>FOURNISSIUR DE S A LE KHEDIVE et de tous les grands Clubs et Hôtels d'Egypte.</p>
                         <p>2—Rue de la Gare du Caire—2 ALEXANDRIE</p>
                         <p> Adresse Télégraphique : SABBAG Alexandrie</p>
                         <p> Téléphone No 559.</p>
@@ -1888,11 +1319,8 @@
                         <p>The most charming Sea-side Residence in Egypt.</p>
                         <p>First Class Family Hotel with Every Modern Comfort.</p>
                         <p>Unique Situation on the Beach.</p>
-                        <p>Lovely Garden. Lawn Tennis. Large Terrace. Electric Light. Sea Baths. Own
-                            springs. Perfect sanitary arrangements. Stables for horses and
-                            carriages.</p>
-                        <p>Moderate Charges. -- Special terms for Government Officials and Officers
-                            of the Army of Occupation.</p>
+                        <p>Lovely Garden. Lawn Tennis. Large Terrace. Electric Light. Sea Baths. Own springs. Perfect sanitary arrangements. Stables for horses and carriages.</p>
+                        <p>Moderate Charges. -- Special terms for Government Officials and Officers of the Army of Occupation.</p>
                         <p>252-17.1.906</p>
                         <p>G. RUNCKEWITZ, Proprietor.</p>
                     </div>
@@ -1903,26 +1331,21 @@
                         <p>Soda Water. Lemonade, Ginger Ale, Ginger Beer. Tonic Water</p>
                         <p>Pomegranade, Orangeaade, Pineapple, Champagne, Cider, etc., etc.</p>
                         <p> Water guaranteed by Chamberlain’s Filter (Pasteur’s System).</p>
-                        <p>Inventor of WHISKY &amp; SODA and BRANDY &amp; SODA, bottled ready for
-                            use.</p>
+                        <p>Inventor of WHISKY &amp; SODA and BRANDY &amp; SODA, bottled ready for use.</p>
                         <p> Sole Agents in Egypt and Soudan for</p>
                         <p> J. Calvet &amp; Co. Bordeaux. Wine &amp; Cognacs.</p>
                         <p>Louis Roederer. Rheims. Champagnes.</p>
                         <p>August Engel. Wiesbaden. Rhine and Moselle Wines.</p>
-                        <p>Mackie &amp; Co. Glasgow. Lagavulin, White Horse Cellar &amp; other
-                            Whiskies.</p>
+                        <p>Mackie &amp; Co. Glasgow. Lagavulin, White Horse Cellar &amp; other Whiskies.</p>
                         <p>Dunville &amp; Co, Ltd. Belfast. Old Irish Whiskies.</p>
                         <p>Wm. Lanahan &amp; Son. Baltimore. Monongshels XXXX Whiskey.</p>
-                        <p>The Cook &amp; Bernheimer Co. New York. Old Valley Whiskey and Gold Lion
-                            Cocktails.</p>
+                        <p>The Cook &amp; Bernheimer Co. New York. Old Valley Whiskey and Gold Lion Cocktails.</p>
                         <p>Stone &amp; Son. London. Guinness' Stout &amp; Bass' Pale Ale.</p>
                         <p>Freund Ballor &amp; Co. Tornio. Vermouth.</p>
                         <p>Pierre Bisset. Cette. Vermouth &amp; Aperitives.</p>
                         <p>Terrabonatea Company, Ld. Teas.</p>
-                        <p>Depot for Prince Metternich's "Richardsquelle," the best mineral table
-                            water in the world.</p>
-                        <p>Great assortment of Wines, Spirits, Liqueurs, of the finest Brands,
-                            etc</p>
+                        <p>Depot for Prince Metternich's "Richardsquelle," the best mineral table water in the world.</p>
+                        <p>Great assortment of Wines, Spirits, Liqueurs, of the finest Brands, etc</p>
                     </div>
                     <!-- TODO Peach's Lace Curtains -->
                     <div type="item" scope="advertisement" xml:id="deg-ad-lea01">
@@ -1933,13 +1356,9 @@
                     <!-- TODO Comptoir National d'Escopmte -->
                     <div type="item" scope="advertisement" xml:id="deg-ad-dia01">
                         <head>DIAMONDS!</head>
-                        <p>The largest and finest stock of Jewellery, Silver Plate, Watches, Clocks,
-                            Dressing Bags, &amp;c., new and second-hand, In the world, at wholesale
-                            prices.</p>
-                        <p>Please write for Illustrated Catalogue V. The Finest in the World. 4,000
-                            Illustrations. Post Free.</p>
-                        <p>£5,000 Worth of Second-hand Jewels in Stock. WRITE FOR SPECIAL
-                            ILLUSTRATED LIST.</p>
+                        <p>The largest and finest stock of Jewellery, Silver Plate, Watches, Clocks, Dressing Bags, &amp;c., new and second-hand, In the world, at wholesale prices.</p>
+                        <p>Please write for Illustrated Catalogue V. The Finest in the World. 4,000 Illustrations. Post Free.</p>
+                        <p>£5,000 Worth of Second-hand Jewels in Stock. WRITE FOR SPECIAL ILLUSTRATED LIST.</p>
                         <p>ASSOCIATION OF DIAMOND MERCHANTS, LIMITED.</p>
                         <p>Trafalgar Square, London, W.C.</p>
                         <p>Established over 50 years</p>
@@ -1993,29 +1412,17 @@
                     </div>
                     <div type="subsection">
                         <head>REMARKS.</head>
-                        <p>The day opened fine and clear. The degree of humidity is rather less but
-                            the barometer is falling.</p>
+                        <p>The day opened fine and clear. The degree of humidity is rather less but the barometer is falling.</p>
                     </div>
                 </div>
                 <div type="item" scope="newspaper">
                     <head>THE EGYPTIAN GAZETTE.</head>
-                    <p>SUBSCRIPTIONS.—Alexandria, Cairo, and the Interior of Egypt (including
-                        delivery in Alexandria or postage to subscriber’s address) P.T. 231½ per
-                        annum, P.T. 116 for six months, P.T. 80 for three months. To other countries
-                        in the Postal Union P.T. 273 (£2.16s.) per annum. Six months P.T. 136½
-                        (£1.8s.), three months P.T. 92 (£0.19s.) N.B.—Subscriptions commence from
-                        the 1st or 16th of any month. </p>
-                    <p>ADVERTISEMENTS.—P.T. 4 per line. Minimum charge P.T. 20. Births, Marriages,
-                        or Deaths, not exceeding three lines, P.T. 20. Every additional line P.T.
-                        10. Notices in news column P.T. 20 per line. Contracts entered into for
-                        standing advertisements. </p>
-                    <p>SUBSCRIPTIONS and ADVERTISEMENTS are due in advance. P.O. Orders and Cheques
-                        to be made payable to the Editor and Manager, Rowland Snelling, Alexandria. </p>
+                    <p>SUBSCRIPTIONS.—Alexandria, Cairo, and the Interior of Egypt (including delivery in Alexandria or postage to subscriber’s address) P.T. 231½ per annum, P.T. 116 for six months, P.T. 80 for three months. To other countries in the Postal Union P.T. 273 (£2.16s.) per annum. Six months P.T. 136½ (£1.8s.), three months P.T. 92 (£0.19s.) N.B.—Subscriptions commence from the 1st or 16th of any month. </p>
+                    <p>ADVERTISEMENTS.—P.T. 4 per line. Minimum charge P.T. 20. Births, Marriages, or Deaths, not exceeding three lines, P.T. 20. Every additional line P.T. 10. Notices in news column P.T. 20 per line. Contracts entered into for standing advertisements. </p>
+                    <p>SUBSCRIPTIONS and ADVERTISEMENTS are due in advance. P.O. Orders and Cheques to be made payable to the Editor and Manager, Rowland Snelling, Alexandria. </p>
                     <p>London Offices : 36, New Broad-street. B.C. </p>
-                    <p>THE EGYPTIAN GAZETTE can be obtained in London at our office, 36, New Broad
-                        Street, E.C., and also at Messrs. May &amp; Williams 160, Piccadilly, W. </p>
-                    <p>THE “EGYPTIAN GAZETTE” IS PRINTED ON PAPER MANUFACTURED AND SUPPLIED BY THE
-                        LONDON PAPER MILLS Co., LIMITED (SALES OFFICE: 27, CANNON STREET, E.C.) </p>
+                    <p>THE EGYPTIAN GAZETTE can be obtained in London at our office, 36, New Broad Street, E.C., and also at Messrs. May &amp; Williams 160, Piccadilly, W. </p>
+                    <p>THE “EGYPTIAN GAZETTE” IS PRINTED ON PAPER MANUFACTURED AND SUPPLIED BY THE LONDON PAPER MILLS Co., LIMITED (SALES OFFICE: 27, CANNON STREET, E.C.) </p>
                 </div>
                 <div type="item" scope="newspaper">
                     <p>The Egyptian Gazette </p>
@@ -2025,22 +1432,21 @@
                     <p>SATURDAY, OCTOBER 7, 1905.</p>
                 </div>
                 <!-- TODO The Sucrereis -->
-                <div type="item" scope="calendar">
-                    <table cols="3" xml:id="CalendarOfTheWeek">
-                        <head>Calendar of Coming Events.</head>
-                        <div type="subsection">
+                <div type="item" scope="calendar" xml:id="CalendarOfTheWeek">
+
+                    <head>Calendar of Coming Events.</head>
+                    <div type="subsection">
+                        <table cols="3" xml:id="CalendarOfTheWeek-Alexandria">
                             <head>Alexandria</head>
                             <head type="sub">October</head>
                             <row>
                                 <cell>Sat.</cell>
                                 <cell>7</cell>
                                 <cell>
-                                    <p>Alex. Swimming Club. 3rd Annual<lb/>Aquatic Sports. New
-                                        Graving<lb/>Dock, Gabbari. 3 p.m.</p>
+                                    <p>Alex. Swimming Club. 3rd Annual<lb/>Aquatic Sports. New Graving<lb/>Dock, Gabbari. 3 p.m.</p>
                                     <p>San Stefano Casino. Telepathy Demonstration. 9.30 p.m.</p>
                                     <p>Mex Casino. Reunion des Familles 9.30 p.m.</p>
-                                    <p>Mex Prinea's Restaurant des Bains Roumanian orchestra, every
-                                        afternoon. Sundays, morning.</p>
+                                    <p>Mex Prinea's Restaurant des Bains Roumanian orchestra, every afternoon. Sundays, morning.</p>
                                     <p>Windsor Hotel. Orchestra. 6 to 11.30 p.m. every day.</p>
                                     <p>Alhambra - Italian company. - 9.15 p.m.</p>
                                 </cell>
@@ -2049,14 +1455,14 @@
                                 <cell>Sat.</cell>
                                 <cell>14</cell>
                                 <cell>
-                                    <p>Alex. Swimming Club. 60yds Juniors'<lb/>100yds. Seniors'
-                                        Chapmpionships.<lb/>Customs Gate 23. 4 p.m.</p>
-                                    <p>B.R.C. Mustapha Pasha Range.<lb/>Practice and Cup
-                                        Compeittion.<lb/>3 p.m.</p>
+                                    <p>Alex. Swimming Club. 60yds Juniors'<lb/>100yds. Seniors' Chapmpionships.<lb/>Customs Gate 23. 4 p.m.</p>
+                                    <p>B.R.C. Mustapha Pasha Range.<lb/>Practice and Cup Compeittion.<lb/>3 p.m.</p>
                                 </cell>
                             </row>
-                        </div>
-                        <div type="subsection">
+                        </table>
+                    </div>
+                    <div type="subsection">
+                        <table cols="3" xml:id="CalendarOfTheWeek-Cairo">
                             <head>Cairo</head>
                             <head type="sub">October</head>
                             <row>
@@ -2072,689 +1478,315 @@
                                 <cell>Tues.</cell>
                                 <cell>10</cell>
                                 <cell>
-                                    <p>Esbekieh Gardens. Performance by British Military Band. 9 to
-                                        11 p.m.</p>
+                                    <p>Esbekieh Gardens. Performance by British Military Band. 9 to 11 p.m.</p>
                                 </cell>
                             </row>
                             <row>
                                 <cell>Fri.</cell>
                                 <cell>13</cell>
                                 <cell>
-                                    <p>Esbekieh Gardens. Performance by British Military Band. 9 to
-                                        11 p.m.</p>
+                                    <p>Esbekieh Gardens. Performance by British Military Band. 9 to 11 p.m.</p>
                                 </cell>
                             </row>
                             <row>
                                 <cell>Mon.</cell>
                                 <cell>16</cell>
-                                <cell><p/>Cairo Musical and Dramatic Society.<lb/>Concert in aid of
-                                    Calabrian Victims.<lb/>Distinguished Patronage.</cell>
+                                <cell><p/>
+                                     Cairo Musical and Dramatic Society.<lb/>Concert in aid of Calabrian Victims.<lb/>Distinguished Patronage.</cell>
                             </row>
-                        </div>
-                    </table>
+                        </table>
+                    </div>
                 </div>
             </div>
             <div type="page" n="3">
                 <head>THE EGYPTIAN GAZETTE, SATURDAY, OCTOBER 7 1905</head>
                 <div type="article">
                     <head>CANAL TRAFFIC, SHIPS ENTER TODAY.</head>
-                    <dateline><placeName ref="https://www.wikidata.org/wiki/Q134509">Port
-                            Said</placeName>, <date value="1905-10-06">October 6</date>.</dateline>
-                    <p>The mail boats will enter the Canal to-morrow and pass the Chatham on Sunday.
-                        The cargo boats will follow.</p>
+                    <dateline><placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>, <date when="1905-10-06">October 6</date>.</dateline>
+                    <p>The mail boats will enter the Canal to-morrow and pass the Chatham on Sunday. The cargo boats will follow.</p>
                     <byline>(Havas)</byline>
                 </div>
                 <div type="article">
                     <head>AMERICAN INSURANCE COMPANIES.</head>
                     <head type="sub">IRREGULARITIES AND WASTE OF FUNDS.</head>
-                    <dateline>New York, <date value="1905-10-06">October 6</date>.</dateline>
-                    <p>The investigation which is being made into the management of the Insurance
-                        Companies is leading every day to the discovery of fresh irregularities and
-                        waste of funds.</p>
+                    <dateline>New York, <date when="1905-10-06">October 6</date>.</dateline>
+                    <p>The investigation which is being made into the management of the Insurance Companies is leading every day to the discovery of fresh irregularities and waste of funds.</p>
                     <byline>(Reuter)</byline>
                 </div>
                 <div type="section">
                     <head>LOCAL AND GENERAL</head>
                     <div type="article">
-                        <p>The Brindisi Mail will be made up at the G.P.O., <placeName
-                                ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>, on
-                            Tuesday at 8.30 a.m.</p>
+                        <p>The Brindisi Mail will be made up at the G.P.O., <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>, on Tuesday at 8.30 a.m.</p>
                     </div>
                     <div type="article">
-                        <p>Stray and Ownerless Dogs found in the Kobessi district during to-morrow
-                            night and at dawn of the 9th inst. will be poisoned by the police.</p>
+                        <p>Stray and Ownerless Dogs found in the Kobessi district during to-morrow night and at dawn of the 9th inst. will be poisoned by the police.</p>
                     </div>
                     <div type="article">
                         <head>The Bank of Abyssinia</head>
-                        <p>The first meeting of the directors of the above banks will be hold at
-                                <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>
-                            next week. As has been expected Mr. McGillivray is to be appointed
-                            governor of the Bank of Abyssinia, and will proceed to Adis Ababba to
-                            take up his now duties in about two months’ time.</p>
+                        <p>The first meeting of the directors of the above banks will be hold at <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> next week. As has been expected Mr. McGillivray is to be appointed governor of the Bank of Abyssinia, and will proceed to Adis Ababba to take up his now duties in about two months’ time.</p>
                     </div>
                     <div type="article">
                         <head>MR. TAFT IN JAPAN.</head>
                         <head type="sub">IMPORTANT UNDERSTANDING WITH U S. A.</head>
-                        <dateline>Tokio. <date value="1905-10-06">October 6</date>.</dateline>
-                        <p>The semi official ‘Kokoumin" says that the occasion of Mr. Taft’s voyage
-                            to Japan the latter concluded an important understanding with the United
-                            States, ‘ in consequence of Japan's explicit disavowal of any designs
-                            whatever upon the Phillipines.</p>
+                        <dateline>Tokio. <date when="1905-10-06">October 6</date>.</dateline>
+                        <p>The semi official ‘Kokoumin" says that the occasion of Mr. Taft’s voyage to Japan the latter concluded an important understanding with the United States, ‘ in consequence of Japan's explicit disavowal of any designs whatever upon the Phillipines.</p>
                         <byline>(Reuter)</byline>
                     </div>
                     <div type="article">
                         <head>RUSSIAN NATIONAL ASSEMBLY.</head>
-                        <p>St. Petersburg, <date value="1905-10-06">October 6</date>. The Minister
-                            of the Interior has ordered the local authorities to abstain from
-                            interference with the forthcoming elections to the National
-                            Assembly.</p>
+                        <p>St. Petersburg, <date when="1905-10-06">October 6</date>. The Minister of the Interior has ordered the local authorities to abstain from interference with the forthcoming elections to the National Assembly.</p>
                         <byline>(Reuter)</byline>
                     </div>
                     <div type="article">
                         <head type="sub">THE REICHSRATH.</head>
                         <head>UNIVERSAL SUFFRAGE.</head>
-                        <dateline>Vienna. <date value="1905-10-06">October 6</date>.</dateline>
+                        <dateline>Vienna. <date when="1905-10-06">October 6</date>.</dateline>
                         <p>The Rechsrath has rejected the resolutions for universal suffrage.</p>
                         <byline>(Havas)</byline>
                     </div>
                     <div type="article">
                         <head>BRITISH SQUADRON AT KOBE.</head>
-                        <dateline>Kobe, <date value="1905-10-06">October 6</date>.</dateline>
-                        <p>The British <placeName ref="https://www.wikidata.org/wiki/Q148"
-                                >China</placeName> Squadron has arrived here.</p>
+                        <dateline>Kobe, <date when="1905-10-06">October 6</date>.</dateline>
+                        <p>The British <placeName ref="https://www.wikidata.org/wiki/Q148">China</placeName> Squadron has arrived here.</p>
                         <byline>(Reuter)</byline>
                     </div>
                     <div type="article">
                         <head>STRIKES IN LIVONIA.</head>
-                        <p>St Petersburg, <date value="1905-10-06">October 6</date>. Strikes and
-                            pillaging continue in the Livonia province. (Havas)</p>
+                        <p>St Petersburg, <date when="1905-10-06">October 6</date>. Strikes and pillaging continue in the Livonia province. (Havas)</p>
                     </div>
                     <div type="article">
                         <head type="sub">HAMBURG-AMERIKA LINE</head>
                         <head>NEW STEAMER PURCHASED.</head>
-                        <dateline>Berlin, <date value="1905-10-06">October 6</date>.</dateline>
-                        <p>The Hamburg-Amerika Line has purchased the Union Castle steamship Scot,
-                            which has been re named the Ocean. This steamer will make one of an
-                            express service between <placeName
-                                ref="https://www.wikidata.org/wiki/Q2634">Naples</placeName> and
-                                <placeName ref="https://www.wikidata.org/wiki/Q87"
-                                >Alexandria</placeName>, in connection with the Berlin express.
-                            (Reuter)</p>
+                        <dateline>Berlin, <date when="1905-10-06">October 6</date>.</dateline>
+                        <p>The Hamburg-Amerika Line has purchased the Union Castle steamship Scot, which has been re named the Ocean. This steamer will make one of an express service between <placeName ref="https://www.wikidata.org/wiki/Q2634">Naples</placeName> and <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>, in connection with the Berlin express. (Reuter)</p>
                     </div>
                     <div type="article">
                         <head>ROMAN ATHLETIC MEETING.</head>
-                        <dateline>Rome, <date value="1905-10-06">October 6</date>.</dateline>
-                        <p>A great athletic meeting is taking place in the Vatican gardens under the
-                            patronage of the Pope, who warmly approves of sports.</p>
+                        <dateline>Rome, <date when="1905-10-06">October 6</date>.</dateline>
+                        <p>A great athletic meeting is taking place in the Vatican gardens under the patronage of the Pope, who warmly approves of sports.</p>
                         <byline>(R.)</byline>
                     </div>
                 </div>
                 <div type="section">
                     <head>PERSONAL AND SOCIAL</head>
                     <div type="article">
-                        <p>Sir Vincent Corbett, the Financial Adviser, will arrive at <placeName
-                                ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> on
-                            Monday from <placeName ref="https://www.wikidata.org/wiki/Q579613"
-                                >Marseilles</placeName> by the North German Lloyd S.S.
-                            Schleswig.</p>
+                        <p>Sir Vincent Corbett, the Financial Adviser, will arrive at <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> on Monday from <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName> by the North German Lloyd S.S. Schleswig.</p>
                     </div>
                     <div type="article">
-                        <p>Lord Hindlip is shortly expected in <placeName
-                                ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> on his way
-                            to British East Africa. His lordship is going on a six months’ visit to
-                            that country in connection with the farming scheme which he started in
-                            the Protectorate last year. Lord Hindlip is accompanied by Lady
-                            Hindlip.</p>
+                        <p>Lord Hindlip is shortly expected in <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> on his way to British East Africa. His lordship is going on a six months’ visit to that country in connection with the farming scheme which he started in the Protectorate last year. Lord Hindlip is accompanied by Lady Hindlip.</p>
                     </div>
                     <div type="article">
-                        <p>Mr. Harrison, general manager of Messrs, Thos. Cook and Sons, is expected
-                            to strive in <placeName ref="https://www.wikidata.org/wiki/Q79"
-                                >Egypt</placeName> towards the end of this month.</p>
+                        <p>Mr. Harrison, general manager of Messrs, Thos. Cook and Sons, is expected to strive in <placeName ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName> towards the end of this month.</p>
                     </div>
                     <div type="article">
-                        <p>Mr. Baehler is expected back in <placeName
-                                ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> with his
-                            family, on Monday.</p>
+                        <p>Mr. Baehler is expected back in <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> with his family, on Monday.</p>
                     </div>
                     <div type="article">
-                        <p>Mr. David Longworth left <placeName
-                                ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> for
-                            Nairobi yesterday.</p>
+                        <p>Mr. David Longworth left <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> for Nairobi yesterday.</p>
                     </div>
                     <div type="article">
                         <head>ST ANDREWS CHURCH.</head>
-                        <head type="sub"><placeName ref="https://www.wikidata.org/wiki/Q85"
-                                >Cairo</placeName>
+                        <head type="sub"><placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>
                         </head>
                         <p>Services — 10:30 a.m.</p>
                         <p>6 p.m.</p>
-                        <p>Beginning Sunday, <date value="1905-10-08">8th October</date>.</p>
+                        <p>Beginning Sunday, <date when="1905-10-08">8th October</date>.</p>
                     </div>
                     <div type="article">
                         <head>Coal Imports</head>
-                        <p>From the 1st of January to the 5th of October, 824,306 tons of coal were
-                            imported into Egypt. Wales sent 443,720, Newcastle 194,487, Scotland
-                            99,112, Yorkshire 56,574, and other places 31.503 tons. During the
-                            corresponding period of 1904, 797,262 tons were received.</p>
+                        <p>From the 1st of January to the 5th of October, 824,306 tons of coal were imported into Egypt. Wales sent 443,720, Newcastle 194,487, Scotland 99,112, Yorkshire 56,574, and other places 31.503 tons. During the corresponding period of 1904, 797,262 tons were received.</p>
                     </div>
                     <div type="article">
                         <head>Found drowned</head>
-                        <p>A corpse of a native lad aged 12, which was not identified, was found
-                            floating in the Mahmudieh canal yesterday, and on being taken out of the
-                            water was removed to the hospital for medical examination. Inquiries are
-                            being made in the hopes of identifying the body.</p>
+                        <p>A corpse of a native lad aged 12, which was not identified, was found floating in the Mahmudieh canal yesterday, and on being taken out of the water was removed to the hospital for medical examination. Inquiries are being made in the hopes of identifying the body.</p>
                     </div>
                     <div type="article">
                         <head>New Ottoman Medal</head>
-                        <p>In accordance with the Sultan's desire the Ottoman Government will strike
-                            a new medal, which will be called the "Yemen Medal." The new medal is to
-                            be confered upon the soldiers who distinguished themselvcs in
-                            suppressing the Yemen rebellion.</p>
+                        <p>In accordance with the Sultan's desire the Ottoman Government will strike a new medal, which will be called the "Yemen Medal." The new medal is to be confered upon the soldiers who distinguished themselvcs in suppressing the Yemen rebellion.</p>
                     </div>
                     <div type="article">
                         <head>Burnt to Death</head>
-                        <p>A woman of the name of Maria Rato, 25 years of age, was boiling a kettle
-                            on a gas stove on the 5th inst. when the flame caught her clothes. The
-                            flimsy material immediately flared up and the unfortunate woman received
-                            terrible burns from which she died very shortly after.</p>
+                        <p>A woman of the name of Maria Rato, 25 years of age, was boiling a kettle on a gas stove on the 5th inst. when the flame caught her clothes. The flimsy material immediately flared up and the unfortunate woman received terrible burns from which she died very shortly after.</p>
                     </div>
                     <div type="article">
                         <head>Alhambra Theatre</head>
-                        <p>The Della Guardia Dramatic company will stage Maison de Poupée at this
-                            evening's performance and a matinée will bo given to-morrow, commenting
-                            at 4 p.m., for which l Fourchambault is billed. To-morrow evening there
-                            will no performance, it being the eve of tbe Jewish Day of
-                            Atonement.</p>
+                        <p>The Della Guardia Dramatic company will stage Maison de Poupée at this evening's performance and a matinée will bo given to-morrow, commenting at 4 p.m., for which l Fourchambault is billed. To-morrow evening there will no performance, it being the eve of tbe Jewish Day of Atonement.</p>
                     </div>
                     <div type="article">
                         <head>Affray at Menshieh</head>
-                        <p>A quarrel took place yesterday at Menshieh between Alexandre Khalikopolo
-                            a Greek carpenter aged 30, and Said Imam, a native cabdriver aged 20, in
-                            which the former stabbed the latter with a knife the right hand. The
-                            man's hand was badly wounded and he was taken to the hospital, where he
-                            will be detained until recovered.</p>
+                        <p>A quarrel took place yesterday at Menshieh between Alexandre Khalikopolo a Greek carpenter aged 30, and Said Imam, a native cabdriver aged 20, in which the former stabbed the latter with a knife the right hand. The man's hand was badly wounded and he was taken to the hospital, where he will be detained until recovered.</p>
                     </div>
                     <div type="article">
                         <head>San Stefano Casino</head>
-                        <p>The demonstration of telepathy, thought-reading, and autosuggestion by
-                            Professor Bellini will take the place of the usual small dance at the
-                            San Stefano Casino this evening. Subscribers will be admitted free,
-                            non-subsribers will be charged P.T. 10. The Bracale orchestra will play
-                            as usual tomorrow at 10.30 a.m. and 5 p.m.</p>
+                        <p>The demonstration of telepathy, thought-reading, and autosuggestion by Professor Bellini will take the place of the usual small dance at the San Stefano Casino this evening. Subscribers will be admitted free, non-subsribers will be charged P.T. 10. The Bracale orchestra will play as usual tomorrow at 10.30 a.m. and 5 p.m.</p>
                     </div>
                     <div type="article">
                         <head>A Painful Death</head>
-                        <p>A <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName>
-                            contemporary announces that a cow in Sullivan County, U.S.A., has just
-                            joined the majority in painful circumstances. Wandering into a kitchen,
-                            the peckish cudster found an old umbrella and several cakes of yeast,
-                            all of which it proceeded to swallow. The subsequent fermenting of the
-                            yeast opened the umbrella, and the beast died in great agony.</p>
+                        <p>A <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> contemporary announces that a cow in Sullivan County, U.S.A., has just joined the majority in painful circumstances. Wandering into a kitchen, the peckish cudster found an old umbrella and several cakes of yeast, all of which it proceeded to swallow. The subsequent fermenting of the yeast opened the umbrella, and the beast died in great agony.</p>
                     </div>
                     <div type="article">
                         <head>Rumoured Hotel Amalgamation</head>
-                        <p>A rumour is current that on the return of Mr. Nungovich Bey a proposal
-                            will be submitted the shareholders of the Nungovich Hotels Co., and the
-                            Upper <placeName ref="https://www.wikidata.org/wiki/Q79"
-                                >Egypt</placeName> Hotels, for the amalgamation of the two companies
-                            under one directorate. It is reported on the <placeName
-                                ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> bonne that
-                            the recent appreciation in the shares of there companies is due to this
-                            reason.</p>
+                        <p>A rumour is current that on the return of Mr. Nungovich Bey a proposal will be submitted the shareholders of the Nungovich Hotels Co., and the Upper <placeName ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName> Hotels, for the amalgamation of the two companies under one directorate. It is reported on the <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> bonne that the recent appreciation in the shares of there companies is due to this reason.</p>
                     </div>
                     <div type="article">
                         <head>The Selection of a Grand Mufti</head>
-                        <p>We learn that the Council of Ministers at their meeting on Monday will
-                            select two sheikhs, shore names will be submitted to H. H. the Khedive
-                            fur the post of Grand Mufti of Egypt. There is much speculation as to
-                            who will be appointed to that important position in the Mohamedan world,
-                            but, our native readers have not to wait much longer now know whether
-                            their own choice has been selected.</p>
+                        <p>We learn that the Council of Ministers at their meeting on Monday will select two sheikhs, shore names will be submitted to H. H. the Khedive fur the post of Grand Mufti of Egypt. There is much speculation as to who will be appointed to that important position in the Mohamedan world, but, our native readers have not to wait much longer now know whether their own choice has been selected.</p>
                     </div>
                     <div type="article">
                         <head>British Chamber of Commerce</head>
-                        <p>We would draw the attention of manufacturers and merchants to the work of
-                            the British Chamber of Commerce of Egypt, which was formed in 1896 with
-                            the sole object of assisting British trade in this country. The services
-                            of the Chamber are always at the disposal of any member desiring
-                            information on trade matters generally, including the question of
-                            appointing suitable agents. As no fee is charged for snob advice, it is
-                            obviously in the interests of all British traders here to become
-                            members, especially when it is remembered that the annual subscription
-                            is merely the nominal one of £1. The latter payment also includes a copy
-                            of the monthly Journal issued by the Chamber. Home enquirers can obtain
-                            farther particulars from our <placeName
-                                ref="https://www.wikidata.org/wiki/Q84">London</placeName> office,
-                            86, New Broad-street, which acts as agents to the Chamber.</p>
+                        <p>We would draw the attention of manufacturers and merchants to the work of the British Chamber of Commerce of Egypt, which was formed in 1896 with the sole object of assisting British trade in this country. The services of the Chamber are always at the disposal of any member desiring information on trade matters generally, including the question of appointing suitable agents. As no fee is charged for snob advice, it is obviously in the interests of all British traders here to become members, especially when it is remembered that the annual subscription is merely the nominal one of £1. The latter payment also includes a copy of the monthly Journal issued by the Chamber. Home enquirers can obtain farther particulars from our <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> office, 86, New Broad-street, which acts as agents to the Chamber.</p>
                     </div>
                     <div type="article">
-                        <head>THE <placeName ref="https://www.wikidata.org/wiki/Q85"
-                                >Cairo</placeName> “ZOO.”</head>
+                        <head>THE <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> “ZOO.”</head>
                         <head>REPORT FOR 1904.</head>
-                        <p>The sixth annual report by the director of the Ghizeh Zoological Gardens
-                            affords most interesting reading. It seems to be complete in every
-                            detail, even to the noting that "one Egyptian pound (L.E. 1) equals
-                            ₤l.0s.61/4d. or 25 francs and 92 centimes.” We may be sure that after
-                            the precision shown in this matter we may rely upon the other statements
-                            in the report being equally exact</p>
-                        <p>Passing over the details as to the staff, which seems to he selected with
-                            a view to complete efficiency, not only as regard the animals, but also
-                            for the upkeep of the ornamental grounds, we notice that the number of
-                            visitors shows a steady increase year after year. There was a slight
-                            falling off in 1902 in consequence, no doubt, of the bad season that
-                            year, but with this exception the increase has been steady, and whereas
-                            in 1899 the number of visitors was 43,567, in 1904 it reached 64,711,
-                            the gate receipts amounting to LE. 1,388.150. December, February,and
-                            March wore the months that brought in</p>
-                        <p>most visitors and gate money, June and August being those in which the
-                            gardens were least frequented. The accounts for the year showed a useful
-                            credit balance of L.E. 189.848, an increase of L.E. 80.288 on the
-                            previous year's figures, although rather considerable new building,
-                            joining and repairing work had to be undertaken. The result shows
-                            clearly enoug that the present director's abilities are not by any means
-                            confined to administration and natural history.</p>
-                        <p>Deaths among the animals, birds and reptiles—not including in the
-                            casualty list the results of the raids of foxes, wild cats, etc. or
-                            purely accidental fatalities—totalled 267 against 235 in the previous
-                            year; the winter mouths November and December, which were marked by
-                            outbreaks of influenza and dengue among human beings at <placeName
-                                ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> , being
-                            exceptionally severe. There were some important departures and deaths to
-                            chronicle, Lord Kitchener’s giraffe dying, and the two Indian elephants
-                            being sent off to Europe; while the champauzee presented by the Sirdar,
-                            which has since unfortunately died, the pair of zebras, the sacred shrew
-                            and sacred ibis, and the giraffe and other animals from the Sudan all
-                            deserve mention among the numerous new arrivals. The note on the
-                            aquarium is most interesting, containing, as it does, evidence of close
-                            personal observation of the various species of Nile fish kept in
-                            captivity there, and Dr. Franz Werner of the University of Vienna has
-                            sent a list of the grasshoppers and kindred insects to be found in the
-                            Gardens which, should interest entomologists.</p>
+                        <p>The sixth annual report by the director of the Ghizeh Zoological Gardens affords most interesting reading. It seems to be complete in every detail, even to the noting that "one Egyptian pound (L.E. 1) equals ₤l.0s.61/4d. or 25 francs and 92 centimes.” We may be sure that after the precision shown in this matter we may rely upon the other statements in the report being equally exact</p>
+                        <p>Passing over the details as to the staff, which seems to he selected with a view to complete efficiency, not only as regard the animals, but also for the upkeep of the ornamental grounds, we notice that the number of visitors shows a steady increase year after year. There was a slight falling off in 1902 in consequence, no doubt, of the bad season that year, but with this exception the increase has been steady, and whereas in 1899 the number of visitors was 43,567, in 1904 it reached 64,711, the gate receipts amounting to LE. 1,388.150. December, February,and March wore the months that brought in</p>
+                        <p>most visitors and gate money, June and August being those in which the gardens were least frequented. The accounts for the year showed a useful credit balance of L.E. 189.848, an increase of L.E. 80.288 on the previous year's figures, although rather considerable new building, joining and repairing work had to be undertaken. The result shows clearly enoug that the present director's abilities are not by any means confined to administration and natural history.</p>
+                        <p>Deaths among the animals, birds and reptiles—not including in the casualty list the results of the raids of foxes, wild cats, etc. or purely accidental fatalities—totalled 267 against 235 in the previous year; the winter mouths November and December, which were marked by outbreaks of influenza and dengue among human beings at <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> , being exceptionally severe. There were some important departures and deaths to chronicle, Lord Kitchener’s giraffe dying, and the two Indian elephants being sent off to Europe; while the champauzee presented by the Sirdar, which has since unfortunately died, the pair of zebras, the sacred shrew and sacred ibis, and the giraffe and other animals from the Sudan all deserve mention among the numerous new arrivals. The note on the aquarium is most interesting, containing, as it does, evidence of close personal observation of the various species of Nile fish kept in
+                            captivity there, and Dr. Franz Werner of the University of Vienna has sent a list of the grasshoppers and kindred insects to be found in the Gardens which, should interest entomologists.</p>
                     </div>
                     <div type="article">
                         <head>THE KHEDIVE.</head>
-                        <p>H.H. the Khedive has graciously consented to open the Mansourah
-                            Agricultural show on Friday, the 20th inst., and daring his stay will be
-                            the guest of the Municipality.</p>
+                        <p>H.H. the Khedive has graciously consented to open the Mansourah Agricultural show on Friday, the 20th inst., and daring his stay will be the guest of the Municipality.</p>
                     </div>
                     <div type="article">
                         <head>FRANCE AND GERMANY.</head>
                         <head>RECEPTION OF BUELOW'S STATEMENTS</head>
-                        <byline>(From our <placeName ref="https://www.wikidata.org/wiki/Q84"
-                                >London</placeName> Correspondent).</byline>
+                        <byline>(From our <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> Correspondent).</byline>
                         <byline>(By Telegraph).</byline>
-                        <dateline><placeName ref="https://www.wikidata.org/wiki/Q84"
-                                >London</placeName>, <date value="1905-10-06"
-                            >Friday</date>.</dateline>
-                        <p>The <placeName ref="https://www.wikidata.org/wiki/Q90">Paris</placeName>
-                            Press shows a bitter unanimity in its reception of the proposals of
-                            Prince von Buelow as to a Franco-German alliance. Even a rapprochement
-                            between France and Germany would, it is declared, be highly distasteful
-                            to the French people, which has not forgotten the loss of Alsace and
-                            Lorraine. Any attempt to reduce France to the position of a submissive
-                            ally of the German Empire is certainly doomed to failure, whether brute
-                            force or diplomatic persuasion be employed. Prince. von Buelow's
-                            suggestions, in whatever spirit they may have been concived, are roundly
-                            declared to be as tactless as they are provocative. "They add insult to
-                            injury.” — Such is the opinion of the general French public.</p>
+                        <dateline><placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName>, <date when="1905-10-06">Friday</date>.</dateline>
+                        <p>The <placeName ref="https://www.wikidata.org/wiki/Q90">Paris</placeName> Press shows a bitter unanimity in its reception of the proposals of Prince von Buelow as to a Franco-German alliance. Even a rapprochement between France and Germany would, it is declared, be highly distasteful to the French people, which has not forgotten the loss of Alsace and Lorraine. Any attempt to reduce France to the position of a submissive ally of the German Empire is certainly doomed to failure, whether brute force or diplomatic persuasion be employed. Prince. von Buelow's suggestions, in whatever spirit they may have been concived, are roundly declared to be as tactless as they are provocative. "They add insult to injury.” — Such is the opinion of the general French public.</p>
                     </div>
                     <div type="article">
                         <head>THE SUCRERIES.</head>
-                        <p>Sir William Willcocks leaves to-day for Upper Egypt, where he will visit
-                            the Sucreries Company's factories and will be followed later by MM.
-                            Fourneron and Sampaulo, whose report will be given to the public on the
-                            18th inst. On their return from Upper <placeName
-                                ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName> they will
-                            draw up a report in combination with Sir William Willcocks, which will
-                            state the exact condition and value of the factories.</p>
+                        <p>Sir William Willcocks leaves to-day for Upper Egypt, where he will visit the Sucreries Company's factories and will be followed later by MM. Fourneron and Sampaulo, whose report will be given to the public on the 18th inst. On their return from Upper <placeName ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName> they will draw up a report in combination with Sir William Willcocks, which will state the exact condition and value of the factories.</p>
                     </div>
                     <div type="article">
                         <head>CREDIT FONCIER EGYPTIEN.</head>
-                        <p>Nothing is known at the offices of the Credit Foncier in <placeName
-                                ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> regarding
-                            the rumor published by some of the local papers of the retirement of Mr.
-                            Beyerle, the managing director. On the contrary in the last letters
-                            received from this gentleman, who is now in <placeName
-                                ref="https://www.wikidata.org/wiki/Q90">Paris</placeName>, he
-                            mentions his intention of returning at the end of this month to resume
-                            his post.</p>
-                        <p>We may add that on the death of his wife a few months back Mr. Beyerle
-                            wished to resign but was requested to reconsider his decision, at d, on
-                            the solicitaiton of his colleagues on the board, be decided to retan his
-                            appointment.</p>
+                        <p>Nothing is known at the offices of the Credit Foncier in <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> regarding the rumor published by some of the local papers of the retirement of Mr. Beyerle, the managing director. On the contrary in the last letters received from this gentleman, who is now in <placeName ref="https://www.wikidata.org/wiki/Q90">Paris</placeName>, he mentions his intention of returning at the end of this month to resume his post.</p>
+                        <p>We may add that on the death of his wife a few months back Mr. Beyerle wished to resign but was requested to reconsider his decision, at d, on the solicitaiton of his colleagues on the board, be decided to retan his appointment.</p>
                     </div>
                     <div type="article">
                         <head>KHEDIVIAL YACHT CLUB.</head>
-                        <p>There will be an extra regatta held on Friday in honor of the visit of H.
-                            H. the Khedive to the yacht club. The weekly regatta will be held on
-                            Wednesday as usual.</p>
+                        <p>There will be an extra regatta held on Friday in honor of the visit of H. H. the Khedive to the yacht club. The weekly regatta will be held on Wednesday as usual.</p>
                     </div>
                     <div type="article">
                         <head>STEAMER MOVEMENTS.</head>
-                        <p>The Moss liner Rameses sailed from. <placeName
-                                ref="https://www.wikidata.org/wiki/Q233">Malta</placeName> yesterday
-                            afternoon and is due at <placeName
-                                ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> on
-                            Tuesday with passengers, mails, and general cargo.</p>
+                        <p>The Moss liner Rameses sailed from. <placeName ref="https://www.wikidata.org/wiki/Q233">Malta</placeName> yesterday afternoon and is due at <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> on Tuesday with passengers, mails, and general cargo.</p>
                     </div>
                 </div>
                 <div type="section">
-                    <head>NOTES FROM <placeName ref="https://www.wikidata.org/wiki/Q134514"
-                            >Suez</placeName>.</head>
+                    <head>NOTES FROM <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>.</head>
                     <div type="article">
                         <head>SHIPS ENTER THE CANAL.</head>
                         <byline>(From our Correspondent).</byline>
-                        <dateline><placeName ref="https://www.wikidata.org/wiki/Q134514"
-                                >Suez</placeName>, <date value="1905-10-06"
-                            >Friday</date>.</dateline>
-                        <p>Till this morning at 8 o’clock, 42 vessels were anchored in the
-                                <placeName ref="https://www.wikidata.org/wiki/Q134514"
-                                >Suez</placeName> roads, and the first steamer to enter the Canal
-                            was the S.S. Clan Ogilvy, which proceeded at 10 am., and was
-                            subsequently followed by 10 more vessels. Some of the remaining steamers
-                            will enter tomorrow morning, and the next divisions on Sunday and
-                            Monday. The S.S. Durham Castle will enter the canal with the fourth
-                            division of steamers, and some of the members of the British Association
-                            have returned to <placeName ref="https://www.wikidata.org/wiki/Q134514"
-                                >Suez</placeName> from <placeName
-                                ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> .</p>
+                        <dateline><placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>, <date when="1905-10-06">Friday</date>.</dateline>
+                        <p>Till this morning at 8 o’clock, 42 vessels were anchored in the <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName> roads, and the first steamer to enter the Canal was the S.S. Clan Ogilvy, which proceeded at 10 am., and was subsequently followed by 10 more vessels. Some of the remaining steamers will enter tomorrow morning, and the next divisions on Sunday and Monday. The S.S. Durham Castle will enter the canal with the fourth division of steamers, and some of the members of the British Association have returned to <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName> from <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> .</p>
                     </div>
                     <div type="article">
                         <head>THE S.S. NUBIA.</head>
-                        <p>The Anchor liner Nubia, which is ashore at Ras Shouhair in the <placeName
-                                ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName> Gulf,
-                            is expected to to be refloated shortly. The Khedivial mail liners Fayoum
-                            and Calioubieh are taking in cargo from the stranded vessel, and up to
-                            now over 1,200 tons have been discharged. The coustguard cruiser Noor el
-                            Bahr is standing by the Nubia guarding the coast for fear of the
-                            Bedouins pillaging the cargo.</p>
+                        <p>The Anchor liner Nubia, which is ashore at Ras Shouhair in the <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName> Gulf, is expected to to be refloated shortly. The Khedivial mail liners Fayoum and Calioubieh are taking in cargo from the stranded vessel, and up to now over 1,200 tons have been discharged. The coustguard cruiser Noor el Bahr is standing by the Nubia guarding the coast for fear of the Bedouins pillaging the cargo.</p>
                     </div>
                     <div type="article">
                         <head>THE BRITISH ASSOCIATION.</head>
                         <byline>(From Another Correspondent.)</byline>
-                        <dateline>Port Tewfik, <date value="1905-10-05">Thursday</date>.</dateline>
-                        <p>As I telegraphed yon yesterday the Durham Castle, one of the famous
-                            Castle liners, arrived here with the members of the British Association
-                            on board, in all about 200 persons. Many of the members ware visiting
-                                <placeName ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName>
-                            for the first time and were very eager to have a few days stay but
-                            several of the Professors have to be home by the 18th inst. as they have
-                            engagements to fulfil at Oxford and Cambridge, the term commencing soon,
-                            and should the canal remain blocked they intend going via <placeName
-                                ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName>
-                            by the M.M. mail boat from <placeName
-                                ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>.</p>
+                        <dateline>Port Tewfik, <date when="1905-10-05">Thursday</date>.</dateline>
+                        <p>As I telegraphed yon yesterday the Durham Castle, one of the famous Castle liners, arrived here with the members of the British Association on board, in all about 200 persons. Many of the members ware visiting <placeName ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName> for the first time and were very eager to have a few days stay but several of the Professors have to be home by the 18th inst. as they have engagements to fulfil at Oxford and Cambridge, the term commencing soon, and should the canal remain blocked they intend going via <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName> by the M.M. mail boat from <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>.</p>
                     </div>
                     <div type="article">
-                        <head>THE BLOCK AT <placeName ref="https://www.wikidata.org/wiki/Q134514"
-                                >Suez</placeName>.</head>
-                        <p>The block in the canal traffic is beginning to show at this end. There
-                            are now over 40 large steamers in the hay including several liners,
-                            notably the P. &amp; 0., Carman mail, Dutch mail, Spanish mail from
-                            Manilla, Bibby liner, three Clan liners, Durham Castle and many other
-                            regular traders, but there is still plenty of room, as the magnificent
-                            bay could easily accomodate 200 or upward. Strangers arriving at night
-                            generally anchor far off as they are unable to find their way to a good
-                            anchorage before daylight The bay has a very fine appearance at night
-                            when all the ships are lit up and many residents take a trip round the
-                            ships in a steam launch in the cool of the</p>
-                        <p>Officizl notice was given yesterday that traffic was to be resumed but
-                            was cancelled late in the evening, and it is now rumoured that no
-                            movement will take place here till Sunday as the ships in <placeName
-                                ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>
-                            will come through first so as avoid too much crossing in the canal and
-                            consequent danger of colliding.</p>
+                        <head>THE BLOCK AT <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>.</head>
+                        <p>The block in the canal traffic is beginning to show at this end. There are now over 40 large steamers in the hay including several liners, notably the P. &amp; 0., Carman mail, Dutch mail, Spanish mail from Manilla, Bibby liner, three Clan liners, Durham Castle and many other regular traders, but there is still plenty of room, as the magnificent bay could easily accomodate 200 or upward. Strangers arriving at night generally anchor far off as they are unable to find their way to a good anchorage before daylight The bay has a very fine appearance at night when all the ships are lit up and many residents take a trip round the ships in a steam launch in the cool of the</p>
+                        <p>Officizl notice was given yesterday that traffic was to be resumed but was cancelled late in the evening, and it is now rumoured that no movement will take place here till Sunday as the ships in <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> will come through first so as avoid too much crossing in the canal and consequent danger of colliding.</p>
                     </div>
                     <div type="article">
                         <head>HARBOUR NOTES</head>
                         <byline>( From our Correspondent. )</byline>
-                        <dateline><placeName ref="https://www.wikidata.org/wiki/Q134509">Port
-                                Said</placeName>, <date value="1905-10-05"
-                            >Thursday</date>.</dateline>
-                        <p>In continuation of my notes sent yon yesterday, I have thought it might
-                            be interesting to your readers to see a list of the numerous vessels
-                            which are at present lying at <placeName
-                                ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>
-                            and <placeName ref="https://www.wikidata.org/wiki/Q134514"
-                                >Suez</placeName> awaiting more or less impatiently the restarting
-                            of traffic, which I hear now (2 p.m.) may occur on Sunday :—</p>
-                        <q>Arrived at <placeName ref="https://www.wikidata.org/wiki/Q134509">Port
-                                Said</placeName>, 27th ult Ping Suey; 28th ult Rugia, Menelaus,
-                            Avooa, Mahratta, Merton Hall; 29th ult. Staads Kratke, Persia (Anchor),
-                            Weissenfels, Langdale; 80th ult Statesman, Oxus; 1st inst Ataka, Buda,
-                            Sicilia (transport), Dunolly; 2nd inst Yana, Siam, Palermo, Sachsen,
-                            Arabistan ; 3rd inst Goentor, Flores, Africa, Nubia, Persia; 4th inst
-                            Wartenfels, Arracan, Hector, City of Athens, Nippoon, City of Madras;
-                            5th inst Bohemia, Atholl, Engineer Civdakoff; Omrah, Assouan: Arrived at
-                                <placeName ref="https://www.wikidata.org/wiki/Q134514"
-                                >Suez</placeName> Roads 27th ult City of Manchester, Clan Campbell,
-                            Oriel, Orselo, Irrawaddi; 28th alt Clan Ogilvie, Aberlour, Forestdale,
-                            Langoe ; 29th ult Coquet, Clan Mackinnon, Isla de Panay ; 80th ult
-                            Trentham Hall, Ras Elba, Acacia, Tebe, Vindobona, Malaoca, Alladin,
-                            Fulwell; 1st inst. Emile; 2nd inst. Matiana, Adm. L. Treville, Victoria,
-                            Britannia, Rocklight; 3rd inst. Umbilo, Warwickshire, Turkistan, Korena
-                            ; 4th inst City of Karachi, Durham Castle, City of Benares, Kanzler,
-                            Kybfels, Yeddo; 5th inst Prinz Hendrik, Sumatra, Ixion, Avals. That is
-                            to say, that exclusive of the nine colliers discharging here now, and
-                            the</q>
+                        <dateline><placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>, <date when="1905-10-05">Thursday</date>.</dateline>
+                        <p>In continuation of my notes sent yon yesterday, I have thought it might be interesting to your readers to see a list of the numerous vessels which are at present lying at <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> and <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName> awaiting more or less impatiently the restarting of traffic, which I hear now (2 p.m.) may occur on Sunday :—</p>
+                        <q>Arrived at <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>, 27th ult Ping Suey; 28th ult Rugia, Menelaus, Avooa, Mahratta, Merton Hall; 29th ult. Staads Kratke, Persia (Anchor), Weissenfels, Langdale; 80th ult Statesman, Oxus; 1st inst Ataka, Buda, Sicilia (transport), Dunolly; 2nd inst Yana, Siam, Palermo, Sachsen, Arabistan ; 3rd inst Goentor, Flores, Africa, Nubia, Persia; 4th inst Wartenfels, Arracan, Hector, City of Athens, Nippoon, City of Madras; 5th inst Bohemia, Atholl, Engineer Civdakoff; Omrah, Assouan: Arrived at <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName> Roads 27th ult City of Manchester, Clan Campbell, Oriel, Orselo, Irrawaddi; 28th alt Clan Ogilvie, Aberlour, Forestdale, Langoe ; 29th ult Coquet, Clan Mackinnon, Isla de Panay ; 80th ult Trentham Hall, Ras Elba, Acacia, Tebe, Vindobona, Malaoca, Alladin, Fulwell; 1st inst. Emile; 2nd inst. Matiana, Adm. L. Treville, Victoria, Britannia,
+                            Rocklight; 3rd inst. Umbilo, Warwickshire, Turkistan, Korena ; 4th inst City of Karachi, Durham Castle, City of Benares, Kanzler, Kybfels, Yeddo; 5th inst Prinz Hendrik, Sumatra, Ixion, Avals. That is to say, that exclusive of the nine colliers discharging here now, and the</q>
                         <!-- TODO find the truncated part of this note -->
                     </div>
                     <div type="article">
                         <head>ENGLISH CHURCH IN KHARTOUM.</head>
-                        <p>The "Standard” has received the following letter from Sir Reginald
-                            Wingate Pasha appealing for funds for the construction an English Church
-                            at Khartoum :—</p>
+                        <p>The "Standard” has received the following letter from Sir Reginald Wingate Pasha appealing for funds for the construction an English Church at Khartoum :—</p>
+                        <!-- 
                         <quotedLetter>
                             <opener>
                                 <salute>Sir,</salute>
                             </opener>
-                            <p>I should esteem it a great favour to be allowed to make an appeal to
-                                the readers of your valuable paper on behalf of an English Church in
-                                Khartoum. Designs and plans for the building are under the
-                                consideration of the Church Committee, and is hoped the work of
-                                construction will be commenced in the autumn of this year. The
-                                estimated cost is £7000, and towards this amount £3000 have already
-                                been raised, almost entirely by local subscriptions. The Government
-                                has provided an excellent site, close to the Gordon Statue, where
-                                the foundation stone of the chuchh was laid by Prinoess Henry of
-                                Battenberg on her visit last year.</p>
-                            <p>The Rev. L. Gwynne has been appointed Archdeacon of the Sudan by the
-                                Bishop in Jerusalem, and he is now organising our church work with a
-                                view to providing service for our rapidly increasing population, not
-                                only at Khartoum, but also in the outlying station, such as Suakin,
-                                Wady Haifa, and Shendi.</p>
-                            <p>The generosity of the British officials and residents in the Sudan
-                                will be taxed to the utmost to provide chaplains, and to build
-                                churches necessary for these far-scattered stations. Therefore, in
-                                order to rect a building at Kharatoum worthy of our Church and
-                                nation, we are forced to ask help from those at home.</p>
-                            <p>Other communions are making progress with their churches. The aged
-                                Patriarch of the Coptic Church in <placeName
-                                    ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName> set a
-                                noble example by undertaking a prolonged and arduous journey up the
-                                Nile, daring which he collected some £1000 for the building of a
-                                chuch in Khartoum, the foundation stone of which he laid on his
-                                arrival, and now the edifice is approaching completion. The Roman
-                                Church has already a suffient sum for its proposed cathedral, whilst
-                                a very handsome mosque has been constructed at a cost of over
-                                £13,000.</p>
-                            <p>We, therefore, more earnestly ask for the generosity and sympathy of
-                                our people at home to enable us to complete the building of our
-                                church in Khartonm,</p>
-                            <p>Subscriptions will be recieved and acknowledged by A. Dyke Acland,
-                                Eq., 186 Strand, W.C. Cheques should be crossed Bank of Egypt, and
-                                made payable to the "Khartonm English Church Fund."</p>
+                            <p>I should esteem it a great favour to be allowed to make an appeal to the readers of your valuable paper on behalf of an English Church in Khartoum. Designs and plans for the building are under the consideration of the Church Committee, and is hoped the work of construction will be commenced in the autumn of this year. The estimated cost is £7000, and towards this amount £3000 have already been raised, almost entirely by local subscriptions. The Government has provided an excellent site, close to the Gordon Statue, where the foundation stone of the chuchh was laid by Prinoess Henry of Battenberg on her visit last year.</p>
+                            <p>The Rev. L. Gwynne has been appointed Archdeacon of the Sudan by the Bishop in Jerusalem, and he is now organising our church work with a view to providing service for our rapidly increasing population, not only at Khartoum, but also in the outlying station, such as Suakin, Wady Haifa, and Shendi.</p>
+                            <p>The generosity of the British officials and residents in the Sudan will be taxed to the utmost to provide chaplains, and to build churches necessary for these far-scattered stations. Therefore, in order to rect a building at Kharatoum worthy of our Church and nation, we are forced to ask help from those at home.</p>
+                            <p>Other communions are making progress with their churches. The aged Patriarch of the Coptic Church in <placeName ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName> set a noble example by undertaking a prolonged and arduous journey up the Nile, daring which he collected some £1000 for the building of a chuch in Khartoum, the foundation stone of which he laid on his arrival, and now the edifice is approaching completion. The Roman Church has already a suffient sum for its proposed cathedral, whilst a very handsome mosque has been constructed at a cost of over £13,000.</p>
+                            <p>We, therefore, more earnestly ask for the generosity and sympathy of our people at home to enable us to complete the building of our church in Khartonm,</p>
+                            <p>Subscriptions will be recieved and acknowledged by A. Dyke Acland, Eq., 186 Strand, W.C. Cheques should be crossed Bank of Egypt, and made payable to the "Khartonm English Church Fund."</p>
                             <closer>
                                 <salute>I am, Sir, your obedient servant</salute>
                                 <signed>(Signed) REGINALD WINGATE</signed>
                             </closer>
                         </quotedLetter>
+                        -->
                     </div>
                 </div>
                 <div type="section">
-                    <head>NOTES FROM <placeName ref="https://www.wikidata.org/wiki/Q134509">Port
-                            Said</placeName>.</head>
+                    <head>NOTES FROM <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>.</head>
                     <div type="article">
-                        <p>Less regularly, we have now 37 steamers in the harbour of <placeName
-                                ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>
-                            and 40 at anchor in <placeName
-                                ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>
-                            Roads.</p>
-                        <p>Roughly speaking there are 1,700 passengers delayed either here or at
-                                <placeName ref="https://www.wikidata.org/wiki/Q134514"
-                                >Suez</placeName>, and at tie lowest computation some 231,000 tons
-                            of cargo and one of the large British <placeName
-                                ref="https://www.wikidata.org/wiki/Q668">India</placeName> turret
-                            ships having 12,500 tons of cargo on board, is expected to-day. A fair
-                            estimate of probable arrivals between now and Sunday will be five ships
-                            at each end per day, say at least 25 mail vessels by Sunday morning,
-                            which will bring up the number of waiting ships to about a hundred and
-                            five. In <placeName ref="https://www.wikidata.org/wiki/Q134509">Port
-                                Said</placeName> harbour practically every possible good berth is
-                            occupied and in many oases, on the main buoys, there are two ships
-                            lying. The Dutch Basin which so far has been used solely for men-of-war
-                            has five ships in it The berth "No. 6 Black" has five ships at anchor
-                            where one usually lies. The Yam and Oxus lie side by side, as do also
-                            the Melenaus and hector; in fact, ships are everywhere, and I think I
-                            may safely say, never before has <placeName
-                                ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>
-                            seen such a sight</p>
+                        <p>Less regularly, we have now 37 steamers in the harbour of <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> and 40 at anchor in <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName> Roads.</p>
+                        <p>Roughly speaking there are 1,700 passengers delayed either here or at <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>, and at tie lowest computation some 231,000 tons of cargo and one of the large British <placeName ref="https://www.wikidata.org/wiki/Q668">India</placeName> turret ships having 12,500 tons of cargo on board, is expected to-day. A fair estimate of probable arrivals between now and Sunday will be five ships at each end per day, say at least 25 mail vessels by Sunday morning, which will bring up the number of waiting ships to about a hundred and five. In <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> harbour practically every possible good berth is occupied and in many oases, on the main buoys, there are two ships lying. The Dutch Basin which so far has been used solely for men-of-war has five ships in it The berth "No. 6 Black" has five ships at anchor where one usually lies. The Yam and Oxus
+                            lie side by side, as do also the Melenaus and hector; in fact, ships are everywhere, and I think I may safely say, never before has <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> seen such a sight</p>
                     </div>
                     <div type="article">
                         <head>CANAL TRAFFIC RESUMED.</head>
                         <byline>(By Telegraph)</byline>
-                        <p><placeName ref="https://www.wikidata.org/wiki/Q134509">Port
-                                Said</placeName>, Saturday, 6.16 a.m. The mail steamers Tourane,
-                            Nippon, Omrah, Wartenfele, Africa, Goentor, Oxus, Sachsen. Yarra,
-                            Staads-Kratka, and Persia will enter the canal at eight o'clock this
-                            morning, and will tie up north of Ras el Esh, and fifteen more will
-                            follow this afternoon. Eleven steamers have entered from <placeName
-                                ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName> and
-                            anchored at Ismailia, and fourteen more will go as far the Bitter Lakes
-                            to-day. Full traffic There are forty-six vessels here and the number at
-                                <placeName ref="https://www.wikidata.org/wiki/Q134514"
-                                >Suez</placeName>.</p>
+                        <p><placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>, Saturday, 6.16 a.m. The mail steamers Tourane, Nippon, Omrah, Wartenfele, Africa, Goentor, Oxus, Sachsen. Yarra, Staads-Kratka, and Persia will enter the canal at eight o'clock this morning, and will tie up north of Ras el Esh, and fifteen more will follow this afternoon. Eleven steamers have entered from <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName> and anchored at Ismailia, and fourteen more will go as far the Bitter Lakes to-day. Full traffic There are forty-six vessels here and the number at <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>.</p>
                     </div>
                     <div type="article">
-                        <head>AT KILOMETRE 18.4 Work goes on in the chiefs and everyone are more
-                            than hard at work, pieces of plate and frame are coutinually being found
-                            and recovered and several have been broken up by small mines under the
-                            supervision of the engineers’ staff assistants advised by Mr. Harris.
-                            Bands of Arabs busy collecting and transporting the smaller pieces in
-                            lighters to <placeName ref="https://www.wikidata.org/wiki/Q134509">Port
-                                Said</placeName> while the dredgers are cutting out the main channel
-                            in the wake of crane". M. Schmitt has been down to the spot examining
-                            the bank and channel, which, I believe, will have a temporary width of
-                            30 yards and a depth of 27 feet</head>
+                        <head>AT KILOMETRE 18.4 Work goes on in the chiefs and everyone are more than hard at work, pieces of plate and frame are coutinually being found and recovered and several have been broken up by small mines under the supervision of the engineers’ staff assistants advised by Mr. Harris. Bands of Arabs busy collecting and transporting the smaller pieces in lighters to <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> while the dredgers are cutting out the main channel in the wake of crane". M. Schmitt has been down to the spot examining the bank and channel, which, I believe, will have a temporary width of 30 yards and a depth of 27 feet</head>
                     </div>
                     <div type="article">
                         <head>DEPARTURE OP M. COULLANT.</head>
-                        <p>M. Conllant, the Canal Company's chief agent at <placeName
-                                ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>,
-                            (who by the way succeeds M. Tillier as chef de service in the coming
-                            year) left last night for France in the M.M. Senegal. M- Coallant
-                            arrived hare by the Brindisi mail in company with Mr. Harris and bis two
-                            assistants in order to form the commission which eventually decided the
-                            fate of the unfortunate Chatham.</p>
+                        <p>M. Conllant, the Canal Company's chief agent at <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>, (who by the way succeeds M. Tillier as chef de service in the coming year) left last night for France in the M.M. Senegal. M- Coallant arrived hare by the Brindisi mail in company with Mr. Harris and bis two assistants in order to form the commission which eventually decided the fate of the unfortunate Chatham.</p>
                     </div>
                 </div>
                 <div type="article">
                     <!-- TODO Replace with ad boilerplate -->
                     <head>BECK &amp; GO'S PILSENER BEER</head>
-                    <p><unclear>OMalaakla frum *r*nr R*M*itatl* fIra</unclear> In <placeName
-                            ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> , <placeName
-                            ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>, &amp;
-                        the Sudan. Otherwise apply too <unclear>. j ntwnn. r. wcauii</unclear></p>
+                    <p><unclear>OMalaakla frum *r*nr R*M*itatl* fIra</unclear> In <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> , <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>, &amp; the Sudan. Otherwise apply too <unclear>. j ntwnn. r. wcauii</unclear></p>
                 </div>
-                <div type="article">
+                <div type="article"><!-- TODO Replace with Ad boilerplate-->
                     <head>Anglo American Nile Steamers &amp; hotel company.</head>
                     <p>Three Saillage a-Week</p>
-                    <ad/>
                 </div>
                 <div type="article">
                     <head>CURONIQUE FINANCIERE</head>
-                    <dateline>Vendredi <date value="1905-10-06">6 Octobre</date>.</dateline>
-                    <p>Il y a Peru de choses à ajouter à ce que none avons dit dans notre dernière
-                        chronique concernant la pénurie de numéaire, l'élévation du taux d’escompte,
-                        les veraement à opérer t' es liquidations de fin du mois, sinou que l'effet
-                        déprimant de ces divers facteurs semble dev i subsister quelques jours
-                        encore sur notre marché.</p>
-                    <p>Durant la semaine qui vient de s'écouler la cots a subi une baisse presque
-                        générale, bien qu'une certaine animation n'ait cassé de prévaloir. Dés lundi
-                        las cours fléchissent et aprés un semblant de reprise mercredi la réaction
-                        ne fait que s'accentuer jusqu'à la clôture d'ajour-d'hui.</p>
-                    <p>Quant aux transactions, alias n'ont au de réelle importance qu'en National
-                        Bank, au Agricole et en Nungovich.</p>
-                    <p>Le Consiel d’Administration de la D ïra Sa nieh s'est réuni jeudi à la
-                        National Bank et a décidé le paiement à la date du 16 courant de £10 par
-                        action et de £78 par part de fondateur. Quelques jours aprés, le 30 courant,
-                        auront lieu les plaidoireries de l'affaire, des princes de la famille
-                        Khédiviale. Bn attendant le cours de la Dura perd 1/8 comme résumé de la
-                        semaine et clôture à 28.</p>
-                    <p>Le capital de £500.000 de 1’Anglo-Egyptian Land Allotment Co., (dont Sir W.
-                        Wilcocks est le président) a été plus que couvert. Un tiers des actions sera
-                        néanmoins offert en souscription publique afin d'obtenir la cotation
-                        officielle. Les promoteurs de l’affaire n'ayont pas touché da rénumération
-                        pécuniaire, il a été créé poor let dédommagsr, an certain, nombre de ports
-                        de fondateurs. Les actions auront droit à un dividende cumulatif de 4 % et
-                        le surplus des bénéfices sera divité entre les parts de fondateurs 30 pour
-                        cent et les actions 70 pour cent.</p>
-                    <p>Aux Sucreries la situation ne s’est pas améliorée: le cours a meme fléchi
-                        d'une façon sensible mais purs reprendre en clôture à 43. Le rapport des
-                        experts qui a paru le 4 courant n'est pas pour rassurer let actionnaires: on
-                        y voit, en effet, que les exercise éjaulés ce soldent tous par das pertes
-                        croisssantes variant de 2000 à 120000 Livres; ces pertes étaient combléas
-                        par an compte annuel d'arbitrages envoyé de <placeName
-                            ref="https://www.wikidata.org/wiki/Q90">Paris</placeName> par Crouier et
-                        dounant un bénéfice suffisant pour distribuer un dividende et laisser un
-                        reliquat.</p>
-                    <p>Le prolongement à bréva échéance du Nubarieh dont on a beaucoup parlé
-                        deraiérement vient d’etre officiallement démenti, Ce travail a été renvoyé à
-                        une date indéterminée et le Gouvernement a suspendu la vents de ses terrains
-                        dans la région intéressée attendant d'étre fixé sur ce point</p>
-                    <p>Une nouvelle banque va incessamment etre laucée ici sous le nom de Egyptian
-                        Bank of Commerce. Son capital est firé à £500000 et conseil d'administration
-                        figurent les noms de plusieurs grands financiers <placeName
-                            ref="https://www.wikidata.org/wiki/Q84">London</placeName>ians.</p>
+                    <dateline>Vendredi <date when="1905-10-06">6 Octobre</date>.</dateline>
+                    <p>Il y a Peru de choses à ajouter à ce que none avons dit dans notre dernière chronique concernant la pénurie de numéaire, l'élévation du taux d’escompte, les veraement à opérer t' es liquidations de fin du mois, sinou que l'effet déprimant de ces divers facteurs semble dev i subsister quelques jours encore sur notre marché.</p>
+                    <p>Durant la semaine qui vient de s'écouler la cots a subi une baisse presque générale, bien qu'une certaine animation n'ait cassé de prévaloir. Dés lundi las cours fléchissent et aprés un semblant de reprise mercredi la réaction ne fait que s'accentuer jusqu'à la clôture d'ajour-d'hui.</p>
+                    <p>Quant aux transactions, alias n'ont au de réelle importance qu'en National Bank, au Agricole et en Nungovich.</p>
+                    <p>Le Consiel d’Administration de la D ïra Sa nieh s'est réuni jeudi à la National Bank et a décidé le paiement à la date du 16 courant de £10 par action et de £78 par part de fondateur. Quelques jours aprés, le 30 courant, auront lieu les plaidoireries de l'affaire, des princes de la famille Khédiviale. Bn attendant le cours de la Dura perd 1/8 comme résumé de la semaine et clôture à 28.</p>
+                    <p>Le capital de £500.000 de 1’Anglo-Egyptian Land Allotment Co., (dont Sir W. Wilcocks est le président) a été plus que couvert. Un tiers des actions sera néanmoins offert en souscription publique afin d'obtenir la cotation officielle. Les promoteurs de l’affaire n'ayont pas touché da rénumération pécuniaire, il a été créé poor let dédommagsr, an certain, nombre de ports de fondateurs. Les actions auront droit à un dividende cumulatif de 4 % et le surplus des bénéfices sera divité entre les parts de fondateurs 30 pour cent et les actions 70 pour cent.</p>
+                    <p>Aux Sucreries la situation ne s’est pas améliorée: le cours a meme fléchi d'une façon sensible mais purs reprendre en clôture à 43. Le rapport des experts qui a paru le 4 courant n'est pas pour rassurer let actionnaires: on y voit, en effet, que les exercise éjaulés ce soldent tous par das pertes croisssantes variant de 2000 à 120000 Livres; ces pertes étaient combléas par an compte annuel d'arbitrages envoyé de <placeName ref="https://www.wikidata.org/wiki/Q90">Paris</placeName> par Crouier et dounant un bénéfice suffisant pour distribuer un dividende et laisser un reliquat.</p>
+                    <p>Le prolongement à bréva échéance du Nubarieh dont on a beaucoup parlé deraiérement vient d’etre officiallement démenti, Ce travail a été renvoyé à une date indéterminée et le Gouvernement a suspendu la vents de ses terrains dans la région intéressée attendant d'étre fixé sur ce point</p>
+                    <p>Une nouvelle banque va incessamment etre laucée ici sous le nom de Egyptian Bank of Commerce. Son capital est firé à £500000 et conseil d'administration figurent les noms de plusieurs grands financiers <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName>ians.</p>
                     <p>Asset mouvementés au début, les Estates</p>
-                    <p>terminent avec une reaction totals de 1/32 à 1 7/32 acheteurs. Cette valeur
-                        sera désormais inscrite au Stock Exchange de Londres,</p>
-                    <p>L’Agrioole qui a été en grande faveur durant toute la semaine finit à 9 5/8,
-                        en gain de 3/16 sur le cours de vendredi dernier.</p>
-                    <p>Toot aussi animée, quo que en snes contraire, 1a National Bank clôture à 27
-                        3/16, en parts de 5/16.</p>
-                    <p>C'est la Nungovich qui a eu les honneurs de la semaine et le record de la
-                        bausse ces joursci; elle monte de 10 3/8 à 10 15/16. Le prix de 11 a meme
-                        été pratiqué pour le 15 courant.</p>
-                    <p>Ea hausse également les Tramways d'Alexandrie de 159 à 169 la Privilégiée et
-                        de 320 à 328 la Dividende, les Eaux du Caire de 1155 à 1160, la Béhéra de 42
-                        1/2 à 43, la Land Bank de 9 3/4 à 9 7/8, les Markets de 23 à 25/ 3, et la
-                        Banque d'Athènes de 188 8/4 à 135.</p>
+                    <p>terminent avec une reaction totals de 1/32 à 1 7/32 acheteurs. Cette valeur sera désormais inscrite au Stock Exchange de Londres,</p>
+                    <p>L’Agrioole qui a été en grande faveur durant toute la semaine finit à 9 5/8, en gain de 3/16 sur le cours de vendredi dernier.</p>
+                    <p>Toot aussi animée, quo que en snes contraire, 1a National Bank clôture à 27 3/16, en parts de 5/16.</p>
+                    <p>C'est la Nungovich qui a eu les honneurs de la semaine et le record de la bausse ces joursci; elle monte de 10 3/8 à 10 15/16. Le prix de 11 a meme été pratiqué pour le 15 courant.</p>
+                    <p>Ea hausse également les Tramways d'Alexandrie de 159 à 169 la Privilégiée et de 320 à 328 la Dividende, les Eaux du Caire de 1155 à 1160, la Béhéra de 42 1/2 à 43, la Land Bank de 9 3/4 à 9 7/8, les Markets de 23 à 25/ 3, et la Banque d'Athènes de 188 8/4 à 135.</p>
                     <p>La Delta Light fléchit de 18 1/4 à 13 1/16, sans beaucoup d_ff ires.</p>
                     <p>Contraiment aux Tramways, la Ramleh Railway tombe de 7 5/16 à 7 1/8.</p>
-                    <p>La Crown Brewery accuse une baisse de 5 francs sur la Privilégiés à 202 et de
-                        11 francs la Dividende à 1_0. Quant à la Brasserie des Pyramides, elle perd
-                        1 frano sur la Dividende et gagne 50 centimes sur la Privilégiée au cours
-                        respectifs de 62 et 125.</p>
-                    <p>Les Cotton Mills fléchissant de 6 à 5/9 et la Salt &amp; Soda de 33/9 à
-                        33/6.</p>
-                    <p>De 5 5/8 l'Anglo-American Nile recule à 5 9/16, la Delta Land de 2 9/16 à 2
-                        1/2, le Treat de 1 5/16 à 1 9/32 et l'Urbaine de 5 1/2 à 5 3/8.</p>
+                    <p>La Crown Brewery accuse une baisse de 5 francs sur la Privilégiés à 202 et de 11 francs la Dividende à 1_0. Quant à la Brasserie des Pyramides, elle perd 1 frano sur la Dividende et gagne 50 centimes sur la Privilégiée au cours respectifs de 62 et 125.</p>
+                    <p>Les Cotton Mills fléchissant de 6 à 5/9 et la Salt &amp; Soda de 33/9 à 33/6.</p>
+                    <p>De 5 5/8 l'Anglo-American Nile recule à 5 9/16, la Delta Land de 2 9/16 à 2 1/2, le Treat de 1 5/16 à 1 9/32 et l'Urbaine de 5 1/2 à 5 3/8.</p>
                     <p>(Aujourd'hui à midi et demis)</p>
-                    <p>Comme d’ordinaire le samedi, notre marché a éte à peu prés nul ce matin, soit
-                        comme variations dans la cote, soit comme transactions. Cependant, on
-                        constate une inclinasion vers la baisse, ce qui est du en partie aux motifs
-                        déjà exposes dans notre chronique, en partie à 1a fermeture de la corbeille
-                        lundi prochain, à l'occasion du Grand Jeûne Israélite.</p>
-                    <p>La National Bank est offerte au prix de 27 3/16, tandis que l'Agricole est
-                        demandés à 9 11/16.</p>
-                    <p>De 2 9/16 la Delta Land fléchit à 2 1/2 acheteurs et Daïra Sanieh de 28 à 27
-                        15/16 vendeurs. La Part de Fondateurs Daïra tombe également de 180 à
-                        178.</p>
+                    <p>Comme d’ordinaire le samedi, notre marché a éte à peu prés nul ce matin, soit comme variations dans la cote, soit comme transactions. Cependant, on constate une inclinasion vers la baisse, ce qui est du en partie aux motifs déjà exposes dans notre chronique, en partie à 1a fermeture de la corbeille lundi prochain, à l'occasion du Grand Jeûne Israélite.</p>
+                    <p>La National Bank est offerte au prix de 27 3/16, tandis que l'Agricole est demandés à 9 11/16.</p>
+                    <p>De 2 9/16 la Delta Land fléchit à 2 1/2 acheteurs et Daïra Sanieh de 28 à 27 15/16 vendeurs. La Part de Fondateurs Daïra tombe également de 180 à 178.</p>
                     <p>Par conre, la Filature estun pen plus ferms</p>
                     <p>Les Estates se font remarquer par leur formeté</p>
-                    <p>Tandis que la Privilégiée Tramways d'Alexandrie est offerts à 162, la
-                        Dividende est demandée à 332, au hausse de 4 francs sur le cours d'hier.</p>
+                    <p>Tandis que la Privilégiée Tramways d'Alexandrie est offerts à 162, la Dividende est demandée à 332, au hausse de 4 francs sur le cours d'hier.</p>
                     <p><unclear/>gouverment a une reprise vere le<unclear/></p>
                 </div>
             </div>

--- a/1905-10-07.xml
+++ b/1905-10-07.xml
@@ -30,24 +30,37 @@
         <body>
             <div type="page" n="1">
                 <head>THE EGYPTIAN GAZETTE</head>
-                <head type="sub">No. 7239] <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>, Saturday, October 7, 1905. [SIX PAGES P.T. 1.</head>
+                <head type="sub">No. 7239] <placeName ref="https://www.wikidata.org/wiki/Q87"
+                        >Alexandria</placeName>, Saturday, October 7, 1905. [SIX PAGES P.T.
+                    1.</head>
                 <div type="section" scope="advertisement">
                     <cb n="1"/>
                     <div type="item" scope="advertisement" xml:id="deg-ad-pos01">
                         <head>Peninsular and Oriental S. N. Company.</head>
                         <p>Summer Rates will be charged from 2 May to 31 October. </p>
-                        <p>For the convenience of families and others, a large portion of each ship’s
-                            accommodation has been reserved for Egypt, so that Berths can be definitely
-                            engaged at once, as if the voyage were commencing at <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>. Plans can be
-                            seen at the Offices of the Company’s Agents. </p>
-                        <p>The through Steamers for <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName> and <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> are intended to leave <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>
-                            after the arrival of the 11 a.m. train from <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> , every Tuesday for the present
-                            except the MONGOLIA, which is taking passengers to the Anglo-French Naval
-                            Review, and will not wait at <placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName>  on 24/25 July. A steam tender will meet
-                            the train to convey passengers to the ship. </p>
+                        <p>For the convenience of families and others, a large portion of each
+                            ship’s accommodation has been reserved for Egypt, so that Berths can be
+                            definitely engaged at once, as if the voyage were commencing at
+                                <placeName ref="https://www.wikidata.org/wiki/Q134509">Port
+                                Said</placeName>. Plans can be seen at the Offices of the Company’s
+                            Agents. </p>
+                        <p>The through Steamers for <placeName
+                                ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName>
+                            and <placeName ref="https://www.wikidata.org/wiki/Q84"
+                                >London</placeName> are intended to leave <placeName
+                                ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>
+                            after the arrival of the 11 a.m. train from <placeName
+                                ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> , every
+                            Tuesday for the present except the MONGOLIA, which is taking passengers
+                            to the Anglo-French Naval Review, and will not wait at <placeName
+                                ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName> on
+                            24/25 July. A steam tender will meet the train to convey passengers to
+                            the ship. </p>
                         <table>
                             <row>
-                                <cell><placeName ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName> </cell>
+                                <cell><placeName ref="https://www.wikidata.org/wiki/Q79"
+                                        >Egypt</placeName>
+                                </cell>
                                 <cell>4 July</cell>
                                 <cell>Arcadia </cell>
                                 <cell>1 August</cell>
@@ -67,39 +80,65 @@
                                 <cell>18 July</cell>
                                 <cell>Arabia </cell>
                                 <cell>15 August</cell>
-                                <cell><placeName ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName> </cell>
+                                <cell><placeName ref="https://www.wikidata.org/wiki/Q79"
+                                        >Egypt</placeName>
+                                </cell>
                                 <cell>12 Sept.</cell>
                             </row>
                             <row>
                                 <cell>Mongolia</cell>
                                 <cell>25 July</cell>
-                                <cell><placeName ref="https://www.wikidata.org/wiki/Q148">China</placeName></cell>
+                                <cell><placeName ref="https://www.wikidata.org/wiki/Q148"
+                                        >China</placeName></cell>
                                 <cell>22 August</cell>
                                 <cell>Macedonia</cell>
                                 <cell>19 Sept.</cell>
                             </row>
                         </table>
-                        <p>The Brindisi Express Steamers leave <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> directly the Indian Mails arrive.
-                            Passengers can go on board the evening before. The Fare remains as usual. </p>
+                        <p>The Brindisi Express Steamers leave <placeName
+                                ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>
+                            directly the Indian Mails arrive. Passengers can go on board the evening
+                            before. The Fare remains as usual. </p>
                         <p>For all further information apply to the Company's Agents, </p>
-                        <p>Messrs. THOS. COOK &amp; SON (Egypt) Ltd. <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> . </p>
-                        <p>GEORGE ROYLE, Esq. <placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName> . </p>
-                        <p>Messrs. HABELDEN &amp; Co. <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>. </p>
-                        <p> F. G. DAVIDSON, Superintendent P. &amp; O. S. N. Company in <placeName ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName> <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>. </p>
+                        <p>Messrs. THOS. COOK &amp; SON (Egypt) Ltd. <placeName
+                                ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> . </p>
+                        <p>GEORGE ROYLE, Esq. <placeName ref="https://www.wikidata.org/wiki/Q134509"
+                                >Port-Said</placeName> . </p>
+                        <p>Messrs. HABELDEN &amp; Co. <placeName
+                                ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>. </p>
+                        <p> F. G. DAVIDSON, Superintendent P. &amp; O. S. N. Company in <placeName
+                                ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName>
+                            <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>.
+                        </p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-opl01">
                         <head>Orient-Pacific Line of Royal Mail Steamers.</head>
                         <p>REDUCED SUMMER FARES FROM MAY TO OCTOBER INCLUSIVE.</p>
-                        <p>OUTWARDS to <placeName ref="https://www.wikidata.org/wiki/Q408">Australia</placeName> .</p>
-                        <p>R.M.S. “Orotava" will leave <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName> about July 28 | R.M.S "Ormuz" will leave <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>
-                            about August 11. </p>
-                        <p>HOMEWARDS to <placeName ref="https://www.wikidata.org/wiki/Q2634">Naples</placeName>  <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName>, GIBRALTAR, PLYMOUTH, <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName>, TILBURY</p>
-                        <p>R.M.S. "Oroya" will leave <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> about July 18 | R.M.S. “Ortona" will leave
-                            <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> about August 1</p>
+                        <p>OUTWARDS to <placeName ref="https://www.wikidata.org/wiki/Q408"
+                                >Australia</placeName> .</p>
+                        <p>R.M.S. “Orotava" will leave <placeName
+                                ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName> about
+                            July 28 | R.M.S "Ormuz" will leave <placeName
+                                ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName> about
+                            August 11. </p>
+                        <p>HOMEWARDS to <placeName ref="https://www.wikidata.org/wiki/Q2634"
+                                >Naples</placeName>
+                            <placeName ref="https://www.wikidata.org/wiki/Q579613"
+                                >Marseilles</placeName>, GIBRALTAR, PLYMOUTH, <placeName
+                                ref="https://www.wikidata.org/wiki/Q84">London</placeName>,
+                            TILBURY</p>
+                        <p>R.M.S. "Oroya" will leave <placeName
+                                ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>
+                            about July 18 | R.M.S. “Ortona" will leave <placeName
+                                ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>
+                            about August 1</p>
                         <table>
                             <row>
                                 <cell rows="4">Reduced Summer Fares</cell>
-                                <cell><placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName>  to <placeName ref="https://www.wikidata.org/wiki/Q2634">Naples</placeName> </cell>
+                                <cell><placeName ref="https://www.wikidata.org/wiki/Q134509"
+                                        >Port-Said</placeName> to <placeName
+                                        ref="https://www.wikidata.org/wiki/Q2634">Naples</placeName>
+                                </cell>
                                 <cell>1st Class</cell>
                                 <cell>£ 11</cell>
                                 <cell>2nd Class</cell>
@@ -108,7 +147,10 @@
                                 <cell>£ 4.8</cell>
                             </row>
                             <row>
-                                <cell><placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName>  to <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName></cell>
+                                <cell><placeName ref="https://www.wikidata.org/wiki/Q134509"
+                                        >Port-Said</placeName> to <placeName
+                                        ref="https://www.wikidata.org/wiki/Q579613"
+                                        >Marseilles</placeName></cell>
                                 <cell>1st Class</cell>
                                 <cell>£ 12.12</cell>
                                 <cell>2nd Class</cell>
@@ -117,7 +159,8 @@
                                 <cell>£ 5.10</cell>
                             </row>
                             <row>
-                                <cell><placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName>  to Gibraltar</cell>
+                                <cell><placeName ref="https://www.wikidata.org/wiki/Q134509"
+                                        >Port-Said</placeName> to Gibraltar</cell>
                                 <cell>1st Class</cell>
                                 <cell>£ 18.0</cell>
                                 <cell>2nd Class</cell>
@@ -126,7 +169,8 @@
                                 <cell>£ 5.10</cell>
                             </row>
                             <row>
-                                <cell><placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName>  to Plymouth or Tilbury</cell>
+                                <cell><placeName ref="https://www.wikidata.org/wiki/Q134509"
+                                        >Port-Said</placeName> to Plymouth or Tilbury</cell>
                                 <cell>1st Class</cell>
                                 <cell>£ 16.16</cell>
                                 <cell>2nd Class</cell>
@@ -135,55 +179,94 @@
                                 <cell>£ 8.16</cell>
                             </row>
                         </table>
-                        <p>Egyptian Government Officials allowed a rebate of 15% off the above fares.</p>
-                        <p>Return tickets no longer issued, but passengers paying full fare in one direction
-                            allowed abatement of 1/3 fare back if return voyage be within 4 months of
-                            arrival, or abatement of 20 o/o if return voyage be made within 8 months of
-                            arrival.</p>
-                        <p>Agents. <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> :—Thos. Cook &amp; Son. <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> : —R. J. Moss &amp; Co.—For all
-                            information apply </p>
-                        <p>Wm. STAPLEDON &amp; Sons, <placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName>  &amp; PORT-TEWFIK (<placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>) 31-12-904</p>
+                        <p>Egyptian Government Officials allowed a rebate of 15% off the above
+                            fares.</p>
+                        <p>Return tickets no longer issued, but passengers paying full fare in one
+                            direction allowed abatement of 1/3 fare back if return voyage be within
+                            4 months of arrival, or abatement of 20 o/o if return voyage be made
+                            within 8 months of arrival.</p>
+                        <p>Agents. <placeName ref="https://www.wikidata.org/wiki/Q85"
+                                >Cairo</placeName> :—Thos. Cook &amp; Son. <placeName
+                                ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> : —R.
+                            J. Moss &amp; Co.—For all information apply </p>
+                        <p>Wm. STAPLEDON &amp; Sons, <placeName
+                                ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName>
+                            &amp; PORT-TEWFIK (<placeName
+                                ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>)
+                            31-12-904</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-blm01">
                         <head>BIBBY LINE MAIL STEAMERS.</head>
                         <p>Special Reduced Rates During Summer Season,</p>
-                        <p>OUTWARDS to COLOMBO, TUTICORIN, etc., and RANGOON. Departures from <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>.</p>
+                        <p>OUTWARDS to COLOMBO, TUTICORIN, etc., and RANGOON. Departures from
+                                <placeName ref="https://www.wikidata.org/wiki/Q134514"
+                                >Suez</placeName>.</p>
                         <p>S.S. Derbyshire 6,635 tons, leaves about July 20.</p>
                         <p>S.S. Lancashire 4,244 tons, leaves about August 3.</p>
-                        <p>HOMEWARDS to <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName> and <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName>. Departures from <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>.</p>
+                        <p>HOMEWARDS to <placeName ref="https://www.wikidata.org/wiki/Q579613"
+                                >Marseilles</placeName> and <placeName
+                                ref="https://www.wikidata.org/wiki/Q84">London</placeName>.
+                            Departures from <placeName ref="https://www.wikidata.org/wiki/Q134509"
+                                >Port Said</placeName>.</p>
                         <p>S.S. Worcestershire 7,160 tons, leaves about July 26.</p>
                         <p>S.S. Yorkshire 4,196 tons leaves about August 9,</p>
-                        <p>FARES from <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> to <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName> £12.0.0, <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> £17.0.0, Colombo £32.10.0,
-                            Rangoon £37.10.0. </p>
-                        <p>Agents <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> : THOS. COOK &amp; SON. <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName> &amp; <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> : WM. STAPLEDON &amp; SONS,
-                            31-12-905</p>
+                        <p>FARES from <placeName ref="https://www.wikidata.org/wiki/Q134509">Port
+                                Said</placeName> to <placeName
+                                ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName>
+                            £12.0.0, <placeName ref="https://www.wikidata.org/wiki/Q84"
+                                >London</placeName> £17.0.0, Colombo £32.10.0, Rangoon £37.10.0. </p>
+                        <p>Agents <placeName ref="https://www.wikidata.org/wiki/Q85"
+                                >Cairo</placeName> : THOS. COOK &amp; SON. <placeName
+                                ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName> &amp;
+                                <placeName ref="https://www.wikidata.org/wiki/Q134509">Port
+                                Said</placeName> : WM. STAPLEDON &amp; SONS, 31-12-905</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-kml01">
                         <head>KHEDIVIAL MAIL LINE.</head>
                         <head type="sub">FAST BRITISH PASSENGER STEAMERS</head>
-                        <head type="sub"><placeName ref="https://www.wikidata.org/wiki/Q41">Greece</placeName> - <placeName ref="https://www.wikidata.org/wiki/Q43">Turkey</placeName> LINE.</head>
-                        <p>Express Steamers leave <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> every Wednesday at 4 p.m. for PIRAEUS, SMYRNA,
-                            MITYLENE, and CONSTANTINOPLE, in connection with Orient Express train-de-luxe
-                            for Vienna, <placeName ref="https://www.wikidata.org/wiki/Q90">Paris</placeName>, and <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName>.</p>
+                        <head type="sub"><placeName ref="https://www.wikidata.org/wiki/Q41"
+                                >Greece</placeName> - <placeName
+                                ref="https://www.wikidata.org/wiki/Q43">Turkey</placeName>
+                            LINE.</head>
+                        <p>Express Steamers leave <placeName ref="https://www.wikidata.org/wiki/Q87"
+                                >Alexandria</placeName> every Wednesday at 4 p.m. for PIRAEUS,
+                            SMYRNA, MITYLENE, and CONSTANTINOPLE, in connection with Orient Express
+                            train-de-luxe for Vienna, <placeName
+                                ref="https://www.wikidata.org/wiki/Q90">Paris</placeName>, and
+                                <placeName ref="https://www.wikidata.org/wiki/Q84"
+                                >London</placeName>.</p>
                         <head type="sub">PALESTINE - SYRIA LINE.</head>
-                        <p>Fast steamers leave <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> every Saturday at 6 p.m., and <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> every
-                            Sunday at 6 p.m., for JAFFA (for Jerusalem), CAIFFA (for Nazareth), BEYROUT (for
-                            Damascus), TRIPOLI, ALEXANDRETTA, MESSINA, continuing in alternate weeks to
-                            LARNACA and LIMASSOL (Cyprus).</p>
+                        <p>Fast steamers leave <placeName ref="https://www.wikidata.org/wiki/Q87"
+                                >Alexandria</placeName> every Saturday at 6 p.m., and <placeName
+                                ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>
+                            every Sunday at 6 p.m., for JAFFA (for Jerusalem), CAIFFA (for
+                            Nazareth), BEYROUT (for Damascus), TRIPOLI, ALEXANDRETTA, MESSINA,
+                            continuing in alternate weeks to LARNACA and LIMASSOL (Cyprus).</p>
                         <head type="sub">RED SEA LINE.</head>
-                        <p>Steamers leave <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName> fortnightly on Wednesday at 6 p.m. for JEDDAH, SUAKIN,
-                            MASSOWAH, HODBIDAH, and ADEN ; and in the intervening weeks for PORT SUDAN and
-                            SUAKIN direct. Calls will be made at TOR (for Mount Sinai) as required.</p>
-                        <p>N.B.—Deck chairs provided for the use of passengers, excellent cuisine and table
-                            wine free.</p>
-                        <p>Steamer plans may be seen and passages booked at the Company’s Agencies at
-                            <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>, <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> , <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>, and <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>, or at THOS. COOK &amp; SON or other
-                            Tourist Agency. 31-12-904</p>
+                        <p>Steamers leave <placeName ref="https://www.wikidata.org/wiki/Q134514"
+                                >Suez</placeName> fortnightly on Wednesday at 6 p.m. for JEDDAH,
+                            SUAKIN, MASSOWAH, HODBIDAH, and ADEN ; and in the intervening weeks for
+                            PORT SUDAN and SUAKIN direct. Calls will be made at TOR (for Mount
+                            Sinai) as required.</p>
+                        <p>N.B.—Deck chairs provided for the use of passengers, excellent cuisine
+                            and table wine free.</p>
+                        <p>Steamer plans may be seen and passages booked at the Company’s Agencies
+                            at <placeName ref="https://www.wikidata.org/wiki/Q87"
+                                >Alexandria</placeName>, <placeName
+                                ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> ,
+                                <placeName ref="https://www.wikidata.org/wiki/Q134509">Port
+                                Said</placeName>, and <placeName
+                                ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>, or at
+                            THOS. COOK &amp; SON or other Tourist Agency. 31-12-904</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-mss01">
                         <head>The Moss S.S. Company, Ltd.</head>
-                        <p>For <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName> calling at <placeName ref="https://www.wikidata.org/wiki/Q233">Malta</placeName> (Messrs. JAMES MOSS &amp; Co. 31, James St,
-                            <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName>, Managers.)</p>
+                        <p>For <placeName ref="https://www.wikidata.org/wiki/Q24826"
+                                >Liverpool</placeName> calling at <placeName
+                                ref="https://www.wikidata.org/wiki/Q233">Malta</placeName> (Messrs.
+                            JAMES MOSS &amp; Co. 31, James St, <placeName
+                                ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName>,
+                            Managers.)</p>
                         <table rows="3" cols="8">
                             <row>
                                 <cell>*Amasis</cell>
@@ -216,129 +299,217 @@
                                 <cell>(Building)</cell>
                             </row>
                         </table>
-                        <p>*Second class accommodation only, unless specially reserved.—Fares : <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>
-                            to <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName>, 1st, £14 Single, £25 Return. 2nd, £9 Single, £15 Return.—To <placeName ref="https://www.wikidata.org/wiki/Q233">Malta</placeName>,
-                            1st, £5 Single, £9 Return, 2nd, £3 Single, £5 Return.—Return tickets available
+                        <p>*Second class accommodation only, unless specially reserved.—Fares :
+                                <placeName ref="https://www.wikidata.org/wiki/Q87"
+                                >Alexandria</placeName> to <placeName
+                                ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName>,
+                            1st, £14 Single, £25 Return. 2nd, £9 Single, £15 Return.—To <placeName
+                                ref="https://www.wikidata.org/wiki/Q233">Malta</placeName>, 1st, £5
+                            Single, £9 Return, 2nd, £3 Single, £5 Return.—Return tickets available
                             for six months.</p>
-                        <p>S.S. Seti now on the berth, will sail on or about Monday, July 17, to be followed
-                            by S.S. Menes.</p>
-                        <p>S.S Tabor for Havre via <placeName ref="https://www.wikidata.org/wiki/Q233">Malta</placeName> to sail about Saturday l5th inst.</p>
-                        <p>Through freight rates on cotton, etc., to Lancashire inland towns, Boston, New
-                            York and other U.S.A. towns, obtained on application. Cargo taken by special
-                            agreement only. </p>
-                        <p>Passenger Tickets also issued inclusive of Railway fare through to and from
-                            <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> . Particulars on application to </p>
-                        <p>R. J. MOSS &amp; Co., <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>, Agents. 26-12-905</p>
+                        <p>S.S. Seti now on the berth, will sail on or about Monday, July 17, to be
+                            followed by S.S. Menes.</p>
+                        <p>S.S Tabor for Havre via <placeName
+                                ref="https://www.wikidata.org/wiki/Q233">Malta</placeName> to sail
+                            about Saturday l5th inst.</p>
+                        <p>Through freight rates on cotton, etc., to Lancashire inland towns,
+                            Boston, New York and other U.S.A. towns, obtained on application. Cargo
+                            taken by special agreement only. </p>
+                        <p>Passenger Tickets also issued inclusive of Railway fare through to and
+                            from <placeName ref="https://www.wikidata.org/wiki/Q85"
+                                >Cairo</placeName> . Particulars on application to </p>
+                        <p>R. J. MOSS &amp; Co., <placeName ref="https://www.wikidata.org/wiki/Q87"
+                                >Alexandria</placeName>, Agents. 26-12-905</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-mic01">
                         <head>MARINE INSURANCE COMPANY, LIMITED.</head>
                         <p>Established 1836. Capital £1,000,000. Reserve Fund £650,000. </p>
-                        <p>THE IMPERIAL FIRE OFFICE united with THE ALLIANCE ASSURANCE, Co., Ltd.</p>
-                        <p>1, Old Broad Street, <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName>—Estabished 1806.—Total Funds exceed £10,000,000.</p>
-                        <p>31-12-905. Policies issued at <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName> by G. BEYTS &amp; Co., Agents.</p>
+                        <p>THE IMPERIAL FIRE OFFICE united with THE ALLIANCE ASSURANCE, Co.,
+                            Ltd.</p>
+                        <p>1, Old Broad Street, <placeName ref="https://www.wikidata.org/wiki/Q84"
+                                >London</placeName>—Estabished 1806.—Total Funds exceed
+                            £10,000,000.</p>
+                        <p>31-12-905. Policies issued at <placeName
+                                ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName> by G.
+                            BEYTS &amp; Co., Agents.</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-tce01">
                         <head>Telephone Company of Egypt, Limited.</head>
-                        <p><placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> -<placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> TELEPHONE.--Rates as follows P.T. 5 for each 3 minutes, or
-                            fraction of 3 minutes; P.T. 10 for over 3 up to 8 minutes communication.</p>
-                        <p>PUBLIC CALL-OFFICES : <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> , Central Office, Opera Square, and New Bar; Helouan,
-                            Central Office, Maison Purvis ; <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>, St Mark’s Buildings, Egyptian Bar,
-                            I. Castelli &amp; Co.; Ramleh, Central Office. San Stefano Casino 30.4.906</p>
+                        <p><placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>
+                                -<placeName ref="https://www.wikidata.org/wiki/Q87"
+                                >Alexandria</placeName> TELEPHONE.--Rates as follows P.T. 5 for each
+                            3 minutes, or fraction of 3 minutes; P.T. 10 for over 3 up to 8 minutes
+                            communication.</p>
+                        <p>PUBLIC CALL-OFFICES : <placeName ref="https://www.wikidata.org/wiki/Q85"
+                                >Cairo</placeName> , Central Office, Opera Square, and New Bar;
+                            Helouan, Central Office, Maison Purvis ; <placeName
+                                ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>, St
+                            Mark’s Buildings, Egyptian Bar, I. Castelli &amp; Co.; Ramleh, Central
+                            Office. San Stefano Casino 30.4.906</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-phc01">
                         <head>P. HENDERSON &amp; CO’s LINE.</head>
-                        <p>Steamers leave <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName> and <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> fortnightly for <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> or <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName> direct.</p>
+                        <p>Steamers leave <placeName ref="https://www.wikidata.org/wiki/Q134514"
+                                >Suez</placeName> and <placeName
+                                ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>
+                            fortnightly for <placeName ref="https://www.wikidata.org/wiki/Q84"
+                                >London</placeName> or <placeName
+                                ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName>
+                            direct.</p>
                         <p>(Electric Light.) SALOON (Amidships) FARE £12. (Latest improvements.)</p>
-                        <p>S.S. RANGOON 6000 Tons will leave <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> about July 23 for <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName>.</p>
-                        <p>S.S. BURMA 5600 Tons will leave <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> about August 6 for <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName>.</p>
-                        <p>S.S. ARRACAN 5800 Tons will leave <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> about 20 for <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName></p>
-                        <p>Due in <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> or <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName> 12 days thereafter.</p>
-                        <p>Apply WORMS &amp; Co., <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> and <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>. THOS. COOK &amp; SON, (EGYPT) LD.,
-                            <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>  ;</p>
-                        <p>G. J. GRACE &amp; CO., <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>.</p>
+                        <p>S.S. RANGOON 6000 Tons will leave <placeName
+                                ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>
+                            about July 23 for <placeName ref="https://www.wikidata.org/wiki/Q84"
+                                >London</placeName>.</p>
+                        <p>S.S. BURMA 5600 Tons will leave <placeName
+                                ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>
+                            about August 6 for <placeName ref="https://www.wikidata.org/wiki/Q84"
+                                >London</placeName>.</p>
+                        <p>S.S. ARRACAN 5800 Tons will leave <placeName
+                                ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>
+                            about 20 for <placeName ref="https://www.wikidata.org/wiki/Q24826"
+                                >Liverpool</placeName></p>
+                        <p>Due in <placeName ref="https://www.wikidata.org/wiki/Q84"
+                                >London</placeName> or <placeName
+                                ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName> 12
+                            days thereafter.</p>
+                        <p>Apply WORMS &amp; Co., <placeName
+                                ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>
+                            and <placeName ref="https://www.wikidata.org/wiki/Q134514"
+                                >Suez</placeName>. THOS. COOK &amp; SON, (EGYPT) LD., <placeName
+                                ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> ;</p>
+                        <p>G. J. GRACE &amp; CO., <placeName ref="https://www.wikidata.org/wiki/Q87"
+                                >Alexandria</placeName>.</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-tcs01">
                         <head>Thos. Cook &amp; Son,</head>
-                        <p>(EGYPT), LIMITED, HEAD OFFICE—LUDGATE CIRCUS—<placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName>.</p>
-                        <p>CHIEF EGYPTIAN OFFICE — <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> , near SHEPHEARD'S HOTEL. </p>
-                        <p><placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>, <placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName> , <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>, Luxor, Assuan, Haifa, &amp; Khartum.</p>
+                        <p>(EGYPT), LIMITED, HEAD OFFICE—LUDGATE CIRCUS—<placeName
+                                ref="https://www.wikidata.org/wiki/Q84">London</placeName>.</p>
+                        <p>CHIEF EGYPTIAN OFFICE — <placeName
+                                ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> , near
+                            SHEPHEARD'S HOTEL. </p>
+                        <p><placeName ref="https://www.wikidata.org/wiki/Q87"
+                            >Alexandria</placeName>, <placeName
+                                ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName> ,
+                                <placeName ref="https://www.wikidata.org/wiki/Q134514"
+                                >Suez</placeName>, Luxor, Assuan, Haifa, &amp; Khartum.</p>
                         <p>GENERAL RAILWAY AND STEAMSHIP AGENTS. BANKERS.</p>
                         <p>BAGGAGE AND FORWARDING AGENTS.</p>
-                        <p>Officially appointed &amp; Sole Agents in <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>  to the P.&amp;O. S.N. Co.</p>
-                        <p>RESIDENTS IN <placeName ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName> proceeding to Europe for the summer are requested to apply to
-                            our offices for information respecting their Passages, where steamer plans may
-                            be consulted and Berths secured by all Lines of Steamers to all parts of the
-                            Globe; arrangements can also be made for the collection and forwarding of their
-                            baggage and clearance at port of arrival.</p>
+                        <p>Officially appointed &amp; Sole Agents in <placeName
+                                ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> to the
+                            P.&amp;O. S.N. Co.</p>
+                        <p>RESIDENTS IN <placeName ref="https://www.wikidata.org/wiki/Q79"
+                                >Egypt</placeName> proceeding to Europe for the summer are requested
+                            to apply to our offices for information respecting their Passages, where
+                            steamer plans may be consulted and Berths secured by all Lines of
+                            Steamers to all parts of the Globe; arrangements can also be made for
+                            the collection and forwarding of their baggage and clearance at port of
+                            arrival.</p>
                         <p>CIRCULAR NOTES issued payable at the current rate of exchange in all the
-                            principal cities of Europe. Cook’s Interpreters in uniform are present at the
-                            principal Railway stations and Landing-places in Europe to assist passengers
-                            holding their travelling tickets.</p>
-                        <p>Large and splendidly appointed steamers belonging to the Co. leave <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>  thrice
-                            weekly, between November and March, for Luxor, Assouan and Wady-Halfa in
-                            connection with trains de luxe to Khartoum. Moderate fares. </p>
-                        <p>FREIGHT SERVICE, Steamers leave <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>  every Saturday and Tuesday for Assouan and
-                            Halfa.</p>
+                            principal cities of Europe. Cook’s Interpreters in uniform are present
+                            at the principal Railway stations and Landing-places in Europe to assist
+                            passengers holding their travelling tickets.</p>
+                        <p>Large and splendidly appointed steamers belonging to the Co. leave
+                                <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>
+                            thrice weekly, between November and March, for Luxor, Assouan and
+                            Wady-Halfa in connection with trains de luxe to Khartoum. Moderate
+                            fares. </p>
+                        <p>FREIGHT SERVICE, Steamers leave <placeName
+                                ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> every
+                            Saturday and Tuesday for Assouan and Halfa.</p>
                         <p>Special Steamers and Dahabeahs for private parties.</p>
-                        <p>Special arrangements for tour in PALESTINE, SYRIA and the DESERT, Lowest Rates.</p>
+                        <p>Special arrangements for tour in PALESTINE, SYRIA and the DESERT, Lowest
+                            Rates.</p>
                         <p>Best camp equipment in the country! 10 12-904 </p>
                     </div>
                     <cb n="2"/>
                     <div type="item" scope="advertisement" xml:id="deg-ad-bis01">
-                        <head>British <placeName ref="https://www.wikidata.org/wiki/Q668">India</placeName> S. N. Company, Limited.</head>
+                        <head>British <placeName ref="https://www.wikidata.org/wiki/Q668"
+                                >India</placeName> S. N. Company, Limited.</head>
                         <p>MAIL AND PASSENGER STEAM SHIPS.</p>
-                        <p>SAILINGS FROM <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>, <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> and CALCUTTA LINE.</p>
-                        <p>Calling at ADEN, COLOMBO and MADRAS Outward, and <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName> (GENOA and PLYMOUTH
-                            optional) Homeward. </p>
-                        <p>Fortnightly Service in connection with the Co's Indian Mail Lines and monthly
-                            with the East African Mail Line between ADEN, MOMBASSA and Zanzibar. </p>
+                        <p>SAILINGS FROM <placeName ref="https://www.wikidata.org/wiki/Q134514"
+                                >Suez</placeName>, <placeName
+                                ref="https://www.wikidata.org/wiki/Q84">London</placeName> and
+                            CALCUTTA LINE.</p>
+                        <p>Calling at ADEN, COLOMBO and MADRAS Outward, and <placeName
+                                ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName>
+                            (GENOA and PLYMOUTH optional) Homeward. </p>
+                        <p>Fortnightly Service in connection with the Co's Indian Mail Lines and
+                            monthly with the East African Mail Line between ADEN, MOMBASSA and
+                            Zanzibar. </p>
                         <p>OUTWARD.—S.S. Fazilka ... July 22 | HOMEWARD.—S.S. Mombassa ... July 21 </p>
-                        <p>Queensland Line of Steamers Between <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> and Brisbane.</p>
+                        <p>Queensland Line of Steamers Between <placeName
+                                ref="https://www.wikidata.org/wiki/Q84">London</placeName> and
+                            Brisbane.</p>
                         <p>Calling at Colombo, Batavia, Cooktown, Townsville, and Rockhamptom.</p>
-                        <p>The S.S. .................. will sail from <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName> on about ..................</p>
+                        <p>The S.S. .................. will sail from <placeName
+                                ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName> on
+                            about ..................</p>
                         <table rows="2" cols="9">
                             <row>
-                                <cell>First Class Fares from <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName> to</cell>
+                                <cell>First Class Fares from <placeName
+                                        ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>
+                                    to</cell>
                                 <cell>Aden</cell>
                                 <cell>£11. 8</cell>
                                 <cell>Colombo</cell>
                                 <cell>£14.14</cell>
                                 <cell>Calcutta</cell>
                                 <cell>£31. 0</cell>
-                                <cell><placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName></cell>
+                                <cell><placeName ref="https://www.wikidata.org/wiki/Q579613"
+                                        >Marseilles</placeName></cell>
                                 <cell>£15.12</cell>
                             </row>
                             <row>
                                 <cell/>
-                                <cell><placeName ref="https://www.wikidata.org/wiki/Q1156">Bombay</placeName></cell>
+                                <cell><placeName ref="https://www.wikidata.org/wiki/Q1156"
+                                        >Bombay</placeName></cell>
                                 <cell>£31.10</cell>
                                 <cell>Madras</cell>
                                 <cell>£xx.11</cell>
                                 <cell>Genoa</cell>
                                 <cell>£13.10</cell>
-                                <cell><placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName></cell>
+                                <cell><placeName ref="https://www.wikidata.org/wiki/Q84"
+                                        >London</placeName></cell>
                                 <cell>£19. 0</cell>
                             </row>
                         </table>
-                        <p>From <placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName>  £2 less Homeward, and £2 more Outward. Second class, two thirds of
-                            1st Class Fares.</p>
-                        <p>Agents at <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>, for the <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName>, Calcutta and Persian Gulf Lines, Messrs.
-                            Worms &amp; Co.</p>
-                        <p>Agents at <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>, for the <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> and Queensland Line, Messrs. Wills &amp; Co.,
-                            Limited.</p>
-                        <p>Messrs. Thos. Cook &amp; Son and the Anglo-American Hotel &amp; Steamer Company,
-                            <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>  &amp; <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>.</p>
-                        <p>For further particulars. Freight and Passage apply to G. BEYTS &amp; Co. Agents,
-                            <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>. 31-12-905</p>
+                        <p>From <placeName ref="https://www.wikidata.org/wiki/Q134509"
+                                >Port-Said</placeName> £2 less Homeward, and £2 more Outward. Second
+                            class, two thirds of 1st Class Fares.</p>
+                        <p>Agents at <placeName ref="https://www.wikidata.org/wiki/Q134509">Port
+                                Said</placeName>, for the <placeName
+                                ref="https://www.wikidata.org/wiki/Q84">London</placeName>, Calcutta
+                            and Persian Gulf Lines, Messrs. Worms &amp; Co.</p>
+                        <p>Agents at <placeName ref="https://www.wikidata.org/wiki/Q134509">Port
+                                Said</placeName>, for the <placeName
+                                ref="https://www.wikidata.org/wiki/Q84">London</placeName> and
+                            Queensland Line, Messrs. Wills &amp; Co., Limited.</p>
+                        <p>Messrs. Thos. Cook &amp; Son and the Anglo-American Hotel &amp; Steamer
+                            Company, <placeName ref="https://www.wikidata.org/wiki/Q85"
+                                >Cairo</placeName> &amp; <placeName
+                                ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>.</p>
+                        <p>For further particulars. Freight and Passage apply to G. BEYTS &amp; Co.
+                            Agents, <placeName ref="https://www.wikidata.org/wiki/Q134514"
+                                >Suez</placeName>. 31-12-905</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-all01">
                         <head>ANCHOR LINE, LIMITED.</head>
-                        <p>(HENDERSON BROTHERS,) <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName>, <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName> AND GLASGOW.</p>
-                        <p>Booking Passengers and Cargo through to Ports in <placeName ref="https://www.wikidata.org/wiki/Q668">India</placeName>, Europe &amp; America</p>
-                        <p>First class passengers steamers. Sailing fortnightly from <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>.</p>
+                        <p>(HENDERSON BROTHERS,) <placeName ref="https://www.wikidata.org/wiki/Q84"
+                                >London</placeName>, <placeName
+                                ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName> AND
+                            GLASGOW.</p>
+                        <p>Booking Passengers and Cargo through to Ports in <placeName
+                                ref="https://www.wikidata.org/wiki/Q668">India</placeName>, Europe
+                            &amp; America</p>
+                        <p>First class passengers steamers. Sailing fortnightly from <placeName
+                                ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>.</p>
                         <table rows="2" cols="6">
                             <row>
-                                <cell>For <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName> &amp; <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName></cell>
+                                <cell>For <placeName ref="https://www.wikidata.org/wiki/Q579613"
+                                        >Marseilles</placeName> &amp; <placeName
+                                        ref="https://www.wikidata.org/wiki/Q24826"
+                                        >Liverpool</placeName></cell>
                                 <cell>S.S. “Bohemia”</cell>
                                 <cell>July 26</cell>
                                 <cell>For CALCUTTA</cell>
@@ -346,45 +517,73 @@
                                 <cell>August 3</cell>
                             </row>
                             <row>
-                                <cell>For <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName></cell>
+                                <cell>For <placeName ref="https://www.wikidata.org/wiki/Q84"
+                                        >London</placeName></cell>
                                 <cell>S.S. “Persia"</cell>
                                 <cell>July 28</cell>
-                                <cell>For <placeName ref="https://www.wikidata.org/wiki/Q1156">Bombay</placeName></cell>
-                                <cell>S.S. "<placeName ref="https://www.wikidata.org/wiki/Q408">Australia</placeName> "</cell>
+                                <cell>For <placeName ref="https://www.wikidata.org/wiki/Q1156"
+                                        >Bombay</placeName></cell>
+                                <cell>S.S. "<placeName ref="https://www.wikidata.org/wiki/Q408"
+                                        >Australia</placeName> "</cell>
                                 <cell>July 23</cell>
                             </row>
                         </table>
-                        <p>Saloon Fares: from <placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName> , to Gibraltar £9; <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName> £9: <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName> (all sea
-                            route) £15; <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> (all sea route) £ 12 <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> via <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName> £15.5.0.
-                            Passengers embarking at <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName> £2 more, 10 % reduction for officers of army of
-                            Occupation and Government employés. Through tickets issued to New-York (via
-                            Glasgow). Fares on application. </p>
-                        <p> Agents in <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> , Messrs. Thos. Cook &amp; Son. <placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName> , Messrs. Cory Brothers
-                            &amp; Co., Ltd.</p>
-                        <p>For further partienlan of Freight or Passage apply to G. BEYTS &amp; Co., <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>.
-                            31-12-905</p>
+                        <p>Saloon Fares: from <placeName ref="https://www.wikidata.org/wiki/Q134509"
+                                >Port-Said</placeName> , to Gibraltar £9; <placeName
+                                ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName>
+                            £9: <placeName ref="https://www.wikidata.org/wiki/Q24826"
+                                >Liverpool</placeName> (all sea route) £15; <placeName
+                                ref="https://www.wikidata.org/wiki/Q84">London</placeName> (all sea
+                            route) £ 12 <placeName ref="https://www.wikidata.org/wiki/Q84"
+                                >London</placeName> via <placeName
+                                ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName>
+                            £15.5.0. Passengers embarking at <placeName
+                                ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName> £2
+                            more, 10 % reduction for officers of army of Occupation and Government
+                            employés. Through tickets issued to New-York (via Glasgow). Fares on
+                            application. </p>
+                        <p> Agents in <placeName ref="https://www.wikidata.org/wiki/Q85"
+                                >Cairo</placeName> , Messrs. Thos. Cook &amp; Son. <placeName
+                                ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName> ,
+                            Messrs. Cory Brothers &amp; Co., Ltd.</p>
+                        <p>For further partienlan of Freight or Passage apply to G. BEYTS &amp; Co.,
+                                <placeName ref="https://www.wikidata.org/wiki/Q134514"
+                                >Suez</placeName>. 31-12-905</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-dll01">
                         <head>Deutsche Levante-Linie.</head>
-                        <p>Mail and Passenger Steamships. Regular three-weekly Service from <lb/> HAMBURG,
-                            via ANTWERP &amp; <placeName ref="https://www.wikidata.org/wiki/Q233">Malta</placeName>, to <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> and vice-versa, admitting<lb/> goods from
-                            all chief German Railway Stations on direct Bill of Landing to<lb/> <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>
-                            and all chief ports of Egypt, Syria, etc., at favourable through<lb/> rates of
-                            DEUTSCHE <lb/> VERKEHR (traffic).</p>
-                        <p>EXPECTED AT <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>.</p>
+                        <p>Mail and Passenger Steamships. Regular three-weekly Service from <lb/>
+                            HAMBURG, via ANTWERP &amp; <placeName
+                                ref="https://www.wikidata.org/wiki/Q233">Malta</placeName>, to
+                                <placeName ref="https://www.wikidata.org/wiki/Q87"
+                                >Alexandria</placeName> and vice-versa, admitting<lb/> goods from
+                            all chief German Railway Stations on direct Bill of Landing to<lb/>
+                            <placeName ref="https://www.wikidata.org/wiki/Q87"
+                                >Alexandria</placeName> and all chief ports of Egypt, Syria, etc.,
+                            at favourable through<lb/> rates of DEUTSCHE <lb/> VERKEHR
+                            (traffic).</p>
+                        <p>EXPECTED AT <placeName ref="https://www.wikidata.org/wiki/Q87"
+                                >Alexandria</placeName>.</p>
                         <p>S.S. Lesbos July 20 from Antwerp.</p>
                         <p>S.S. Androos July 20 from Hamburg bound for Beyrout.</p>
                         <p>S.S. Lemnos July 31 from Hamburg bound for Beyrout.</p>
-                        <p>For tariff and particulars apply to ADOLPHE STROSS, <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>, Agent. </p>
+                        <p>For tariff and particulars apply to ADOLPHE STROSS, <placeName
+                                ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>,
+                            Agent. </p>
                         <p>15-2-905 </p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-mma01">
                         <head>Messageries Maritimes.</head>
-                        <p>From <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName></p>
+                        <p>From <placeName ref="https://www.wikidata.org/wiki/Q87"
+                                >Alexandria</placeName></p>
                         <table rows="12" cols="6">
-                            <head><hi rend="bold">Sailing from <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> in July, 1905.</hi></head>
+                            <head><hi rend="bold">Sailing from <placeName
+                                        ref="https://www.wikidata.org/wiki/Q87"
+                                        >Alexandria</placeName> in July, 1905.</hi></head>
                             <row>
-                                <cell cols="6"><hi rend="bold">For <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName> direct</hi></cell>
+                                <cell cols="6"><hi rend="bold">For <placeName
+                                            ref="https://www.wikidata.org/wiki/Q579613"
+                                            >Marseilles</placeName> direct</hi></cell>
                             </row>
                             <row>
                                 <cell>Friday</cell>
@@ -427,7 +626,9 @@
                                 <cell>Capt. Vincenti</cell>
                             </row>
                             <row>
-                                <cell cols="6"><hi rend="bold">For <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> and Beyrouth</hi></cell>
+                                <cell cols="6"><hi rend="bold">For <placeName
+                                            ref="https://www.wikidata.org/wiki/Q134509">Port
+                                            Said</placeName> and Beyrouth</hi></cell>
                             </row>
                             <row>
                                 <cell>Thursday</cell>
@@ -446,7 +647,9 @@
                                 <cell>Capt. Aillaud</cell>
                             </row>
                             <row>
-                                <cell cols="6"><hi rend="bold">For <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>, Jaffa and Beyrouth</hi></cell>
+                                <cell cols="6"><hi rend="bold">For <placeName
+                                            ref="https://www.wikidata.org/wiki/Q134509">Port
+                                            Said</placeName>, Jaffa and Beyrouth</hi></cell>
                             </row>
                             <row>
                                 <cell>Thursday</cell>
@@ -474,61 +677,97 @@
                                 <cell>2nd Class</cell>
                             </row>
                             <row>
-                                <cell>From <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> or <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> (directly or via <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>) To
-                                    <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName></cell>
+                                <cell>From <placeName ref="https://www.wikidata.org/wiki/Q87"
+                                        >Alexandria</placeName> or <placeName
+                                        ref="https://www.wikidata.org/wiki/Q134509">Port
+                                        Said</placeName> (directly or via <placeName
+                                        ref="https://www.wikidata.org/wiki/Q87"
+                                        >Alexandria</placeName>) To <placeName
+                                        ref="https://www.wikidata.org/wiki/Q579613"
+                                        >Marseilles</placeName></cell>
                                 <cell>£12.9.8 </cell>
                                 <cell>£9.10.3</cell>
                             </row>
                             <row>
-                                <cell>From <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> To <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName></cell>
+                                <cell>From <placeName ref="https://www.wikidata.org/wiki/Q87"
+                                        >Alexandria</placeName> To <placeName
+                                        ref="https://www.wikidata.org/wiki/Q134509">Port
+                                        Said</placeName></cell>
                                 <cell>£1.15.10</cell>
                                 <cell>£1.7.10</cell>
                             </row>
                             <row>
-                                <cell>From <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> to Jaffa</cell>
+                                <cell>From <placeName ref="https://www.wikidata.org/wiki/Q87"
+                                        >Alexandria</placeName> to Jaffa</cell>
                                 <cell>£3.3.5</cell>
                                 <cell>£2.2.5</cell>
                             </row>
                             <row>
-                                <cell>From <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> to Beyrouth</cell>
+                                <cell>From <placeName ref="https://www.wikidata.org/wiki/Q87"
+                                        >Alexandria</placeName> to Beyrouth</cell>
                                 <cell>£4.7.2</cell>
                                 <cell>£3.3.2.</cell>
                             </row>
                             <row>
-                                <cell>Through tickets for <placeName ref="https://www.wikidata.org/wiki/Q90">Paris</placeName> (via <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName> from <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>) </cell>
+                                <cell>Through tickets for <placeName
+                                        ref="https://www.wikidata.org/wiki/Q90">Paris</placeName>
+                                    (via <placeName ref="https://www.wikidata.org/wiki/Q579613"
+                                        >Marseilles</placeName> from <placeName
+                                        ref="https://www.wikidata.org/wiki/Q87"
+                                        >Alexandria</placeName>) </cell>
                                 <cell>£15.12.1</cell>
                                 <cell>£10.12.5</cell>
                             </row>
                             <row>
-                                <cell>Through tickets for <placeName ref="https://www.wikidata.org/wiki/Q90">Paris</placeName> (via <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName>) from <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> (directly or
-                                    via <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>) </cell>
+                                <cell>Through tickets for <placeName
+                                        ref="https://www.wikidata.org/wiki/Q90">Paris</placeName>
+                                    (via <placeName ref="https://www.wikidata.org/wiki/Q579613"
+                                        >Marseilles</placeName>) from <placeName
+                                        ref="https://www.wikidata.org/wiki/Q134509">Port
+                                        Said</placeName> (directly or via <placeName
+                                        ref="https://www.wikidata.org/wiki/Q87"
+                                        >Alexandria</placeName>) </cell>
                                 <cell>£16.5.11</cell>
                                 <cell>£12.1.5</cell>
                             </row>
                             <row>
-                                <cell>Through tickets for <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> (via <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName>) (Calais-Douvree) from
-                                    <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> or <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> (directly or via <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>)</cell>
+                                <cell>Through tickets for <placeName
+                                        ref="https://www.wikidata.org/wiki/Q84">London</placeName>
+                                    (via <placeName ref="https://www.wikidata.org/wiki/Q579613"
+                                        >Marseilles</placeName>) (Calais-Douvree) from <placeName
+                                        ref="https://www.wikidata.org/wiki/Q87"
+                                        >Alexandria</placeName> or <placeName
+                                        ref="https://www.wikidata.org/wiki/Q134509">Port
+                                        Said</placeName> (directly or via <placeName
+                                        ref="https://www.wikidata.org/wiki/Q87"
+                                        >Alexandria</placeName>)</cell>
                                 <cell>£16.12.10</cell>
                                 <cell>£12.9.8</cell>
                             </row>
                             <row>
-                                <cell>Interchangeable return tickets with the Austrian Lloyd Cy. (available
-                                    one way by Messageries</cell>
+                                <cell>Interchangeable return tickets with the Austrian Lloyd Cy.
+                                    (available one way by Messageries</cell>
                                 <cell>£21.11.10</cell>
                                 <cell>£15.11.2</cell>
                             </row>
                         </table>
                         <table rend="frame" xml:id="SailingfromPortSaid">
-                            <head><hi rend="bold">Sailing from <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> in July, 1905</hi></head>
+                            <head><hi rend="bold">Sailing from <placeName
+                                        ref="https://www.wikidata.org/wiki/Q134509">Port
+                                        Said</placeName> in July, 1905</hi></head>
                             <row>
-                                <cell rows="5">For <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName> Direct</cell>
+                                <cell rows="5">For <placeName
+                                        ref="https://www.wikidata.org/wiki/Q579613"
+                                        >Marseilles</placeName> Direct</cell>
                                 <cell>Probably on</cell>
                                 <cell>Thursday</cell>
                                 <cell>6</cell>
                                 <cell>July</cell>
                                 <cell>Polynesien</cell>
                                 <cell>Capt. Broc</cell>
-                                <cell>returning from <placeName ref="https://www.wikidata.org/wiki/Q1239">Indian Ocean</placeName></cell>
+                                <cell>returning from <placeName
+                                        ref="https://www.wikidata.org/wiki/Q1239">Indian
+                                        Ocean</placeName></cell>
                             </row>
                             <row>
                                 <cell>Probably on</cell>
@@ -537,7 +776,9 @@
                                 <cell>July</cell>
                                 <cell>Iraouaddy</cell>
                                 <cell>Capt. Riquier</cell>
-                                <cell>returning from <placeName ref="https://www.wikidata.org/wiki/Q148">China</placeName></cell>
+                                <cell>returning from <placeName
+                                        ref="https://www.wikidata.org/wiki/Q148"
+                                    >China</placeName></cell>
                             </row>
                             <row>
                                 <cell>Probably on</cell>
@@ -546,7 +787,9 @@
                                 <cell>July</cell>
                                 <cell>Caledonian</cell>
                                 <cell>Capt. Grégory</cell>
-                                <cell>returning from <placeName ref="https://www.wikidata.org/wiki/Q1239">Indian Ocean</placeName></cell>
+                                <cell>returning from <placeName
+                                        ref="https://www.wikidata.org/wiki/Q1239">Indian
+                                        Ocean</placeName></cell>
                             </row>
                             <row>
                                 <cell>Probably on</cell>
@@ -555,7 +798,9 @@
                                 <cell>July</cell>
                                 <cell>Natal</cell>
                                 <cell>Capt. Fabre</cell>
-                                <cell>returning from <placeName ref="https://www.wikidata.org/wiki/Q148">China</placeName></cell>
+                                <cell>returning from <placeName
+                                        ref="https://www.wikidata.org/wiki/Q148"
+                                    >China</placeName></cell>
                             </row>
                             <row>
                                 <cell>Probably on</cell>
@@ -564,14 +809,19 @@
                                 <cell>July</cell>
                                 <cell>Ville de la Ciatat</cell>
                                 <cell>Capt. Etienne</cell>
-                                <cell>returning from <placeName ref="https://www.wikidata.org/wiki/Q408">Australia</placeName> </cell>
+                                <cell>returning from <placeName
+                                        ref="https://www.wikidata.org/wiki/Q408"
+                                        >Australia</placeName>
+                                </cell>
                             </row>
                         </table>
                         <table rend="frame" xml:id="SailingFromSuez">
-                            <head><hi rend="bold">Sailing from <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName> in July, 1905</hi></head>
+                            <head><hi rend="bold">Sailing from <placeName
+                                        ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>
+                                    in July, 1905</hi></head>
                             <row>
-                                <cell rows="2">For Aden, Colombo, Singapore, Saigon, Hong-Kong, Shanghai,
-                                    Kobe and Yokohama</cell>
+                                <cell rows="2">For Aden, Colombo, Singapore, Saigon, Hong-Kong,
+                                    Shanghai, Kobe and Yokohama</cell>
                                 <cell>Saturday</cell>
                                 <cell>1</cell>
                                 <cell>July</cell>
@@ -586,8 +836,8 @@
                                 <cell>Capt. Bourdon</cell>
                             </row>
                             <row>
-                                <cell>For Djibouti, Colombo, Singapore, Saigon, Hong-Kong, Shanghai, Kobe
-                                    and Yokohama</cell>
+                                <cell>For Djibouti, Colombo, Singapore, Saigon, Hong-Kong, Shanghai,
+                                    Kobe and Yokohama</cell>
                                 <cell>Saturday</cell>
                                 <cell>15</cell>
                                 <cell>July</cell>
@@ -595,8 +845,8 @@
                                 <cell>Capt. Guionnet</cell>
                             </row>
                             <row>
-                                <cell>For Djibouti, Zanzibar, Mutsamudu, Mayotte, Majunga, Nossi-Bé, D.
-                                    Suares, Tamatave, La Réunion and Maurice</cell>
+                                <cell>For Djibouti, Zanzibar, Mutsamudu, Mayotte, Majunga, Nossi-Bé,
+                                    D. Suares, Tamatave, La Réunion and Maurice</cell>
                                 <cell>Sunday</cell>
                                 <cell>16</cell>
                                 <cell>July</cell>
@@ -604,8 +854,8 @@
                                 <cell>Capt. Jourdan</cell>
                             </row>
                             <row>
-                                <cell rows="2">For Djibouti, Aden, Mabé Diego-Suares, Ste. Marie, Tamatave,
-                                    La Réunion and Maurice</cell>
+                                <cell rows="2">For Djibouti, Aden, Mabé Diego-Suares, Ste. Marie,
+                                    Tamatave, La Réunion and Maurice</cell>
                                 <cell>Saturday</cell>
                                 <cell>1</cell>
                                 <cell>July</cell>
@@ -620,8 +870,9 @@
                                 <cell>Capt. Riquier</cell>
                             </row>
                             <row>
-                                <cell>For Aden, <placeName ref="https://www.wikidata.org/wiki/Q1156">Bombay</placeName>, Colombo, Freemantle, Adelaide, Melbourne, Sidney, and
-                                    Noumes</cell>
+                                <cell>For Aden, <placeName ref="https://www.wikidata.org/wiki/Q1156"
+                                        >Bombay</placeName>, Colombo, Freemantle, Adelaide,
+                                    Melbourne, Sidney, and Noumes</cell>
                                 <cell>Monday</cell>
                                 <cell>10</cell>
                                 <cell>July</cell>
@@ -629,7 +880,8 @@
                                 <cell>Capt. Boyer</cell>
                             </row>
                         </table>
-                        <p><placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>  Agency (Shepheard's Hotel) 28-2-905</p>
+                        <p><placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>
+                            Agency (Shepheard's Hotel) 28-2-905</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-pri01">
                         <head>Prince Line.</head>
@@ -764,8 +1016,13 @@
                             </row>
                         </table>
                         <p>Good Accommodation for Passengers.</p>
-                        <p>Sailings every 10 days from Manchester and <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName> and fortnightly from Antwerp
-                            and <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> to <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> and Syrian Coast. The dates are approximate</p>
+                        <p>Sailings every 10 days from Manchester and <placeName
+                                ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName> and
+                            fortnightly from Antwerp and <placeName
+                                ref="https://www.wikidata.org/wiki/Q84">London</placeName> to
+                                <placeName ref="https://www.wikidata.org/wiki/Q87"
+                                >Alexandria</placeName> and Syrian Coast. The dates are
+                            approximate</p>
                         <table rows="4" cols="8">
                             <row>
                                 <cell>OCEAN PRINCE</cell>
@@ -780,11 +1037,15 @@
                             <row>
                                 <cell>PERSIAN PRINCE</cell>
                                 <cell>due from</cell>
-                                <cell>Antwerp &amp; <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName></cell>
+                                <cell>Antwerp &amp; <placeName
+                                        ref="https://www.wikidata.org/wiki/Q84"
+                                    >London</placeName></cell>
                                 <cell>July 23</cell>
                                 <cell>CARIB PRINCE</cell>
                                 <cell>due from</cell>
-                                <cell>Antwerp &amp; <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName></cell>
+                                <cell>Antwerp &amp; <placeName
+                                        ref="https://www.wikidata.org/wiki/Q84"
+                                    >London</placeName></cell>
                                 <cell>August 15</cell>
                             </row>
                             <row>
@@ -800,17 +1061,23 @@
                             <row>
                                 <cell>TROJAN PRINCE</cell>
                                 <cell>due from</cell>
-                                <cell>Antwerp &amp; <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName></cell>
+                                <cell>Antwerp &amp; <placeName
+                                        ref="https://www.wikidata.org/wiki/Q84"
+                                    >London</placeName></cell>
                                 <cell>July 31</cell>
                                 <cell>CREOLE PRINCE</cell>
                                 <cell>due from</cell>
-                                <cell>Antwerp &amp; <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName></cell>
+                                <cell>Antwerp &amp; <placeName
+                                        ref="https://www.wikidata.org/wiki/Q84"
+                                    >London</placeName></cell>
                                 <cell>August 29</cell>
                             </row>
                         </table>
-                        <p>HOMEWARD SAILINGS: -- The S.S. SPARTAN PRINCE is now loading for Manchester.</p>
-                        <p>For terms of freight or passage apply to C. J. Grace &amp; Co., <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>,
-                            Agents. 31-12-904</p>
+                        <p>HOMEWARD SAILINGS: -- The S.S. SPARTAN PRINCE is now loading for
+                            Manchester.</p>
+                        <p>For terms of freight or passage apply to C. J. Grace &amp; Co.,
+                                <placeName ref="https://www.wikidata.org/wiki/Q87"
+                                >Alexandria</placeName>, Agents. 31-12-904</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-nml01">
                         <head>THE NATIONAL MUTUAL LIFE ASSOCIATION OF AUSTRALASIA, LIMITED.</head>
@@ -818,8 +1085,8 @@
                         <p>With Profits Distributed every 3 Years. </p>
                         <p>Nearest Age 30.-Sun Assured £1,000.-Payable at age 50.</p>
                         <p>ANNUAL PREMIUM £47:18:4 TOTAL COST £958:6:8</p>
-                        <p>Minimum Return Over Cost exclusive of Bonuses £41:13:4. Several options at the
-                            end of 20 years. Guaranteed benefits during 20 years.</p>
+                        <p>Minimum Return Over Cost exclusive of Bonuses £41:13:4. Several options
+                            at the end of 20 years. Guaranteed benefits during 20 years.</p>
                         <table rend="frame">
                             <row>
                                 <cell/>
@@ -858,7 +1125,8 @@
                             </row>
                         </table>
                         <p>Full particulars on application to</p>
-                        <p>AGENTS IN <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> :</p>
+                        <p>AGENTS IN <placeName ref="https://www.wikidata.org/wiki/Q85"
+                                >Cairo</placeName> :</p>
                         <p>S. &amp; A. DE BILINSKI,</p>
                         <p>Khedivial Bourse Court.</p>
                         <p>LOW RATES. LIBERAL CONTRACTS. LARGE BONUSES.</p>
@@ -866,44 +1134,66 @@
                     <div type="item" scope="advertisement" xml:id="deg-ad-bal01">
                         <head>BANK OF ATHENS, LIMITED.</head>
                         <p><hi rend="bold">Capital 20,000,000 (Fully paid up).</hi></p>
-                        <p>BRANCHES: <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> 55-56 Bishops gate-street Within-<placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>, <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> ,
-                            Constantinople, Smyrna, At Candia and throughout <placeName ref="https://www.wikidata.org/wiki/Q41">Greece</placeName>.</p>
-                        <p>The Bank undertakes all banking business in Egypt, <placeName ref="https://www.wikidata.org/wiki/Q41">Greece</placeName>,<lb/> etc.
-                            Interest, on cash deposits: 3 0/0 per ann. at sight; 3 1/2 0/0 <lb/> per
-                            ann. for 6 months ; 4 0/0 per ann. for 12 months ; 5 0/0 per<lb/> ann.
-                            for 3 years and over. Savings Bank Branch receives de-<lb/>posits at 3
-                            1/2 0/0 per ann., from P.T. 30 to P.T. 10,000. 23538-19-1.905</p>
+                        <p>BRANCHES: <placeName ref="https://www.wikidata.org/wiki/Q84"
+                                >London</placeName> 55-56 Bishops gate-street Within-<placeName
+                                ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>,
+                                <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>
+                            , Constantinople, Smyrna, At Candia and throughout <placeName
+                                ref="https://www.wikidata.org/wiki/Q41">Greece</placeName>.</p>
+                        <p>The Bank undertakes all banking business in Egypt, <placeName
+                                ref="https://www.wikidata.org/wiki/Q41">Greece</placeName>,<lb/>
+                            etc. Interest, on cash deposits: 3 0/0 per ann. at sight; 3 1/2 0/0
+                            <lb/> per ann. for 6 months ; 4 0/0 per ann. for 12 months ; 5 0/0
+                            per<lb/> ann. for 3 years and over. Savings Bank Branch receives
+                            de-<lb/>posits at 3 1/2 0/0 per ann., from P.T. 30 to P.T. 10,000.
+                            23538-19-1.905</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-bam01">
                         <head>Bell's Asia Minor Steamship Co. </head>
-                        <p>Despatch weekly a steamer with good passenger accommodation carrying Mails from
-                            <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> to Cyrpus and the Syrian Coast and vice-versa.</p>
-                        <p>For particulars of freight, passage, etc., apply to the Agent Ed. A. Minotte.
-                            1099-25.2.905</p>
+                        <p>Despatch weekly a steamer with good passenger accommodation carrying
+                            Mails from <placeName ref="https://www.wikidata.org/wiki/Q87"
+                                >Alexandria</placeName> to Cyrpus and the Syrian Coast and
+                            vice-versa.</p>
+                        <p>For particulars of freight, passage, etc., apply to the Agent Ed. A.
+                            Minotte. 1099-25.2.905</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-iob01">
                         <head>IMPERIAL OTTOMAN BANK.</head>
                         <p>CAPITAL: £10,000,000.</p>
-                        <p>HEAD OFFIOE IN CONSTANTINOPLE. CHIEF AGENCIES: <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> &amp; <placeName ref="https://www.wikidata.org/wiki/Q90">Paris</placeName>.</p>
-                        <p>BRANCHES IN ALL THE PRINCIPAL TOWNS IN <placeName ref="https://www.wikidata.org/wiki/Q43">Turkey</placeName>.</p>
-                        <p>Agencies in <placeName ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName> : <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>, <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> , &amp; <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>.</p>
-                        <p>Advances on Merchandise and Securities in current account and for fixed periods.
-                            Purchase and sale of stocks and Shares on the <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> and Continental exchanges,
-                            letters of credit issued, valuables reoeived in safe custody. Drafts, cheques
-                            and telegraphic transfers issued on the principal towns of the world. Foreign
-                            exchange purchased, bills discounted, bills, invoices, annuities and dividends
-                            collected and every description of banking business transacted. 18-4-906</p>
+                        <p>HEAD OFFIOE IN CONSTANTINOPLE. CHIEF AGENCIES: <placeName
+                                ref="https://www.wikidata.org/wiki/Q84">London</placeName> &amp;
+                                <placeName ref="https://www.wikidata.org/wiki/Q90"
+                            >Paris</placeName>.</p>
+                        <p>BRANCHES IN ALL THE PRINCIPAL TOWNS IN <placeName
+                                ref="https://www.wikidata.org/wiki/Q43">Turkey</placeName>.</p>
+                        <p>Agencies in <placeName ref="https://www.wikidata.org/wiki/Q79"
+                                >Egypt</placeName> : <placeName
+                                ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>,
+                                <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>
+                            , &amp; <placeName ref="https://www.wikidata.org/wiki/Q134509">Port
+                                Said</placeName>.</p>
+                        <p>Advances on Merchandise and Securities in current account and for fixed
+                            periods. Purchase and sale of stocks and Shares on the <placeName
+                                ref="https://www.wikidata.org/wiki/Q84">London</placeName> and
+                            Continental exchanges, letters of credit issued, valuables reoeived in
+                            safe custody. Drafts, cheques and telegraphic transfers issued on the
+                            principal towns of the world. Foreign exchange purchased, bills
+                            discounted, bills, invoices, annuities and dividends collected and every
+                            description of banking business transacted. 18-4-906</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-sgr01">
                         <head>SUDAN GOVERNMENT RAILWAYS.</head>
-                        <p><placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> -KHARTOUM SUMMER MAIL SERVICE.</p>
+                        <p><placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>
+                            -KHARTOUM SUMMER MAIL SERVICE.</p>
 
-                            <table rows="3" cols="7">
+                        <table rows="3" cols="7">
                             <row>
                                 <cell>Wednesday and *Saturday</cell>
                                 <cell>8 p.m.</cell>
                                 <cell>depart</cell>
-                                <cell><placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> </cell>
+                                <cell><placeName ref="https://www.wikidata.org/wiki/Q85"
+                                        >Cairo</placeName>
+                                </cell>
                                 <cell>arrive</cell>
                                 <cell>*Monday and *Friday</cell>
                                 <cell>7.20 a.m.</cell>
@@ -936,45 +1226,64 @@
                                 <cell>12 noon</cell>
                             </row>
                         </table>
-                        <p>Mail delivered Khartoum, Sun. and Wednesday evening, and <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> , Mon. and Friday
-                            evening. *Dining and Sleeping Cars.</p>
+                        <p>Mail delivered Khartoum, Sun. and Wednesday evening, and <placeName
+                                ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> , Mon. and
+                            Friday evening. *Dining and Sleeping Cars.</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-sde01">
                         <head>SUDAN DEVELOPMENT &amp; EXPLORATION COMPANY, LIMITED</head>
-                        <p>KHARTOUM: <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>  Office, Sharia Kasr-el-Nil.</p>
-                        <p>TRANSPORT DEPARTMENT. Six days White Nile Tourist Trip dep. Khartoum Tuesdays.
-                            Steamer plans may be seen and passages booked at all <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>  Tourist Agents. -
-                            Special Steamers for private charter. - Trips arranged and transport of goods
-                            undertaken to all places on White and Blue Niles within navigation limits.</p>
-                        <p>ENGINEERING DEPARTMENT. Shipyard for construction of sternwheel steamers, barges,
-                            stream, motor launches, etc. Contractors for supply and erection of all classes
-                            of machinery, buildings, irrigation pumps, etc.</p>
-                        <p>SOLE AGENTS FOR Dudbridges Oil Engines from 1 to 25 B.H.P. as supplied to Sudan
-                            Government. Seamless xxxxxxxxxxxxxxxxxxxxx</p>
+                        <p>KHARTOUM: <placeName ref="https://www.wikidata.org/wiki/Q85"
+                                >Cairo</placeName> Office, Sharia Kasr-el-Nil.</p>
+                        <p>TRANSPORT DEPARTMENT. Six days White Nile Tourist Trip dep. Khartoum
+                            Tuesdays. Steamer plans may be seen and passages booked at all
+                                <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>
+                            Tourist Agents. - Special Steamers for private charter. - Trips arranged
+                            and transport of goods undertaken to all places on White and Blue Niles
+                            within navigation limits.</p>
+                        <p>ENGINEERING DEPARTMENT. Shipyard for construction of sternwheel steamers,
+                            barges, stream, motor launches, etc. Contractors for supply and erection
+                            of all classes of machinery, buildings, irrigation pumps, etc.</p>
+                        <p>SOLE AGENTS FOR Dudbridges Oil Engines from 1 to 25 B.H.P. as supplied to
+                            Sudan Government. Seamless xxxxxxxxxxxxxxxxxxxxx</p>
                     </div>
                     <cb n="3"/>
                     <div type="item" scope="advertisement" xml:id="deg-ad-aan01">
                         <head>Anglo-American Nile Steamer &amp; Hotel Coy.</head>
-                        <p>Weekly departure during Winter Season by the<lb/> Luxurious First Class Tourist
-                            Steamers VICTORIA, PURITAN &amp; MAYFLOWER.<lb/> Regular weekly Departures to
-                            the SECOND CATARACT by the S.S. IndianA.<lb/> THROUGH BOOKINGS TO KHARTOUM,
-                            GONDOKORO AND THE WHITE NILE.<lb/> Steamers and Dahabeahs for private charter.
-                            Steam Tugs and Steam Launches for hire.<lb/> FREIGHT SERVICE BY STEAM BARGES
-                            BETWEEN <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>  AND <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>.<lb/> Working in conjunction and under special
-                            arrangement with the<lb/> “Upper <placeName ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName> Hotels Company."</p>
-                        <p>For details and illustrated programmes apply to "THE ANGLO-AMERICAN NILE STEAMER
-                            and<lb/> HOTEL COMPANY."</p>
-                        <p> OFFICES IN <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> : Sharia Boulac, "Grand Continental Hotel Buildings.” 31-3-06</p>
+                        <p>Weekly departure during Winter Season by the<lb/> Luxurious First Class
+                            Tourist Steamers VICTORIA, PURITAN &amp; MAYFLOWER.<lb/> Regular weekly
+                            Departures to the SECOND CATARACT by the S.S. IndianA.<lb/> THROUGH
+                            BOOKINGS TO KHARTOUM, GONDOKORO AND THE WHITE NILE.<lb/> Steamers and
+                            Dahabeahs for private charter. Steam Tugs and Steam Launches for
+                            hire.<lb/> FREIGHT SERVICE BY STEAM BARGES BETWEEN <placeName
+                                ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> AND
+                                <placeName ref="https://www.wikidata.org/wiki/Q87"
+                                >Alexandria</placeName>.<lb/> Working in conjunction and under
+                            special arrangement with the<lb/> “Upper <placeName
+                                ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName> Hotels
+                            Company."</p>
+                        <p>For details and illustrated programmes apply to "THE ANGLO-AMERICAN NILE
+                            STEAMER and<lb/> HOTEL COMPANY."</p>
+                        <p> OFFICES IN <placeName ref="https://www.wikidata.org/wiki/Q85"
+                                >Cairo</placeName> : Sharia Boulac, "Grand Continental Hotel
+                            Buildings.” 31-3-06</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-nll02">
                         <head>NORDDEUTSCHER LLOYD.</head>
-                        <p>Regular Service from <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> (Passenger and Freight) to <placeName ref="https://www.wikidata.org/wiki/Q2634">Naples</placeName> -<placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName>.</p>
-                        <p> SCHLESWIG will leave <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> at 4 p.m. July 26, August 30, September 20, etc. </p>
-                        <p>The following steamers are intended to leave <placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName> : </p>
+                        <p>Regular Service from <placeName ref="https://www.wikidata.org/wiki/Q87"
+                                >Alexandria</placeName> (Passenger and Freight) to <placeName
+                                ref="https://www.wikidata.org/wiki/Q2634">Naples</placeName>
+                                -<placeName ref="https://www.wikidata.org/wiki/Q579613"
+                                >Marseilles</placeName>.</p>
+                        <p> SCHLESWIG will leave <placeName ref="https://www.wikidata.org/wiki/Q87"
+                                >Alexandria</placeName> at 4 p.m. July 26, August 30, September 20,
+                            etc. </p>
+                        <p>The following steamers are intended to leave <placeName
+                                ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName> : </p>
                         <table rows="14" cols="3">
                             <row>
-                                <cell cols="3">HOMEWARD : for Bremen Hamburg via <placeName ref="https://www.wikidata.org/wiki/Q2634">Naples</placeName> , Genoa, (Gibraltar),
-                                    Southampton, Antwerp.</cell>
+                                <cell cols="3">HOMEWARD : for Bremen Hamburg via <placeName
+                                        ref="https://www.wikidata.org/wiki/Q2634">Naples</placeName>
+                                    , Genoa, (Gibraltar), Southampton, Antwerp.</cell>
                             </row>
                             <row>
                                 <cell>Zieten</cell>
@@ -1002,8 +1311,11 @@
                                 <cell>about 28 August</cell>
                             </row>
                             <row>
-                                <cell cols="3">OUTWARD: for <placeName ref="https://www.wikidata.org/wiki/Q148">China</placeName> and JAPAN via <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>, ADEN, COLOMBO, PENANG,
-                                    SINGAPORE.</cell>
+                                <cell cols="3">OUTWARD: for <placeName
+                                        ref="https://www.wikidata.org/wiki/Q148">China</placeName>
+                                    and JAPAN via <placeName
+                                        ref="https://www.wikidata.org/wiki/Q134514"
+                                    >Suez</placeName>, ADEN, COLOMBO, PENANG, SINGAPORE.</cell>
                             </row>
                             <row>
                                 <cell>Prinz E. Friedrich</cell>
@@ -1021,7 +1333,11 @@
                                 <cell>about 7 August</cell>
                             </row>
                             <row>
-                                <cell cols="3">For <placeName ref="https://www.wikidata.org/wiki/Q408">Australia</placeName> via <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>, ADEN, COLOMBO.</cell>
+                                <cell cols="3">For <placeName
+                                        ref="https://www.wikidata.org/wiki/Q408"
+                                        >Australia</placeName> via <placeName
+                                        ref="https://www.wikidata.org/wiki/Q134514"
+                                    >Suez</placeName>, ADEN, COLOMBO.</cell>
                             </row>
                             <row>
                                 <cell>Seydlitz</cell>
@@ -1040,19 +1356,38 @@
                             </row>
                         </table>
                         <p>FOR FURTHER PARTICULARS APPLY TO THE AGENTS OF THE </p>
-                        <p>NORDDEUTSCHER LLOYD at <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> , <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>, <placeName ref="https://www.wikidata.org/wiki/Q134509">Port-Said</placeName>  and <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>. </p>
-                        <p>OTTO STERZING, Agent In <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> , Opera Square. </p>
-                        <p>C. H. SCHOELLER, Agent In <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>, Cleopatra Lane.</p>
-                        <p>Messrs. THOS. COOK &amp; SON (Egypt) LTD., and CARL STANGENS REISEBUREAN are
-                            anthorised to sell tickets in <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>  and <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>, 31-8-905</p>
+                        <p>NORDDEUTSCHER LLOYD at <placeName ref="https://www.wikidata.org/wiki/Q85"
+                                >Cairo</placeName> , <placeName
+                                ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>,
+                                <placeName ref="https://www.wikidata.org/wiki/Q134509"
+                                >Port-Said</placeName> and <placeName
+                                ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>. </p>
+                        <p>OTTO STERZING, Agent In <placeName
+                                ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> , Opera
+                            Square. </p>
+                        <p>C. H. SCHOELLER, Agent In <placeName
+                                ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>,
+                            Cleopatra Lane.</p>
+                        <p>Messrs. THOS. COOK &amp; SON (Egypt) LTD., and CARL STANGENS REISEBUREAN
+                            are anthorised to sell tickets in <placeName
+                                ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> and
+                                <placeName ref="https://www.wikidata.org/wiki/Q87"
+                                >Alexandria</placeName>, 31-8-905</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-als01">
                         <head>Austrian Lloyd’s Steam Navigation</head>
-                        <p><placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>-Brindisi-Venice-Trieste.</p>
-                        <p>Weekly Express Mail Service. Steamers leave <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> every Saturday at 4 p.m.
-                            arrive at Brindisi, Tuesday a.m. in time for express to <placeName ref="https://www.wikidata.org/wiki/Q90">Paris</placeName>, <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName>, <placeName ref="https://www.wikidata.org/wiki/Q2634">Naples</placeName> ,
-                            Rome. Arrival Trieste Wednesday noon connecting with Vienna Express
-                            (Trieste-Ostende through carriage) and expresses to Italy and Germany.</p>
+                        <p><placeName ref="https://www.wikidata.org/wiki/Q87"
+                            >Alexandria</placeName>-Brindisi-Venice-Trieste.</p>
+                        <p>Weekly Express Mail Service. Steamers leave <placeName
+                                ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> every
+                            Saturday at 4 p.m. arrive at Brindisi, Tuesday a.m. in time for express
+                            to <placeName ref="https://www.wikidata.org/wiki/Q90">Paris</placeName>,
+                                <placeName ref="https://www.wikidata.org/wiki/Q84"
+                                >London</placeName>, <placeName
+                                ref="https://www.wikidata.org/wiki/Q2634">Naples</placeName> , Rome.
+                            Arrival Trieste Wednesday noon connecting with Vienna Express
+                            (Trieste-Ostende through carriage) and expresses to Italy and
+                            Germany.</p>
                         <table rows="3" cols="8">
                             <row>
                                 <cell>July 8</cell>
@@ -1085,7 +1420,8 @@
                                 <cell/>
                             </row>
                         </table>
-                        <p>Fortnightly Service: <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>-Brindisi-Venice-Trieste </p>
+                        <p>Fortnightly Service: <placeName ref="https://www.wikidata.org/wiki/Q87"
+                                >Alexandria</placeName>-Brindisi-Venice-Trieste </p>
                         <table rows="1" cols="8">
                             <row>
                                 <cell>June 21</cell>
@@ -1098,28 +1434,46 @@
                                 <cell>Capt. Knezevich</cell>
                             </row>
                         </table>
-                        <p>(Departures from <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>) To Aden, <placeName ref="https://www.wikidata.org/wiki/Q1156">Bombay</placeName>, Colombo, Penang, Singapore, Hong-Kong,
-                            Shanghai, Yokohama, Kobé about July 5 and August 4. To Aden, Karachi, and <placeName ref="https://www.wikidata.org/wiki/Q1156">Bombay</placeName>
-                            accelerated service about August 18. To Aden, Karachi, <placeName ref="https://www.wikidata.org/wiki/Q1156">Bombay</placeName>, Colombo, Madras,
-                            Rangoon, and Calcutta about July 20.</p>
+                        <p>(Departures from <placeName ref="https://www.wikidata.org/wiki/Q134514"
+                                >Suez</placeName>) To Aden, <placeName
+                                ref="https://www.wikidata.org/wiki/Q1156">Bombay</placeName>,
+                            Colombo, Penang, Singapore, Hong-Kong, Shanghai, Yokohama, Kobé about
+                            July 5 and August 4. To Aden, Karachi, and <placeName
+                                ref="https://www.wikidata.org/wiki/Q1156">Bombay</placeName>
+                            accelerated service about August 18. To Aden, Karachi, <placeName
+                                ref="https://www.wikidata.org/wiki/Q1156">Bombay</placeName>,
+                            Colombo, Madras, Rangoon, and Calcutta about July 20.</p>
                         <p>East African Line.</p>
-                        <p>To Aden, Mombassa, Zanzibar, Beira, Delagoa Bay, Durban, about July 4 and August
-                            3.</p>
+                        <p>To Aden, Mombassa, Zanzibar, Beira, Delagoa Bay, Durban, about July 4 and
+                            August 3.</p>
                         <p>Syrian-Cyprus-Caramanian Line.</p>
-                        <p>Steamers leaves <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> on or about July 3, 17 and 31.</p>
-                        <p>For information apply to the Agents, <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>, <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> and <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>, Thos. Cook
-                            &amp; Son, Ld., Leon Heller, <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>  Agent, 4, Sharia Maghraby, (Telephone 192),
-                            <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> ; F. Tedeschi, Helouan.</p>
-                        <p>Special passage rates granted to Egyptian Government officials, members of the
-                            Army of Occupation and their families. </p>
+                        <p>Steamers leaves <placeName ref="https://www.wikidata.org/wiki/Q87"
+                                >Alexandria</placeName> on or about July 3, 17 and 31.</p>
+                        <p>For information apply to the Agents, <placeName
+                                ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>,
+                                <placeName ref="https://www.wikidata.org/wiki/Q134509">Port
+                                Said</placeName> and <placeName
+                                ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>, Thos.
+                            Cook &amp; Son, Ld., Leon Heller, <placeName
+                                ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> Agent, 4,
+                            Sharia Maghraby, (Telephone 192), <placeName
+                                ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> ; F.
+                            Tedeschi, Helouan.</p>
+                        <p>Special passage rates granted to Egyptian Government officials, members
+                            of the Army of Occupation and their families. </p>
                         <p>31-12-905</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-cun01">
                         <head>Cunard Line.</head>
                         <table rows="4" cols="6">
-                            <head><placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> to New-York and Boston via the Continent and <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName></head>
+                            <head><placeName ref="https://www.wikidata.org/wiki/Q87"
+                                    >Alexandria</placeName> to New-York and Boston via the Continent
+                                and <placeName ref="https://www.wikidata.org/wiki/Q24826"
+                                    >Liverpool</placeName></head>
                             <row>
-                                <cell cols="6">Sailings from <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName> on Saturdays and Tuesdays. Royal Mail
+                                <cell cols="6">Sailings from <placeName
+                                        ref="https://www.wikidata.org/wiki/Q24826"
+                                        >Liverpool</placeName> on Saturdays and Tuesdays. Royal Mail
                                     Steamers:</cell>
                             </row>
                             <row>
@@ -1148,10 +1502,12 @@
                             </row>
                         </table>
                         <table rows="3" cols="4">
-                            <head><placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> to New-York via Trieste, Fiume or Palermo</head>
+                            <head><placeName ref="https://www.wikidata.org/wiki/Q87"
+                                    >Alexandria</placeName> to New-York via Trieste, Fiume or
+                                Palermo</head>
                             <row>
-                                <cell cols="4">Regular twin-screw Passenger Service from the Adriatic.
-                                    Excellent accommodation.</cell>
+                                <cell cols="4">Regular twin-screw Passenger Service from the
+                                    Adriatic. Excellent accommodation.</cell>
                             </row>
                             <row>
                                 <cell>Carpathia</cell>
@@ -1166,45 +1522,73 @@
                                 <cell>10,402 tons</cell>
                             </row>
                         </table>
-                        <p>All steamers fitted with Marconi's wireless telegraphy. For through tickets from
-                            Egypt, and particulars aply to the Agents Rodacanachi &amp; Co., <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>;
-                            Nic. Kerzis, <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> ; R. Broadbent, <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>. 19-1-905</p>
+                        <p>All steamers fitted with Marconi's wireless telegraphy. For through
+                            tickets from Egypt, and particulars aply to the Agents Rodacanachi &amp;
+                            Co., <placeName ref="https://www.wikidata.org/wiki/Q87"
+                                >Alexandria</placeName>; Nic. Kerzis, <placeName
+                                ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> ; R.
+                            Broadbent, <placeName ref="https://www.wikidata.org/wiki/Q134509">Port
+                                Said</placeName>. 19-1-905</p>
                     </div>
                     <!-- TODO Russian Steam Navigation -->
                     <div type="item" scope="advertisement" xml:id="deg-ad-pap01">
                         <head>THE PAPAYANNI LINE.</head>
                         <head type="sub">(The Ellerman Lines, Ltd.)</head>
-                        <p>Frequent Sailings from <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> to <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName>, also Regular Services from
-                            <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName> to <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> and to ALGERIA, <placeName ref="https://www.wikidata.org/wiki/Q233">Malta</placeName>, LEVANT, BLACK SEA, and other
-                            Mediterranean Ports.</p>
-                        <p>Excellent Passenger Accommodation. Stewardess carried. Liberal table and Moderate
-                            Fares for single and retnrn tickets. </p>
-                        <p>The S S. SARDINIA will sail for <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName> (via Bona) on Friday, the 7th inst. at
-                            4 p.m.</p>
-                        <p>CARGO taken by special agreement only. Through Freights quoted for the UNITED
-                            STATES and INLAND TOWNS in GREAT BRITAIN.</p>
-                        <p>For passage or freight apply to the Agents, BARKER &amp; Co., <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>.
+                        <p>Frequent Sailings from <placeName ref="https://www.wikidata.org/wiki/Q87"
+                                >Alexandria</placeName> to <placeName
+                                ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName>,
+                            also Regular Services from <placeName
+                                ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName> to
+                                <placeName ref="https://www.wikidata.org/wiki/Q87"
+                                >Alexandria</placeName> and to ALGERIA, <placeName
+                                ref="https://www.wikidata.org/wiki/Q233">Malta</placeName>, LEVANT,
+                            BLACK SEA, and other Mediterranean Ports.</p>
+                        <p>Excellent Passenger Accommodation. Stewardess carried. Liberal table and
+                            Moderate Fares for single and retnrn tickets. </p>
+                        <p>The S S. SARDINIA will sail for <placeName
+                                ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName>
+                            (via Bona) on Friday, the 7th inst. at 4 p.m.</p>
+                        <p>CARGO taken by special agreement only. Through Freights quoted for the
+                            UNITED STATES and INLAND TOWNS in GREAT BRITAIN.</p>
+                        <p>For passage or freight apply to the Agents, BARKER &amp; Co., <placeName
+                                ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>.
                             2061-17-10-905 </p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-ell01">
                         <head>Ellerman Lines, Limited.</head>
                         <table rows="3" cols="6">
                             <row>
-                                <cell cols="3">CITY LINE to <placeName ref="https://www.wikidata.org/wiki/Q233">Malta</placeName>, <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName>, COLOMBO &amp; CALCUTTA.</cell>
+                                <cell cols="3">CITY LINE to <placeName
+                                        ref="https://www.wikidata.org/wiki/Q233">Malta</placeName>,
+                                        <placeName ref="https://www.wikidata.org/wiki/Q84"
+                                        >London</placeName>, COLOMBO &amp; CALCUTTA.</cell>
                                 <cell cols="3">
-                                    <p>CITY &amp; HALL LINES. Joint Service to <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName>, <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName>, <placeName ref="https://www.wikidata.org/wiki/Q1156">Bombay</placeName>
-                                        &amp; KARACHI.</p>
+                                    <p>CITY &amp; HALL LINES. Joint Service to <placeName
+                                            ref="https://www.wikidata.org/wiki/Q579613"
+                                            >Marseilles</placeName>, <placeName
+                                            ref="https://www.wikidata.org/wiki/Q24826"
+                                            >Liverpool</placeName>, <placeName
+                                            ref="https://www.wikidata.org/wiki/Q1156"
+                                            >Bombay</placeName> &amp; KARACHI.</p>
                                 </cell>
                             </row>
                             <row>
-                                <cell cols="6">The undermentioned First Class Passenger Steamers will be
-                                    dispatched from <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> on or about the following dates for </cell>
+                                <cell cols="6">The undermentioned First Class Passenger Steamers
+                                    will be dispatched from <placeName
+                                        ref="https://www.wikidata.org/wiki/Q134509">Port
+                                        Said</placeName> on or about the following dates for </cell>
                             </row>
                             <row>
-                                <cell><placeName ref="https://www.wikidata.org/wiki/Q233">Malta</placeName> and <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> </cell>
+                                <cell><placeName ref="https://www.wikidata.org/wiki/Q233"
+                                        >Malta</placeName> and <placeName
+                                        ref="https://www.wikidata.org/wiki/Q84">London</placeName>
+                                </cell>
                                 <cell>S.S. City of Corinth </cell>
                                 <cell>July 26</cell>
-                                <cell><placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName> and <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName></cell>
+                                <cell><placeName ref="https://www.wikidata.org/wiki/Q579613"
+                                        >Marseilles</placeName> and <placeName
+                                        ref="https://www.wikidata.org/wiki/Q24826"
+                                        >Liverpool</placeName></cell>
                                 <cell/>
                                 <cell/>
                             </row>
@@ -1212,68 +1596,102 @@
                                 <cell>Colombo and Calcutta</cell>
                                 <cell>S.S. City of Manchester</cell>
                                 <cell>July 12</cell>
-                                <cell><placeName ref="https://www.wikidata.org/wiki/Q1156">Bombay</placeName></cell>
+                                <cell><placeName ref="https://www.wikidata.org/wiki/Q1156"
+                                        >Bombay</placeName></cell>
                                 <cell>S.S. Anton Hall</cell>
                                 <cell>July 13</cell>
                             </row>
                         </table>
-                        <p>SALOON FARES:—<placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> to <placeName ref="https://www.wikidata.org/wiki/Q233">Malta</placeName> £4.10.0. <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName>. £8.0.0. <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> or
-                            <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName>, £l2.l0.0. Colombo, Calcutta, <placeName ref="https://www.wikidata.org/wiki/Q1156">Bombay</placeName> or Karachi, £35.0.0. Special
-                            rates for steamers not carrying Doctor or Stewardess. For further particulars
-                            apply to </p>
-                        <p>CORY BROS. &amp; Co., Ltd., Agents for CITY Line, <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>: W. STAPLEDON &amp;
-                            SON, Agents for Hall Line, <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> ; or COOK &amp; SON (Egypt), Ltd., <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> .
+                        <p>SALOON FARES:—<placeName ref="https://www.wikidata.org/wiki/Q134509">Port
+                                Said</placeName> to <placeName
+                                ref="https://www.wikidata.org/wiki/Q233">Malta</placeName> £4.10.0.
+                                <placeName ref="https://www.wikidata.org/wiki/Q579613"
+                                >Marseilles</placeName>. £8.0.0. <placeName
+                                ref="https://www.wikidata.org/wiki/Q84">London</placeName> or
+                                <placeName ref="https://www.wikidata.org/wiki/Q24826"
+                                >Liverpool</placeName>, £l2.l0.0. Colombo, Calcutta, <placeName
+                                ref="https://www.wikidata.org/wiki/Q1156">Bombay</placeName> or
+                            Karachi, £35.0.0. Special rates for steamers not carrying Doctor or
+                            Stewardess. For further particulars apply to </p>
+                        <p>CORY BROS. &amp; Co., Ltd., Agents for CITY Line, <placeName
+                                ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>:
+                            W. STAPLEDON &amp; SON, Agents for Hall Line, <placeName
+                                ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> ;
+                            or COOK &amp; SON (Egypt), Ltd., <placeName
+                                ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> .
                             23788-28-8-905 </p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-ell02">
                         <head>The Ellerman Lines, Limited.</head>
                         <head type="sub">(Including Westcott &amp; Laurance Line.)</head>
-                        <p>Regular sailings from <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName>, Glasgow, Antwerp and <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> to <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>.
-                            Frequent sailings from <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> to <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName> and <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName>. Through freight rates
-                            to Inland towns in Great Britain also to the U.S.A</p>
+                        <p>Regular sailings from <placeName
+                                ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName>,
+                            Glasgow, Antwerp and <placeName ref="https://www.wikidata.org/wiki/Q84"
+                                >London</placeName> to <placeName
+                                ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>.
+                            Frequent sailings from <placeName
+                                ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> to
+                                <placeName ref="https://www.wikidata.org/wiki/Q24826"
+                                >Liverpool</placeName> and <placeName
+                                ref="https://www.wikidata.org/wiki/Q84">London</placeName>. Through
+                            freight rates to Inland towns in Great Britain also to the U.S.A</p>
                         <table rows="4" cols="5">
                             <row>
                                 <cell>Westcott S.S. Joshua Nicholson</cell>
                                 <cell>expected from</cell>
-                                <cell>Antwerp, <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> &amp; <placeName ref="https://www.wikidata.org/wiki/Q233">Malta</placeName></cell>
+                                <cell>Antwerp, <placeName ref="https://www.wikidata.org/wiki/Q84"
+                                        >London</placeName> &amp; <placeName
+                                        ref="https://www.wikidata.org/wiki/Q233"
+                                    >Malta</placeName></cell>
                                 <cell>is due on or about</cell>
                                 <cell>July 16</cell>
                             </row>
                             <row>
                                 <cell>Ellerman S.S. City of Dundee</cell>
                                 <cell>expected from</cell>
-                                <cell>Glasgow, Gibraltar &amp; <placeName ref="https://www.wikidata.org/wiki/Q233">Malta</placeName></cell>
+                                <cell>Glasgow, Gibraltar &amp; <placeName
+                                        ref="https://www.wikidata.org/wiki/Q233"
+                                    >Malta</placeName></cell>
                                 <cell>is due on or about</cell>
                                 <cell>July 25</cell>
                             </row>
                             <row>
                                 <cell>Westcott S.S. Plymothian</cell>
                                 <cell>expected from</cell>
-                                <cell>Antwerp, <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> &amp; <placeName ref="https://www.wikidata.org/wiki/Q233">Malta</placeName></cell>
+                                <cell>Antwerp, <placeName ref="https://www.wikidata.org/wiki/Q84"
+                                        >London</placeName> &amp; <placeName
+                                        ref="https://www.wikidata.org/wiki/Q233"
+                                    >Malta</placeName></cell>
                                 <cell>is due on or about</cell>
                                 <cell>July 25</cell>
                             </row>
                             <row>
                                 <cell>Ellerman S.S. City of Oxford</cell>
                                 <cell>expected from</cell>
-                                <cell><placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName> &amp; Melta</cell>
+                                <cell><placeName ref="https://www.wikidata.org/wiki/Q24826"
+                                        >Liverpool</placeName> &amp; Melta</cell>
                                 <cell>is due on or about</cell>
                                 <cell>July 30</cell>
                             </row>
                         </table>
-                        <p>Ellerman S.S. Britannia now on the berth for <placeName ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName> is expected to sail about
-                            the 25th inst.</p>
-                        <p>N. E. TAMVACO <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> agents 23186-20-3-3</p>
+                        <p>Ellerman S.S. Britannia now on the berth for <placeName
+                                ref="https://www.wikidata.org/wiki/Q24826">Liverpool</placeName> is
+                            expected to sail about the 25th inst.</p>
+                        <p>N. E. TAMVACO <placeName ref="https://www.wikidata.org/wiki/Q87"
+                                >Alexandria</placeName> agents 23186-20-3-3</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-ngi01">
                         <head>Navigation Générale Italienne.</head>
-                        <p>Societes Reunies Florio-Rubattino. - Services Postaux. - Departs de Juillet.</p>
+                        <p>Societes Reunies Florio-Rubattino. - Services Postaux. - Departs de
+                            Juillet.</p>
                         <table rows="5" cols="4">
                             <row>
                                 <cell>Les Jeudis</cell>
                                 <cell>6, 13, 20, et 27</cell>
                                 <cell>à 3 h. p.m.</cell>
-                                <cell>direct pour Messine, <placeName ref="https://www.wikidata.org/wiki/Q2634">Naples</placeName> , Livourne et Gênes.</cell>
+                                <cell>direct pour Messine, <placeName
+                                        ref="https://www.wikidata.org/wiki/Q2634">Naples</placeName>
+                                    , Livourne et Gênes.</cell>
                             </row>
                             <row>
                                 <cell>Les Samedis</cell>
@@ -1291,7 +1709,9 @@
                                 <cell>Le Lundi</cell>
                                 <cell>24</cell>
                                 <cell>à 4 h. p.m.</cell>
-                                <cell>pour Port-Saïd, <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName> et Massawah.</cell>
+                                <cell>pour Port-Saïd, <placeName
+                                        ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>
+                                    et Massawah.</cell>
                             </row>
                             <row>
                                 <cell>Le Vendredi</cell>
@@ -1303,13 +1723,18 @@
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-sio01">
                         <head>Sun Insurance Office,</head>
-                        <p><placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName>. Founded 1710.-Total sum insured in 1902 £487,600,000.</p>
-                        <p>Agents : LEON HELLER, <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> , and BEHREND &amp; Co., <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>. 16-1-906</p>
+                        <p><placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName>.
+                            Founded 1710.-Total sum insured in 1902 £487,600,000.</p>
+                        <p>Agents : LEON HELLER, <placeName ref="https://www.wikidata.org/wiki/Q85"
+                                >Cairo</placeName> , and BEHREND &amp; Co., <placeName
+                                ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>.
+                            16-1-906</p>
                     </div>
                     <div type="item" scope="advertisement" xml:id="deg-ad-rea01">
                         <head>ROYAL EXCHANGE ASSURANCE.</head>
                         <p>Incorporated A. D. 1720.</p>
-                        <p>Chief Office: ROYAL EXCHANGE, <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName>, E.C.</p>
+                        <p>Chief Office: ROYAL EXCHANGE, <placeName
+                                ref="https://www.wikidata.org/wiki/Q84">London</placeName>, E.C.</p>
                         <p>FUNDS IN HAND EXCEED £4,500,000 CLAIMS PAID £40,000,000</p>
                         <table rows="2" cols="2">
                             <row role="label">
@@ -1317,12 +1742,16 @@
                                 <cell>MARINE</cell>
                             </row>
                             <row>
-                                <cell><placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> … ANGLO-EGYPTIAN BANK.</cell>
-                                <cell><placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> … Mr. J. B. CAFFARI</cell>
+                                <cell><placeName ref="https://www.wikidata.org/wiki/Q87"
+                                        >Alexandria</placeName> … ANGLO-EGYPTIAN BANK.</cell>
+                                <cell><placeName ref="https://www.wikidata.org/wiki/Q87"
+                                        >Alexandria</placeName> … Mr. J. B. CAFFARI</cell>
                             </row>
                             <row>
-                                <cell><placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>  … Mr. J. B. CAFFARI</cell>
-                                <cell><placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName> … Mr. GEO. MEINECKE.</cell>
+                                <cell><placeName ref="https://www.wikidata.org/wiki/Q85"
+                                        >Cairo</placeName> … Mr. J. B. CAFFARI</cell>
+                                <cell><placeName ref="https://www.wikidata.org/wiki/Q134514"
+                                        >Suez</placeName> … Mr. GEO. MEINECKE.</cell>
                             </row>
                         </table>
                         <p>21281-216905</p>
@@ -1350,20 +1779,20 @@
                         <p>Codes-- ABC, 4th and 5th Editions, A1.</p>
                         <p>MORNING &amp; NEAL'S.</p>
                         <p>Trade Mark — “INVINCIBLE."</p>
-                        <p>MANUFACTURERS OF THE LARGEST AND MOST EFFICIENT Centrifugal Pumping Machinery In
-                              the world, suitable fcr all purposes, including RECLAMATION, DRAINAGE,
-                              IRRIGATION, SEWAGE WORKS, GRAVING &amp; FLOATING DOCKS, MINES, &amp; ALL
-                              MANUFACTURING PURPOSES.</p>
-                        <p>These Pumps can be driven by Steam, Gas, Oil, Water, Electricity, or other power,
-                              for Lifts of from 1 ft. to 500ft., and from 5 to 500,000 Gallons a Minute.
-                              Makers of the Mex Pumps.</p>
+                        <p>MANUFACTURERS OF THE LARGEST AND MOST EFFICIENT Centrifugal Pumping
+                            Machinery In the world, suitable fcr all purposes, including
+                            RECLAMATION, DRAINAGE, IRRIGATION, SEWAGE WORKS, GRAVING &amp; FLOATING
+                            DOCKS, MINES, &amp; ALL MANUFACTURING PURPOSES.</p>
+                        <p>These Pumps can be driven by Steam, Gas, Oil, Water, Electricity, or
+                            other power, for Lifts of from 1 ft. to 500ft., and from 5 to 500,000
+                            Gallons a Minute. Makers of the Mex Pumps.</p>
                         <p>Results Guaranteed.</p>
                         <p>Over 50 Years' Practical Experience.</p>
-                        <p>All kinds of Pumping and Irrigation Machinery specially designed to meet Egyptian
-                              requirements.</p>
+                        <p>All kinds of Pumping and Irrigation Machinery specially designed to meet
+                            Egyptian requirements.</p>
                         <p>London Offices— 81, Cannon Street, London, E.C.</p>
                         <p>The British Engineering Company of Egypt, Ltd: Rue de la Gare du Caire,
-                              Alexandria.</p>
+                            Alexandria.</p>
                         <p>Works- Hammersmith, London, W</p>
                         <p>23362-11-12-904</p>
                     </div>
@@ -1371,44 +1800,48 @@
                         <head>THE ARTESIAN BORING AND PROSPECTING COMPANY.</head>
                         <p>(SOCIÉTÉ ANONYME)</p>
                         <p>CAIRO, 28, SHARIA-EL-MANAKH,<lb/> (OPPOSITE IMPERIAL OTTOMAN BANK).</p>
-                        <p>I. —Installation of complete Water supplies for drinking, agricultural, and<lb/>
-                              industrial purposes by means of artesian wells.</p>
-                        <p>II. - Deep borings for prospecting purposes in all conditions of soil by means of
-                              the<lb/> “Express Boring System."</p>
+                        <p>I. —Installation of complete Water supplies for drinking, agricultural,
+                            and<lb/> industrial purposes by means of artesian wells.</p>
+                        <p>II. - Deep borings for prospecting purposes in all conditions of soil by
+                            means of the<lb/> “Express Boring System."</p>
                         <p>24,437-12-1-905</p>
                     </div>
                     <cols n="2"/>
                     <cb n="1"/>
                     <div type="item" scope="advertisement" xml:id="deg-ad-aeb01">
                         <head>THE ANGLO-EGYPTIAN BANK, LIMITED.</head>
-                        <p>LONDON, PARIS ALEXANDRIA, CAIRO MALTA, GIBRALTAR, TANTAH, AND PORT SAID.</p>
+                        <p>LONDON, PARIS ALEXANDRIA, CAIRO MALTA, GIBRALTAR, TANTAH, AND PORT
+                            SAID.</p>
                         <p>Subscribed Capital JS1.500,000</p>
                         <p> Paid up '' £ 500,000</p>
                         <p>Reserve Fund... 500,000</p>
                         <p>The Anglo-Egyptian Bank. Limited, undertakes every description of banking
-                              business on the most favourable conditions.</p>
+                            business on the most favourable conditions.</p>
                         <p>Current accounts opened with commercial homes and private individuals in
-                              conformity with the custom of Bankers.</p>
-                        <p>Fixed deposits for one year certain received at 8 per cent. per annum. Deposits
-                              at interest for shorter periods are also received at rates to be agreed upon.</p>
-                        <p>Letters of Credit for the use of travellers are issued payable in all parts of
-                              the World.</p>
+                            conformity with the custom of Bankers.</p>
+                        <p>Fixed deposits for one year certain received at 8 per cent. per annum.
+                            Deposits at interest for shorter periods are also received at rates to
+                            be agreed upon.</p>
+                        <p>Letters of Credit for the use of travellers are issued payable in all
+                            parts of the World.</p>
                         <p>Approved bills discounted.</p>
                         <p>Bills, documentary invoices, etc, collected.</p>
                         <p>Drafts and telegraphic transfers issued payable all over the World.</p>
                         <p>Foreign exchange bought and sold.</p>
-                        <p>Advances made upon approved securities and upon cotton, cotton-seed, sugar and
-                              other merchandise.</p>
-                        <p>The purchase and sale of stocks and shares on the London Stock Exchange; and on
-                              the local and Continental Bourses, undertaken.</p>
-                        <p>Customers can deposit their valuables, bonds, etc., for safe custody in the
-                              Bank's fire-proof strong-rooms, and the Bank will attend to the collection of
-                              the coupons and drawn bonds so deporited as they fall due.</p>
+                        <p>Advances made upon approved securities and upon cotton, cotton-seed,
+                            sugar and other merchandise.</p>
+                        <p>The purchase and sale of stocks and shares on the London Stock Exchange;
+                            and on the local and Continental Bourses, undertaken.</p>
+                        <p>Customers can deposit their valuables, bonds, etc., for safe custody in
+                            the Bank's fire-proof strong-rooms, and the Bank will attend to the
+                            collection of the coupons and drawn bonds so deporited as they fall
+                            due.</p>
                         <p>Mercantile credits issued.</p>
                         <p>Annuities, pensions, dividends, etc., collected.</p>
-                        <p>All farther particulars and information can be obtained on application.</p>
-                        <p>The officers and clerks of the Bank are pledged to secrecy as to the transactions
-                              of customers. 18-9-905</p>
+                        <p>All farther particulars and information can be obtained on
+                            application.</p>
+                        <p>The officers and clerks of the Bank are pledged to secrecy as to the
+                            transactions of customers. 18-9-905</p>
                     </div>
                     <!-- TODO Surplus Drapery Stock -->
                     <!-- TODO Howie & Co, The Hygenic Dairy -->
@@ -1434,7 +1867,8 @@
                         <p>de provenance directe et de toutes les meilleures marques</p>
                         <p>Nicolas G Sabbag</p>
                         <p>IMPORTATEUR GENERAL</p>
-                        <p>FOURNISSIUR DE S A LE KHEDIVE et de tous les grands Clubs et Hôtels d'Egypte.</p>
+                        <p>FOURNISSIUR DE S A LE KHEDIVE et de tous les grands Clubs et Hôtels
+                            d'Egypte.</p>
                         <p>2—Rue de la Gare du Caire—2 ALEXANDRIE</p>
                         <p> Adresse Télégraphique : SABBAG Alexandrie</p>
                         <p> Téléphone No 559.</p>
@@ -1455,9 +1889,10 @@
                         <p>First Class Family Hotel with Every Modern Comfort.</p>
                         <p>Unique Situation on the Beach.</p>
                         <p>Lovely Garden. Lawn Tennis. Large Terrace. Electric Light. Sea Baths. Own
-                              springs. Perfect sanitary arrangements. Stables for horses and carriages.</p>
-                        <p>Moderate Charges. -- Special terms for Government Officials and Officers of the
-                              Army of Occupation.</p>
+                            springs. Perfect sanitary arrangements. Stables for horses and
+                            carriages.</p>
+                        <p>Moderate Charges. -- Special terms for Government Officials and Officers
+                            of the Army of Occupation.</p>
                         <p>252-17.1.906</p>
                         <p>G. RUNCKEWITZ, Proprietor.</p>
                     </div>
@@ -1468,23 +1903,26 @@
                         <p>Soda Water. Lemonade, Ginger Ale, Ginger Beer. Tonic Water</p>
                         <p>Pomegranade, Orangeaade, Pineapple, Champagne, Cider, etc., etc.</p>
                         <p> Water guaranteed by Chamberlain’s Filter (Pasteur’s System).</p>
-                        <p>Inventor of WHISKY &amp; SODA and BRANDY &amp; SODA, bottled ready for use.</p>
+                        <p>Inventor of WHISKY &amp; SODA and BRANDY &amp; SODA, bottled ready for
+                            use.</p>
                         <p> Sole Agents in Egypt and Soudan for</p>
                         <p> J. Calvet &amp; Co. Bordeaux. Wine &amp; Cognacs.</p>
                         <p>Louis Roederer. Rheims. Champagnes.</p>
                         <p>August Engel. Wiesbaden. Rhine and Moselle Wines.</p>
-                        <p>Mackie &amp; Co. Glasgow. Lagavulin, White Horse Cellar &amp; other Whiskies.</p>
+                        <p>Mackie &amp; Co. Glasgow. Lagavulin, White Horse Cellar &amp; other
+                            Whiskies.</p>
                         <p>Dunville &amp; Co, Ltd. Belfast. Old Irish Whiskies.</p>
                         <p>Wm. Lanahan &amp; Son. Baltimore. Monongshels XXXX Whiskey.</p>
                         <p>The Cook &amp; Bernheimer Co. New York. Old Valley Whiskey and Gold Lion
-                              Cocktails.</p>
+                            Cocktails.</p>
                         <p>Stone &amp; Son. London. Guinness' Stout &amp; Bass' Pale Ale.</p>
                         <p>Freund Ballor &amp; Co. Tornio. Vermouth.</p>
                         <p>Pierre Bisset. Cette. Vermouth &amp; Aperitives.</p>
                         <p>Terrabonatea Company, Ld. Teas.</p>
-                        <p>Depot for Prince Metternich's "Richardsquelle," the best mineral table water in
-                              the world.</p>
-                        <p>Great assortment of Wines, Spirits, Liqueurs, of the finest Brands, etc</p>
+                        <p>Depot for Prince Metternich's "Richardsquelle," the best mineral table
+                            water in the world.</p>
+                        <p>Great assortment of Wines, Spirits, Liqueurs, of the finest Brands,
+                            etc</p>
                     </div>
                     <!-- TODO Peach's Lace Curtains -->
                     <div type="item" scope="advertisement" xml:id="deg-ad-lea01">
@@ -1496,12 +1934,12 @@
                     <div type="item" scope="advertisement" xml:id="deg-ad-dia01">
                         <head>DIAMONDS!</head>
                         <p>The largest and finest stock of Jewellery, Silver Plate, Watches, Clocks,
-                              Dressing Bags, &amp;c., new and second-hand, In the world, at wholesale
-                              prices.</p>
+                            Dressing Bags, &amp;c., new and second-hand, In the world, at wholesale
+                            prices.</p>
                         <p>Please write for Illustrated Catalogue V. The Finest in the World. 4,000
-                              Illustrations. Post Free.</p>
-                        <p>£5,000 Worth of Second-hand Jewels in Stock. WRITE FOR SPECIAL ILLUSTRATED
-                              LIST.</p>
+                            Illustrations. Post Free.</p>
+                        <p>£5,000 Worth of Second-hand Jewels in Stock. WRITE FOR SPECIAL
+                            ILLUSTRATED LIST.</p>
                         <p>ASSOCIATION OF DIAMOND MERCHANTS, LIMITED.</p>
                         <p>Trafalgar Square, London, W.C.</p>
                         <p>Established over 50 years</p>
@@ -1517,47 +1955,48 @@
                     </div>
                 </div>
                 <div type="section" scope="weather">
-                        <head>DAILY WEATHER REPORT</head>
-                        <p>OBSERVATIONS BY THE SURVEY DEPARTMENT.</p>
-                        <div type="subsection">
-                            <table rend="frame" xml:id="AlexandriaWeather">
-                                <head>ALEXANDRIA</head>
-                                <row>
-                                    <cell cols="2">Direction of wind</cell>
-                                    <cell>Calm</cell>
-                                </row>
-                                <row>
-                                    <cell cols="2">Force of wind</cell>
-                                    <cell>Slight</cell>
-                                </row>
-                                <row>
-                                    <cell cols="2">State of Sea</cell>
-                                    <cell>Calm</cell>
-                                </row>
-                                <row>
-                                    <cell rows="4">During 24 hours ending ? a.m.</cell>
-                                    <cell>Max. Temp in the shade</cell>
-                                    <cell><measure unit="degC">37.6</measure></cell>
-                                </row>
-                                <row>
-                                    <cell>Min. Temp in the shade</cell>
-                                    <cell><measure unit="degC">20.0</measure></cell>
-                                </row>
-                                <row>
-                                    <cell>Humidity</cell>
-                                    <cell><measure type="percentage">79.0</measure></cell>
-                                </row>
-                                <row>
-                                    <cell>Rainfall</cell>
-                                    <cell><measure unit="mm">—</measure></cell>
-                                </row>
-                            </table>
-                        </div>
-                        <div type="subsection">
-                            <head>REMARKS.</head>
-                            <p>The day opened fine and clear.  The degree of humidity is rather less but the barometer is falling.</p>
-                        </div>
+                    <head>DAILY WEATHER REPORT</head>
+                    <p>OBSERVATIONS BY THE SURVEY DEPARTMENT.</p>
+                    <div type="subsection">
+                        <table rend="frame" xml:id="AlexandriaWeather">
+                            <head>ALEXANDRIA</head>
+                            <row>
+                                <cell cols="2">Direction of wind</cell>
+                                <cell>Calm</cell>
+                            </row>
+                            <row>
+                                <cell cols="2">Force of wind</cell>
+                                <cell>Slight</cell>
+                            </row>
+                            <row>
+                                <cell cols="2">State of Sea</cell>
+                                <cell>Calm</cell>
+                            </row>
+                            <row>
+                                <cell rows="4">During 24 hours ending ? a.m.</cell>
+                                <cell>Max. Temp in the shade</cell>
+                                <cell><measure unit="degC">37.6</measure></cell>
+                            </row>
+                            <row>
+                                <cell>Min. Temp in the shade</cell>
+                                <cell><measure unit="degC">20.0</measure></cell>
+                            </row>
+                            <row>
+                                <cell>Humidity</cell>
+                                <cell><measure type="percentage">79.0</measure></cell>
+                            </row>
+                            <row>
+                                <cell>Rainfall</cell>
+                                <cell><measure unit="mm">—</measure></cell>
+                            </row>
+                        </table>
                     </div>
+                    <div type="subsection">
+                        <head>REMARKS.</head>
+                        <p>The day opened fine and clear. The degree of humidity is rather less but
+                            the barometer is falling.</p>
+                    </div>
+                </div>
                 <div type="item" scope="newspaper">
                     <head>THE EGYPTIAN GAZETTE.</head>
                     <p>SUBSCRIPTIONS.—Alexandria, Cairo, and the Interior of Egypt (including
@@ -1596,11 +2035,13 @@
                                 <cell>Sat.</cell>
                                 <cell>7</cell>
                                 <cell>
-                                    <p>Alex. Swimming Club. 3rd Annual<lb/>Aquatic Sports. New Graving<lb/>Dock, Gabbari. 3 p.m.</p>
-                                    <p>San Stefano Casino.  Telepathy Demonstration. 9.30 p.m.</p>
-                                    <p>Mex Casino.  Reunion des Familles 9.30 p.m.</p>
-                                    <p>Mex Prinea's Restaurant des Bains Roumanian orchestra, every afternoon.  Sundays, morning.</p>
-                                    <p>Windsor Hotel.  Orchestra.  6 to 11.30 p.m. every day.</p>
+                                    <p>Alex. Swimming Club. 3rd Annual<lb/>Aquatic Sports. New
+                                        Graving<lb/>Dock, Gabbari. 3 p.m.</p>
+                                    <p>San Stefano Casino. Telepathy Demonstration. 9.30 p.m.</p>
+                                    <p>Mex Casino. Reunion des Familles 9.30 p.m.</p>
+                                    <p>Mex Prinea's Restaurant des Bains Roumanian orchestra, every
+                                        afternoon. Sundays, morning.</p>
+                                    <p>Windsor Hotel. Orchestra. 6 to 11.30 p.m. every day.</p>
                                     <p>Alhambra - Italian company. - 9.15 p.m.</p>
                                 </cell>
                             </row>
@@ -1608,8 +2049,10 @@
                                 <cell>Sat.</cell>
                                 <cell>14</cell>
                                 <cell>
-                                    <p>Alex. Swimming Club. 60yds Juniors'<lb/>100yds. Seniors' Chapmpionships.<lb/>Customs Gate 23. 4 p.m.</p>
-                                    <p>B.R.C. Mustapha Pasha Range.<lb/>Practice and Cup Compeittion.<lb/>3 p.m.</p>
+                                    <p>Alex. Swimming Club. 60yds Juniors'<lb/>100yds. Seniors'
+                                        Chapmpionships.<lb/>Customs Gate 23. 4 p.m.</p>
+                                    <p>B.R.C. Mustapha Pasha Range.<lb/>Practice and Cup
+                                        Compeittion.<lb/>3 p.m.</p>
                                 </cell>
                             </row>
                         </div>
@@ -1620,7 +2063,7 @@
                                 <cell>Sat.</cell>
                                 <cell>7</cell>
                                 <cell>
-                                    <p>Esbekieh Theatre.  French Operetta Company.  9.15 p.m.</p>
+                                    <p>Esbekieh Theatre. French Operetta Company. 9.15 p.m.</p>
                                     <p>Theatre des Nouveautes. 9.30 p.m.</p>
                                     <p>Alcasar Parisien. 9.30 p.m.</p>
                                 </cell>
@@ -1629,20 +2072,23 @@
                                 <cell>Tues.</cell>
                                 <cell>10</cell>
                                 <cell>
-                                    <p>Esbekieh Gardens.  Performance by British Military Band. 9 to 11 p.m.</p>
+                                    <p>Esbekieh Gardens. Performance by British Military Band. 9 to
+                                        11 p.m.</p>
                                 </cell>
                             </row>
                             <row>
                                 <cell>Fri.</cell>
                                 <cell>13</cell>
                                 <cell>
-                                    <p>Esbekieh Gardens.  Performance by British Military Band. 9 to 11 p.m.</p>
+                                    <p>Esbekieh Gardens. Performance by British Military Band. 9 to
+                                        11 p.m.</p>
                                 </cell>
                             </row>
                             <row>
                                 <cell>Mon.</cell>
                                 <cell>16</cell>
-                                <cell><p></p>Cairo Musical and Dramatic Society.<lb/>Concert in aid of Calabrian Victims.<lb/>Distinguished Patronage.</cell>
+                                <cell><p/>Cairo Musical and Dramatic Society.<lb/>Concert in aid of
+                                    Calabrian Victims.<lb/>Distinguished Patronage.</cell>
                             </row>
                         </div>
                     </table>
@@ -1652,39 +2098,56 @@
                 <head>THE EGYPTIAN GAZETTE, SATURDAY, OCTOBER 7 1905</head>
                 <div type="article">
                     <head>CANAL TRAFFIC, SHIPS ENTER TODAY.</head>
-                    <dateline><placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>, <date value="1905-10-06">October 6</date>.</dateline>
-                    <p>The mail boats will enter the Canal to-morrow and pass the Chatham on Sunday. The cargo boats will follow.</p>
+                    <dateline><placeName ref="https://www.wikidata.org/wiki/Q134509">Port
+                            Said</placeName>, <date value="1905-10-06">October 6</date>.</dateline>
+                    <p>The mail boats will enter the Canal to-morrow and pass the Chatham on Sunday.
+                        The cargo boats will follow.</p>
                     <byline>(Havas)</byline>
                 </div>
                 <div type="article">
                     <head>AMERICAN INSURANCE COMPANIES.</head>
                     <head type="sub">IRREGULARITIES AND WASTE OF FUNDS.</head>
                     <dateline>New York, <date value="1905-10-06">October 6</date>.</dateline>
-                    <p>The investigation which is being made into the management of the Insurance Companies is leading every day to the discovery of fresh irregularities and waste of funds.</p>
+                    <p>The investigation which is being made into the management of the Insurance
+                        Companies is leading every day to the discovery of fresh irregularities and
+                        waste of funds.</p>
                     <byline>(Reuter)</byline>
                 </div>
                 <div type="section">
                     <head>LOCAL AND GENERAL</head>
                     <div type="article">
-                        <p>The Brindisi Mail will be made up at the G.P.O., <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>, on Tuesday at 8.30 a.m.</p>
+                        <p>The Brindisi Mail will be made up at the G.P.O., <placeName
+                                ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>, on
+                            Tuesday at 8.30 a.m.</p>
                     </div>
                     <div type="article">
-                        <p>Stray and Ownerless Dogs found in the Kobessi district during to-morrow night and at dawn of the 9th inst. will be poisoned by the police.</p>
+                        <p>Stray and Ownerless Dogs found in the Kobessi district during to-morrow
+                            night and at dawn of the 9th inst. will be poisoned by the police.</p>
                     </div>
                     <div type="article">
                         <head>The Bank of Abyssinia</head>
-                        <p>The first meeting of the directors of the above banks will be hold at <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>  next week. As has been expected Mr. McGillivray is to be appointed governor of the Bank of Abyssinia, and will proceed to Adis Ababba to take up his now duties in about two months’ time.</p>
+                        <p>The first meeting of the directors of the above banks will be hold at
+                                <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>
+                            next week. As has been expected Mr. McGillivray is to be appointed
+                            governor of the Bank of Abyssinia, and will proceed to Adis Ababba to
+                            take up his now duties in about two months’ time.</p>
                     </div>
                     <div type="article">
                         <head>MR. TAFT IN JAPAN.</head>
                         <head type="sub">IMPORTANT UNDERSTANDING WITH U S. A.</head>
                         <dateline>Tokio. <date value="1905-10-06">October 6</date>.</dateline>
-                        <p>The semi official ‘Kokoumin" says that the occasion of Mr. Taft’s voyage to Japan the latter concluded an important understanding with the United States, ‘ in consequence of Japan's explicit disavowal of any designs whatever upon the Phillipines.</p>
+                        <p>The semi official ‘Kokoumin" says that the occasion of Mr. Taft’s voyage
+                            to Japan the latter concluded an important understanding with the United
+                            States, ‘ in consequence of Japan's explicit disavowal of any designs
+                            whatever upon the Phillipines.</p>
                         <byline>(Reuter)</byline>
                     </div>
                     <div type="article">
                         <head>RUSSIAN NATIONAL ASSEMBLY.</head>
-                        <p>St. Petersburg, <date value="1905-10-06">October 6</date>. The Minister of the Interior has ordered the local authorities to abstain from interference with the forthcoming elections to the National Assembly.</p>
+                        <p>St. Petersburg, <date value="1905-10-06">October 6</date>. The Minister
+                            of the Interior has ordered the local authorities to abstain from
+                            interference with the forthcoming elections to the National
+                            Assembly.</p>
                         <byline>(Reuter)</byline>
                     </div>
                     <div type="article">
@@ -1697,176 +2160,430 @@
                     <div type="article">
                         <head>BRITISH SQUADRON AT KOBE.</head>
                         <dateline>Kobe, <date value="1905-10-06">October 6</date>.</dateline>
-                        <p>The British <placeName ref="https://www.wikidata.org/wiki/Q148">China</placeName> Squadron has arrived here.</p>
+                        <p>The British <placeName ref="https://www.wikidata.org/wiki/Q148"
+                                >China</placeName> Squadron has arrived here.</p>
                         <byline>(Reuter)</byline>
                     </div>
                     <div type="article">
                         <head>STRIKES IN LIVONIA.</head>
-                        <p>St Petersburg, <date value="1905-10-06">October 6</date>. Strikes and pillaging continue in the Livonia province.	(Havas)</p>
+                        <p>St Petersburg, <date value="1905-10-06">October 6</date>. Strikes and
+                            pillaging continue in the Livonia province. (Havas)</p>
                     </div>
                     <div type="article">
                         <head type="sub">HAMBURG-AMERIKA LINE</head>
                         <head>NEW STEAMER PURCHASED.</head>
                         <dateline>Berlin, <date value="1905-10-06">October 6</date>.</dateline>
-                        <p>The Hamburg-Amerika Line has purchased the Union Castle steamship Scot, which has been re named the Ocean. This steamer will make one of an express service between <placeName ref="https://www.wikidata.org/wiki/Q2634">Naples</placeName>  and <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>, in connection with the Berlin express.	(Reuter)</p>
+                        <p>The Hamburg-Amerika Line has purchased the Union Castle steamship Scot,
+                            which has been re named the Ocean. This steamer will make one of an
+                            express service between <placeName
+                                ref="https://www.wikidata.org/wiki/Q2634">Naples</placeName> and
+                                <placeName ref="https://www.wikidata.org/wiki/Q87"
+                                >Alexandria</placeName>, in connection with the Berlin express.
+                            (Reuter)</p>
                     </div>
                     <div type="article">
                         <head>ROMAN ATHLETIC MEETING.</head>
                         <dateline>Rome, <date value="1905-10-06">October 6</date>.</dateline>
-                        <p>A great athletic meeting is taking place in the Vatican gardens under the patronage of the Pope, who warmly approves of sports.</p>
+                        <p>A great athletic meeting is taking place in the Vatican gardens under the
+                            patronage of the Pope, who warmly approves of sports.</p>
                         <byline>(R.)</byline>
                     </div>
                 </div>
                 <div type="section">
                     <head>PERSONAL AND SOCIAL</head>
                     <div type="article">
-                        <p>Sir Vincent Corbett, the Financial Adviser, will arrive at <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> on Monday from <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName> by the North German Lloyd S.S. Schleswig.</p>
+                        <p>Sir Vincent Corbett, the Financial Adviser, will arrive at <placeName
+                                ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> on
+                            Monday from <placeName ref="https://www.wikidata.org/wiki/Q579613"
+                                >Marseilles</placeName> by the North German Lloyd S.S.
+                            Schleswig.</p>
                     </div>
                     <div type="article">
-                        <p>Lord Hindlip is shortly expected in <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>  on his way to British East Africa. His lordship is going on a six months’ visit to that country in connection with the farming scheme which he started in the Protectorate last year. Lord Hindlip is accompanied by Lady Hindlip.</p>
+                        <p>Lord Hindlip is shortly expected in <placeName
+                                ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> on his way
+                            to British East Africa. His lordship is going on a six months’ visit to
+                            that country in connection with the farming scheme which he started in
+                            the Protectorate last year. Lord Hindlip is accompanied by Lady
+                            Hindlip.</p>
                     </div>
                     <div type="article">
-                        <p>Mr. Harrison, general manager of Messrs, Thos. Cook and Sons, is expected to strive in <placeName ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName> towards the end of this month.</p>
+                        <p>Mr. Harrison, general manager of Messrs, Thos. Cook and Sons, is expected
+                            to strive in <placeName ref="https://www.wikidata.org/wiki/Q79"
+                                >Egypt</placeName> towards the end of this month.</p>
                     </div>
                     <div type="article">
-                        <p>Mr. Baehler is expected back in <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>  with his family, on Monday.</p>
+                        <p>Mr. Baehler is expected back in <placeName
+                                ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> with his
+                            family, on Monday.</p>
                     </div>
                     <div type="article">
-                        <p>Mr. David Longworth left <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>  for Nairobi yesterday.</p>
+                        <p>Mr. David Longworth left <placeName
+                                ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> for
+                            Nairobi yesterday.</p>
                     </div>
                     <div type="article">
                         <head>ST ANDREWS CHURCH.</head>
-                        <head type="sub"><placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> </head>
+                        <head type="sub"><placeName ref="https://www.wikidata.org/wiki/Q85"
+                                >Cairo</placeName>
+                        </head>
                         <p>Services — 10:30 a.m.</p>
                         <p>6 p.m.</p>
                         <p>Beginning Sunday, <date value="1905-10-08">8th October</date>.</p>
                     </div>
                     <div type="article">
                         <head>Coal Imports</head>
-                        <p>From the 1st of January to the 5th of October, 824,306 tons of coal were imported into Egypt. Wales sent 443,720, Newcastle 194,487, Scotland 99,112, Yorkshire 56,574, and other places 31.503 tons. During the corresponding period of 1904, 797,262 tons were received.</p>
+                        <p>From the 1st of January to the 5th of October, 824,306 tons of coal were
+                            imported into Egypt. Wales sent 443,720, Newcastle 194,487, Scotland
+                            99,112, Yorkshire 56,574, and other places 31.503 tons. During the
+                            corresponding period of 1904, 797,262 tons were received.</p>
                     </div>
                     <div type="article">
                         <head>Found drowned</head>
-                        <p>A corpse of a native lad aged 12, which was not identified, was found floating in the Mahmudieh canal yesterday, and on being taken out of the water was removed to the hospital for medical examination. Inquiries are being made in the hopes of identifying the body.</p>
+                        <p>A corpse of a native lad aged 12, which was not identified, was found
+                            floating in the Mahmudieh canal yesterday, and on being taken out of the
+                            water was removed to the hospital for medical examination. Inquiries are
+                            being made in the hopes of identifying the body.</p>
                     </div>
                     <div type="article">
                         <head>New Ottoman Medal</head>
-                        <p>In accordance with the Sultan's desire the Ottoman Government will strike a new medal, which will be called the "Yemen Medal." The new medal is to be confered upon the soldiers who distinguished themselvcs in suppressing the Yemen rebellion.</p>
+                        <p>In accordance with the Sultan's desire the Ottoman Government will strike
+                            a new medal, which will be called the "Yemen Medal." The new medal is to
+                            be confered upon the soldiers who distinguished themselvcs in
+                            suppressing the Yemen rebellion.</p>
                     </div>
                     <div type="article">
                         <head>Burnt to Death</head>
-                        <p>A woman of the name of Maria Rato, 25 years of age, was boiling a kettle on a gas stove on the 5th inst. when the flame caught her clothes. The flimsy material immediately flared up and the unfortunate woman received terrible burns from which she died very shortly after.</p>
+                        <p>A woman of the name of Maria Rato, 25 years of age, was boiling a kettle
+                            on a gas stove on the 5th inst. when the flame caught her clothes. The
+                            flimsy material immediately flared up and the unfortunate woman received
+                            terrible burns from which she died very shortly after.</p>
                     </div>
                     <div type="article">
                         <head>Alhambra Theatre</head>
-                        <p>The Della Guardia Dramatic company will stage Maison de Poupée at this evening's performance and a matinée will bo given to-morrow, commenting at 4 p.m., for which l Fourchambault is billed. To-morrow evening there will no performance, it being the eve of tbe Jewish Day of Atonement.</p>
+                        <p>The Della Guardia Dramatic company will stage Maison de Poupée at this
+                            evening's performance and a matinée will bo given to-morrow, commenting
+                            at 4 p.m., for which l Fourchambault is billed. To-morrow evening there
+                            will no performance, it being the eve of tbe Jewish Day of
+                            Atonement.</p>
                     </div>
                     <div type="article">
                         <head>Affray at Menshieh</head>
-                        <p>A quarrel took place yesterday at Menshieh between Alexandre Khalikopolo a Greek carpenter aged 30, and Said Imam, a native cabdriver aged 20, in which the former stabbed the latter with a knife the right hand. The man's hand was badly wounded and he was taken to the hospital, where he will be detained until recovered.</p>
+                        <p>A quarrel took place yesterday at Menshieh between Alexandre Khalikopolo
+                            a Greek carpenter aged 30, and Said Imam, a native cabdriver aged 20, in
+                            which the former stabbed the latter with a knife the right hand. The
+                            man's hand was badly wounded and he was taken to the hospital, where he
+                            will be detained until recovered.</p>
                     </div>
                     <div type="article">
                         <head>San Stefano Casino</head>
-                        <p>The demonstration of telepathy, thought-reading, and autosuggestion by Professor Bellini will take the place of the usual small dance at the San Stefano Casino this evening. Subscribers will be admitted free, non-subsribers will be charged P.T. 10. The Bracale orchestra will play as usual tomorrow at 10.30 a.m. and 5 p.m.</p>
+                        <p>The demonstration of telepathy, thought-reading, and autosuggestion by
+                            Professor Bellini will take the place of the usual small dance at the
+                            San Stefano Casino this evening. Subscribers will be admitted free,
+                            non-subsribers will be charged P.T. 10. The Bracale orchestra will play
+                            as usual tomorrow at 10.30 a.m. and 5 p.m.</p>
                     </div>
                     <div type="article">
                         <head>A Painful Death</head>
-                        <p>A <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> contemporary announces that a cow in Sullivan County, U.S.A., has just joined the majority in painful circumstances. Wandering into a kitchen, the peckish cudster found an old umbrella and several cakes of yeast, all of which it proceeded to swallow. The subsequent fermenting of the yeast opened the umbrella, and the beast died in great agony.</p>
+                        <p>A <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName>
+                            contemporary announces that a cow in Sullivan County, U.S.A., has just
+                            joined the majority in painful circumstances. Wandering into a kitchen,
+                            the peckish cudster found an old umbrella and several cakes of yeast,
+                            all of which it proceeded to swallow. The subsequent fermenting of the
+                            yeast opened the umbrella, and the beast died in great agony.</p>
                     </div>
                     <div type="article">
                         <head>Rumoured Hotel Amalgamation</head>
-                        <p>A rumour is current that on the return of Mr. Nungovich Bey a proposal will be submitted the shareholders of the Nungovich Hotels Co., and the Upper <placeName ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName> Hotels, for the amalgamation of the two companies under one directorate. It is reported on the <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>  bonne that the recent appreciation in the shares of there companies is due to this reason.</p>
+                        <p>A rumour is current that on the return of Mr. Nungovich Bey a proposal
+                            will be submitted the shareholders of the Nungovich Hotels Co., and the
+                            Upper <placeName ref="https://www.wikidata.org/wiki/Q79"
+                                >Egypt</placeName> Hotels, for the amalgamation of the two companies
+                            under one directorate. It is reported on the <placeName
+                                ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> bonne that
+                            the recent appreciation in the shares of there companies is due to this
+                            reason.</p>
                     </div>
                     <div type="article">
                         <head>The Selection of a Grand Mufti</head>
-                        <p>We learn that the Council of Ministers at their meeting on Monday will select two sheikhs, shore names will be submitted to H. H. the Khedive fur the post of Grand Mufti of Egypt. There is much speculation as to who will be appointed to that important position in the Mohamedan world, but, our native readers have not to wait much longer now know whether their own choice has been selected.</p>
+                        <p>We learn that the Council of Ministers at their meeting on Monday will
+                            select two sheikhs, shore names will be submitted to H. H. the Khedive
+                            fur the post of Grand Mufti of Egypt. There is much speculation as to
+                            who will be appointed to that important position in the Mohamedan world,
+                            but, our native readers have not to wait much longer now know whether
+                            their own choice has been selected.</p>
                     </div>
                     <div type="article">
                         <head>British Chamber of Commerce</head>
-                        <p>We would draw the attention of manufacturers and merchants to the work of the British Chamber of Commerce of Egypt, which was formed in 1896 with the sole object of assisting British trade in this country. The services of the Chamber are always at the disposal of any member desiring information on trade matters generally, including the question of appointing suitable agents. As no fee is charged for snob advice, it is obviously in the interests of all British traders here to become members, especially when it is remembered that the annual subscription is merely the nominal one of £1. The latter payment also includes a copy of the monthly Journal issued by the Chamber. Home enquirers can obtain farther particulars from our <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> office, 86, New Broad-street, which acts as agents to the Chamber.</p>
+                        <p>We would draw the attention of manufacturers and merchants to the work of
+                            the British Chamber of Commerce of Egypt, which was formed in 1896 with
+                            the sole object of assisting British trade in this country. The services
+                            of the Chamber are always at the disposal of any member desiring
+                            information on trade matters generally, including the question of
+                            appointing suitable agents. As no fee is charged for snob advice, it is
+                            obviously in the interests of all British traders here to become
+                            members, especially when it is remembered that the annual subscription
+                            is merely the nominal one of £1. The latter payment also includes a copy
+                            of the monthly Journal issued by the Chamber. Home enquirers can obtain
+                            farther particulars from our <placeName
+                                ref="https://www.wikidata.org/wiki/Q84">London</placeName> office,
+                            86, New Broad-street, which acts as agents to the Chamber.</p>
                     </div>
                     <div type="article">
-                        <head>THE <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>  “ZOO.”</head>
+                        <head>THE <placeName ref="https://www.wikidata.org/wiki/Q85"
+                                >Cairo</placeName> “ZOO.”</head>
                         <head>REPORT FOR 1904.</head>
-                        <p>The sixth annual report by the director of the Ghizeh Zoological Gardens affords most interesting reading. It seems to be complete in every detail, even to the noting that "one Egyptian pound (L.E. 1) equals ₤l.0s.61/4d. or 25 francs and 92 centimes.” We may be sure that after the precision shown in this matter we may rely upon the other statements in the report being equally exact</p>
-                        <p>Passing over the details as to the staff, which seems to he selected with a view to complete efficiency, not only as regard the animals, but also for the upkeep of the ornamental grounds, we notice that the number of visitors shows a steady increase year after year. There was a slight falling off in 1902 in consequence, no doubt, of the bad season that year, but with this exception the increase has been steady, and whereas in 1899 the number of visitors was 43,567, in 1904 it reached 64,711, the gate receipts amounting to LE. 1,388.150. December, February,and March wore the months that brought in</p>
-                        <p>most visitors and gate money, June and August being those in which the gardens were least frequented. The accounts for the year showed a useful credit balance of L.E. 189.848, an increase of L.E. 80.288 on the previous year's figures, although rather considerable new building, joining and repairing work had to be undertaken. The result shows clearly enoug that the present director's abilities are not by any means confined to administration and natural history.</p>
-                        <p>Deaths among the animals, birds and reptiles—not including in the casualty list the results of the raids of foxes, wild cats, etc. or purely accidental fatalities—totalled 267 against 235 in the previous year; the winter mouths November and December, which were marked by outbreaks of influenza and dengue among human beings at <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> , being exceptionally severe. There were some important departures and deaths to chronicle, Lord Kitchener’s giraffe dying, and the two Indian elephants being sent off to Europe; while the champauzee presented by the Sirdar, which has since unfortunately died, the pair of zebras, the sacred shrew and sacred ibis, and the giraffe and other animals from the Sudan all deserve mention among the numerous new arrivals. The note on the aquarium is most interesting, containing, as it does, evidence of close personal observation of the various species of Nile fish kept in captivity there, and Dr. Franz Werner of the University of Vienna has sent a list of the grasshoppers and kindred insects to be found in the Gardens which, should interest entomologists.</p>
+                        <p>The sixth annual report by the director of the Ghizeh Zoological Gardens
+                            affords most interesting reading. It seems to be complete in every
+                            detail, even to the noting that "one Egyptian pound (L.E. 1) equals
+                            ₤l.0s.61/4d. or 25 francs and 92 centimes.” We may be sure that after
+                            the precision shown in this matter we may rely upon the other statements
+                            in the report being equally exact</p>
+                        <p>Passing over the details as to the staff, which seems to he selected with
+                            a view to complete efficiency, not only as regard the animals, but also
+                            for the upkeep of the ornamental grounds, we notice that the number of
+                            visitors shows a steady increase year after year. There was a slight
+                            falling off in 1902 in consequence, no doubt, of the bad season that
+                            year, but with this exception the increase has been steady, and whereas
+                            in 1899 the number of visitors was 43,567, in 1904 it reached 64,711,
+                            the gate receipts amounting to LE. 1,388.150. December, February,and
+                            March wore the months that brought in</p>
+                        <p>most visitors and gate money, June and August being those in which the
+                            gardens were least frequented. The accounts for the year showed a useful
+                            credit balance of L.E. 189.848, an increase of L.E. 80.288 on the
+                            previous year's figures, although rather considerable new building,
+                            joining and repairing work had to be undertaken. The result shows
+                            clearly enoug that the present director's abilities are not by any means
+                            confined to administration and natural history.</p>
+                        <p>Deaths among the animals, birds and reptiles—not including in the
+                            casualty list the results of the raids of foxes, wild cats, etc. or
+                            purely accidental fatalities—totalled 267 against 235 in the previous
+                            year; the winter mouths November and December, which were marked by
+                            outbreaks of influenza and dengue among human beings at <placeName
+                                ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> , being
+                            exceptionally severe. There were some important departures and deaths to
+                            chronicle, Lord Kitchener’s giraffe dying, and the two Indian elephants
+                            being sent off to Europe; while the champauzee presented by the Sirdar,
+                            which has since unfortunately died, the pair of zebras, the sacred shrew
+                            and sacred ibis, and the giraffe and other animals from the Sudan all
+                            deserve mention among the numerous new arrivals. The note on the
+                            aquarium is most interesting, containing, as it does, evidence of close
+                            personal observation of the various species of Nile fish kept in
+                            captivity there, and Dr. Franz Werner of the University of Vienna has
+                            sent a list of the grasshoppers and kindred insects to be found in the
+                            Gardens which, should interest entomologists.</p>
                     </div>
                     <div type="article">
                         <head>THE KHEDIVE.</head>
-                        <p>H.H. the Khedive has graciously consented to open the Mansourah Agricultural show on Friday, the 20th inst., and daring his stay will be the guest of the Municipality.</p>
+                        <p>H.H. the Khedive has graciously consented to open the Mansourah
+                            Agricultural show on Friday, the 20th inst., and daring his stay will be
+                            the guest of the Municipality.</p>
                     </div>
                     <div type="article">
                         <head>FRANCE AND GERMANY.</head>
                         <head>RECEPTION OF BUELOW'S STATEMENTS</head>
-                        <byline>(From our <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName> Correspondent).</byline>
+                        <byline>(From our <placeName ref="https://www.wikidata.org/wiki/Q84"
+                                >London</placeName> Correspondent).</byline>
                         <byline>(By Telegraph).</byline>
-                        <dateline><placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName>, <date value="1905-10-06">Friday</date>.</dateline>
-                        <p>The <placeName ref="https://www.wikidata.org/wiki/Q90">Paris</placeName> Press shows a bitter unanimity in its reception of the proposals of Prince von Buelow as to a Franco-German alliance. Even a rapprochement between France and Germany would, it is declared, be highly distasteful to the French people, which has not forgotten the loss of Alsace and Lorraine. Any attempt to reduce France to the position of a submissive ally of the German Empire is certainly doomed to failure, whether brute force or diplomatic persuasion be employed. Prince. von Buelow's suggestions, in whatever spirit they may have been concived, are roundly declared to be as tactless as they are provocative. "They add insult to injury.” — Such is the opinion of the general French public.</p>
+                        <dateline><placeName ref="https://www.wikidata.org/wiki/Q84"
+                                >London</placeName>, <date value="1905-10-06"
+                            >Friday</date>.</dateline>
+                        <p>The <placeName ref="https://www.wikidata.org/wiki/Q90">Paris</placeName>
+                            Press shows a bitter unanimity in its reception of the proposals of
+                            Prince von Buelow as to a Franco-German alliance. Even a rapprochement
+                            between France and Germany would, it is declared, be highly distasteful
+                            to the French people, which has not forgotten the loss of Alsace and
+                            Lorraine. Any attempt to reduce France to the position of a submissive
+                            ally of the German Empire is certainly doomed to failure, whether brute
+                            force or diplomatic persuasion be employed. Prince. von Buelow's
+                            suggestions, in whatever spirit they may have been concived, are roundly
+                            declared to be as tactless as they are provocative. "They add insult to
+                            injury.” — Such is the opinion of the general French public.</p>
                     </div>
                     <div type="article">
                         <head>THE SUCRERIES.</head>
-                        <p>Sir William Willcocks leaves to-day for Upper Egypt, where he will visit the Sucreries Company's factories and will be followed later by MM. Fourneron and Sampaulo, whose report will be given to the public on the 18th inst. On their return from Upper <placeName ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName> they will draw up a report in combination with Sir William Willcocks, which will state the exact condition and value of the factories.</p>
+                        <p>Sir William Willcocks leaves to-day for Upper Egypt, where he will visit
+                            the Sucreries Company's factories and will be followed later by MM.
+                            Fourneron and Sampaulo, whose report will be given to the public on the
+                            18th inst. On their return from Upper <placeName
+                                ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName> they will
+                            draw up a report in combination with Sir William Willcocks, which will
+                            state the exact condition and value of the factories.</p>
                     </div>
                     <div type="article">
                         <head>CREDIT FONCIER EGYPTIEN.</head>
-                        <p>Nothing is known at the offices of the Credit Foncier in <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName>  regarding the rumor published by some of the local papers of the retirement of Mr. Beyerle, the managing director. On the contrary in the last letters received from this gentleman, who is now in <placeName ref="https://www.wikidata.org/wiki/Q90">Paris</placeName>, he mentions his intention of returning at the end of this month to resume his post.</p>
-                        <p>We may add that on the death of his wife a few months back Mr. Beyerle wished to resign but was requested to reconsider his decision, at d, on the solicitaiton of his colleagues on the board, be decided to retan his appointment.</p>
+                        <p>Nothing is known at the offices of the Credit Foncier in <placeName
+                                ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> regarding
+                            the rumor published by some of the local papers of the retirement of Mr.
+                            Beyerle, the managing director. On the contrary in the last letters
+                            received from this gentleman, who is now in <placeName
+                                ref="https://www.wikidata.org/wiki/Q90">Paris</placeName>, he
+                            mentions his intention of returning at the end of this month to resume
+                            his post.</p>
+                        <p>We may add that on the death of his wife a few months back Mr. Beyerle
+                            wished to resign but was requested to reconsider his decision, at d, on
+                            the solicitaiton of his colleagues on the board, be decided to retan his
+                            appointment.</p>
                     </div>
                     <div type="article">
                         <head>KHEDIVIAL YACHT CLUB.</head>
-                        <p>There will be an extra regatta held on Friday in honor of the visit of H. H. the Khedive to the yacht club. The weekly regatta will be held on Wednesday as usual.</p>
+                        <p>There will be an extra regatta held on Friday in honor of the visit of H.
+                            H. the Khedive to the yacht club. The weekly regatta will be held on
+                            Wednesday as usual.</p>
                     </div>
                     <div type="article">
                         <head>STEAMER MOVEMENTS.</head>
-                        <p>The Moss liner Rameses sailed from. <placeName ref="https://www.wikidata.org/wiki/Q233">Malta</placeName> yesterday afternoon and is due at <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> on Tuesday with passengers, mails, and general cargo.</p>
+                        <p>The Moss liner Rameses sailed from. <placeName
+                                ref="https://www.wikidata.org/wiki/Q233">Malta</placeName> yesterday
+                            afternoon and is due at <placeName
+                                ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName> on
+                            Tuesday with passengers, mails, and general cargo.</p>
                     </div>
                 </div>
                 <div type="section">
-                    <head>NOTES FROM <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>.</head>
+                    <head>NOTES FROM <placeName ref="https://www.wikidata.org/wiki/Q134514"
+                            >Suez</placeName>.</head>
                     <div type="article">
                         <head>SHIPS ENTER THE CANAL.</head>
                         <byline>(From our Correspondent).</byline>
-                        <dateline><placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>, <date value="1905-10-06">Friday</date>.</dateline>
-                        <p>Till this morning at 8 o’clock, 42 vessels were anchored in the <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName> roads, and the first steamer to enter the Canal was the S.S. Clan Ogilvy, which proceeded at 10 am., and was subsequently followed by 10 more vessels. Some of the remaining steamers will enter tomorrow morning, and the next divisions on Sunday and Monday. The S.S. Durham Castle will enter the canal with the fourth division of steamers, and some of the members of the British Association have returned to <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName> from <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> .</p>
+                        <dateline><placeName ref="https://www.wikidata.org/wiki/Q134514"
+                                >Suez</placeName>, <date value="1905-10-06"
+                            >Friday</date>.</dateline>
+                        <p>Till this morning at 8 o’clock, 42 vessels were anchored in the
+                                <placeName ref="https://www.wikidata.org/wiki/Q134514"
+                                >Suez</placeName> roads, and the first steamer to enter the Canal
+                            was the S.S. Clan Ogilvy, which proceeded at 10 am., and was
+                            subsequently followed by 10 more vessels. Some of the remaining steamers
+                            will enter tomorrow morning, and the next divisions on Sunday and
+                            Monday. The S.S. Durham Castle will enter the canal with the fourth
+                            division of steamers, and some of the members of the British Association
+                            have returned to <placeName ref="https://www.wikidata.org/wiki/Q134514"
+                                >Suez</placeName> from <placeName
+                                ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> .</p>
                     </div>
                     <div type="article">
                         <head>THE S.S. NUBIA.</head>
-                        <p>The Anchor liner Nubia, which is ashore at Ras Shouhair in the <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName> Gulf, is expected to to be refloated shortly. The Khedivial mail liners Fayoum and Calioubieh are taking in cargo from the stranded vessel, and up to now over 1,200 tons have been discharged. The coustguard cruiser Noor el Bahr is standing by the Nubia guarding the coast for fear of the Bedouins pillaging the cargo.</p>
+                        <p>The Anchor liner Nubia, which is ashore at Ras Shouhair in the <placeName
+                                ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName> Gulf,
+                            is expected to to be refloated shortly. The Khedivial mail liners Fayoum
+                            and Calioubieh are taking in cargo from the stranded vessel, and up to
+                            now over 1,200 tons have been discharged. The coustguard cruiser Noor el
+                            Bahr is standing by the Nubia guarding the coast for fear of the
+                            Bedouins pillaging the cargo.</p>
                     </div>
                     <div type="article">
                         <head>THE BRITISH ASSOCIATION.</head>
                         <byline>(From Another Correspondent.)</byline>
                         <dateline>Port Tewfik, <date value="1905-10-05">Thursday</date>.</dateline>
-                        <p>As I telegraphed yon yesterday the Durham Castle, one of the famous Castle liners, arrived here with the members of the British Association on board, in all about 200 persons. Many of the members ware visiting <placeName ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName> for the first time and were very eager to have a few days stay but several of the Professors have to be home by the 18th inst. as they have engagements to fulfil at Oxford and Cambridge, the term commencing soon, and should the canal remain blocked they intend going via <placeName ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName> by the M.M. mail boat from <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>.</p>
+                        <p>As I telegraphed yon yesterday the Durham Castle, one of the famous
+                            Castle liners, arrived here with the members of the British Association
+                            on board, in all about 200 persons. Many of the members ware visiting
+                                <placeName ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName>
+                            for the first time and were very eager to have a few days stay but
+                            several of the Professors have to be home by the 18th inst. as they have
+                            engagements to fulfil at Oxford and Cambridge, the term commencing soon,
+                            and should the canal remain blocked they intend going via <placeName
+                                ref="https://www.wikidata.org/wiki/Q579613">Marseilles</placeName>
+                            by the M.M. mail boat from <placeName
+                                ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>.</p>
                     </div>
                     <div type="article">
-                        <head>THE BLOCK AT <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>.</head>
-                        <p>The block in the canal traffic is beginning to show at this end. There are now over 40 large steamers in the hay including several liners, notably the P. &amp; 0., Carman mail, Dutch mail, Spanish mail from Manilla, Bibby liner, three Clan liners, Durham Castle and many other regular traders, but there is still plenty of room, as the magnificent bay could easily accomodate 200 or upward. Strangers arriving at night generally anchor far off as they are unable to find their way to a good anchorage before daylight The bay has a very fine appearance at night when all the ships are lit up and many residents take a trip round the ships in a steam launch in the cool of the</p>
-                        <p>Officizl notice was given yesterday that traffic was to be resumed but was cancelled late in the evening, and it is now rumoured that no movement will take place here till Sunday as the ships in <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> will come through first so as avoid too much crossing in the canal and consequent danger of colliding.</p>
+                        <head>THE BLOCK AT <placeName ref="https://www.wikidata.org/wiki/Q134514"
+                                >Suez</placeName>.</head>
+                        <p>The block in the canal traffic is beginning to show at this end. There
+                            are now over 40 large steamers in the hay including several liners,
+                            notably the P. &amp; 0., Carman mail, Dutch mail, Spanish mail from
+                            Manilla, Bibby liner, three Clan liners, Durham Castle and many other
+                            regular traders, but there is still plenty of room, as the magnificent
+                            bay could easily accomodate 200 or upward. Strangers arriving at night
+                            generally anchor far off as they are unable to find their way to a good
+                            anchorage before daylight The bay has a very fine appearance at night
+                            when all the ships are lit up and many residents take a trip round the
+                            ships in a steam launch in the cool of the</p>
+                        <p>Officizl notice was given yesterday that traffic was to be resumed but
+                            was cancelled late in the evening, and it is now rumoured that no
+                            movement will take place here till Sunday as the ships in <placeName
+                                ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>
+                            will come through first so as avoid too much crossing in the canal and
+                            consequent danger of colliding.</p>
                     </div>
                     <div type="article">
                         <head>HARBOUR NOTES</head>
                         <byline>( From our Correspondent. )</byline>
-                        <dateline><placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>, <date value="1905-10-05">Thursday</date>.</dateline>
-                        <p>In continuation of my notes sent yon yesterday, I have thought it might be interesting to your readers to see a list of the numerous vessels which are at present lying at <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> and <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName> awaiting more or less impatiently the restarting of traffic, which I hear now (2 p.m.) may occur on Sunday :—</p>
-                        <q>Arrived at <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>, 27th ult Ping Suey; 28th ult Rugia, Menelaus, Avooa, Mahratta, Merton Hall; 29th ult. Staads Kratke, Persia (Anchor), Weissenfels, Langdale; 80th ult Statesman, Oxus; 1st inst Ataka, Buda, Sicilia (transport), Dunolly; 2nd inst Yana, Siam, Palermo, Sachsen, Arabistan ; 3rd inst Goentor, Flores, Africa, Nubia, Persia; 4th inst Wartenfels, Arracan, Hector, City of Athens, Nippoon, City of Madras; 5th inst Bohemia, Atholl, Engineer Civdakoff; Omrah, Assouan: Arrived at <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName> Roads 27th ult City of Manchester, Clan Campbell, Oriel, Orselo, Irrawaddi; 28th alt Clan Ogilvie, Aberlour, Forestdale, Langoe ; 29th ult Coquet, Clan Mackinnon, Isla de Panay ; 80th ult Trentham Hall, Ras Elba, Acacia, Tebe, Vindobona, Malaoca, Alladin, Fulwell; 1st inst. Emile; 2nd inst. Matiana, Adm. L. Treville, Victoria, Britannia, Rocklight; 3rd inst. Umbilo, Warwickshire, Turkistan, Korena ; 4th inst City of Karachi, Durham Castle, City of Benares, Kanzler, Kybfels, Yeddo; 5th inst Prinz Hendrik, Sumatra, Ixion, Avals. That is to say, that exclusive of the nine colliers discharging here now, and the</q>
+                        <dateline><placeName ref="https://www.wikidata.org/wiki/Q134509">Port
+                                Said</placeName>, <date value="1905-10-05"
+                            >Thursday</date>.</dateline>
+                        <p>In continuation of my notes sent yon yesterday, I have thought it might
+                            be interesting to your readers to see a list of the numerous vessels
+                            which are at present lying at <placeName
+                                ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>
+                            and <placeName ref="https://www.wikidata.org/wiki/Q134514"
+                                >Suez</placeName> awaiting more or less impatiently the restarting
+                            of traffic, which I hear now (2 p.m.) may occur on Sunday :—</p>
+                        <q>Arrived at <placeName ref="https://www.wikidata.org/wiki/Q134509">Port
+                                Said</placeName>, 27th ult Ping Suey; 28th ult Rugia, Menelaus,
+                            Avooa, Mahratta, Merton Hall; 29th ult. Staads Kratke, Persia (Anchor),
+                            Weissenfels, Langdale; 80th ult Statesman, Oxus; 1st inst Ataka, Buda,
+                            Sicilia (transport), Dunolly; 2nd inst Yana, Siam, Palermo, Sachsen,
+                            Arabistan ; 3rd inst Goentor, Flores, Africa, Nubia, Persia; 4th inst
+                            Wartenfels, Arracan, Hector, City of Athens, Nippoon, City of Madras;
+                            5th inst Bohemia, Atholl, Engineer Civdakoff; Omrah, Assouan: Arrived at
+                                <placeName ref="https://www.wikidata.org/wiki/Q134514"
+                                >Suez</placeName> Roads 27th ult City of Manchester, Clan Campbell,
+                            Oriel, Orselo, Irrawaddi; 28th alt Clan Ogilvie, Aberlour, Forestdale,
+                            Langoe ; 29th ult Coquet, Clan Mackinnon, Isla de Panay ; 80th ult
+                            Trentham Hall, Ras Elba, Acacia, Tebe, Vindobona, Malaoca, Alladin,
+                            Fulwell; 1st inst. Emile; 2nd inst. Matiana, Adm. L. Treville, Victoria,
+                            Britannia, Rocklight; 3rd inst. Umbilo, Warwickshire, Turkistan, Korena
+                            ; 4th inst City of Karachi, Durham Castle, City of Benares, Kanzler,
+                            Kybfels, Yeddo; 5th inst Prinz Hendrik, Sumatra, Ixion, Avals. That is
+                            to say, that exclusive of the nine colliers discharging here now, and
+                            the</q>
                         <!-- TODO find the truncated part of this note -->
                     </div>
                     <div type="article">
                         <head>ENGLISH CHURCH IN KHARTOUM.</head>
-                        <p>The "Standard” has received the following letter from Sir Reginald Wingate Pasha appealing for funds for the construction an English Church at Khartoum :—</p>
+                        <p>The "Standard” has received the following letter from Sir Reginald
+                            Wingate Pasha appealing for funds for the construction an English Church
+                            at Khartoum :—</p>
                         <quotedLetter>
                             <opener>
                                 <salute>Sir,</salute>
                             </opener>
-                            <p>I should esteem it a great favour to be allowed to make an appeal to the readers of your valuable paper on behalf of an English Church in Khartoum. Designs and plans for the building are under the consideration of the Church Committee, and is hoped the work of construction will be commenced in the autumn of this year. The estimated cost is £7000, and towards this amount £3000 have already been raised, almost entirely by local subscriptions. The Government has provided an excellent site, close to the Gordon Statue, where the foundation stone of the chuchh was laid by Prinoess Henry of Battenberg on her visit last year.</p>
-                            <p>The Rev. L. Gwynne has been appointed Archdeacon of the Sudan by the Bishop in Jerusalem, and he is now organising our church work with a view to providing service for our rapidly increasing population, not only at Khartoum, but also in the outlying station, such as Suakin, Wady Haifa, and Shendi.</p>
-                            <p>The generosity of the British officials and residents in the Sudan will be taxed to the utmost to provide chaplains, and to build churches necessary for these far-scattered stations. Therefore, in order to rect a building at Kharatoum worthy of our Church and nation, we are forced to ask help from those at home.</p>
-                            <p>Other communions are making progress with their churches. The aged Patriarch of the Coptic Church in <placeName ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName> set a noble example by undertaking a prolonged and arduous journey up the Nile, daring which he collected some £1000 for the building of a chuch in Khartoum, the foundation stone of which he laid on his arrival, and now the edifice is approaching completion. The Roman Church has already a suffient sum for its proposed cathedral, whilst a very handsome mosque has been constructed at a cost of over £13,000.</p>
-                            <p>We, therefore, more earnestly ask for the generosity and sympathy of our people at home to enable us to complete the building of our church in Khartonm,</p>
-                            <p>Subscriptions will be recieved and acknowledged by A. Dyke Acland, Eq., 186 Strand, W.C. Cheques should be crossed Bank of Egypt, and made payable to the "Khartonm English Church Fund."</p>
+                            <p>I should esteem it a great favour to be allowed to make an appeal to
+                                the readers of your valuable paper on behalf of an English Church in
+                                Khartoum. Designs and plans for the building are under the
+                                consideration of the Church Committee, and is hoped the work of
+                                construction will be commenced in the autumn of this year. The
+                                estimated cost is £7000, and towards this amount £3000 have already
+                                been raised, almost entirely by local subscriptions. The Government
+                                has provided an excellent site, close to the Gordon Statue, where
+                                the foundation stone of the chuchh was laid by Prinoess Henry of
+                                Battenberg on her visit last year.</p>
+                            <p>The Rev. L. Gwynne has been appointed Archdeacon of the Sudan by the
+                                Bishop in Jerusalem, and he is now organising our church work with a
+                                view to providing service for our rapidly increasing population, not
+                                only at Khartoum, but also in the outlying station, such as Suakin,
+                                Wady Haifa, and Shendi.</p>
+                            <p>The generosity of the British officials and residents in the Sudan
+                                will be taxed to the utmost to provide chaplains, and to build
+                                churches necessary for these far-scattered stations. Therefore, in
+                                order to rect a building at Kharatoum worthy of our Church and
+                                nation, we are forced to ask help from those at home.</p>
+                            <p>Other communions are making progress with their churches. The aged
+                                Patriarch of the Coptic Church in <placeName
+                                    ref="https://www.wikidata.org/wiki/Q79">Egypt</placeName> set a
+                                noble example by undertaking a prolonged and arduous journey up the
+                                Nile, daring which he collected some £1000 for the building of a
+                                chuch in Khartoum, the foundation stone of which he laid on his
+                                arrival, and now the edifice is approaching completion. The Roman
+                                Church has already a suffient sum for its proposed cathedral, whilst
+                                a very handsome mosque has been constructed at a cost of over
+                                £13,000.</p>
+                            <p>We, therefore, more earnestly ask for the generosity and sympathy of
+                                our people at home to enable us to complete the building of our
+                                church in Khartonm,</p>
+                            <p>Subscriptions will be recieved and acknowledged by A. Dyke Acland,
+                                Eq., 186 Strand, W.C. Cheques should be crossed Bank of Egypt, and
+                                made payable to the "Khartonm English Church Fund."</p>
                             <closer>
                                 <salute>I am, Sir, your obedient servant</salute>
                                 <signed>(Signed) REGINALD WINGATE</signed>
@@ -1875,27 +2592,79 @@
                     </div>
                 </div>
                 <div type="section">
-                    <head>NOTES FROM <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>.</head>
+                    <head>NOTES FROM <placeName ref="https://www.wikidata.org/wiki/Q134509">Port
+                            Said</placeName>.</head>
                     <div type="article">
-                        <p>Less regularly, we have now 37 steamers in the harbour of <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> and 40 at anchor in <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName> Roads.</p>
-                        <p>Roughly speaking there are 1,700 passengers delayed either here or at <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>, and at tie lowest computation some 231,000 tons of cargo and one of the large British <placeName ref="https://www.wikidata.org/wiki/Q668">India</placeName> turret ships having 12,500 tons of cargo on board, is expected to-day. A fair estimate of probable arrivals between now and Sunday will be five ships at each end per day, say at least 25 mail vessels by Sunday morning, which will bring up the number of waiting ships to about a hundred and five. In <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> harbour practically every possible good berth is occupied and in many oases, on the main buoys, there are two ships lying. The Dutch Basin which so far has been used solely for men-of-war has five ships in it The berth "No. 6 Black" has five ships at anchor where one usually lies. The Yam and Oxus lie side by side, as do also the Melenaus and hector; in fact, ships are everywhere, and I think I may safely say, never before has <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> seen such a sight</p>
+                        <p>Less regularly, we have now 37 steamers in the harbour of <placeName
+                                ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>
+                            and 40 at anchor in <placeName
+                                ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>
+                            Roads.</p>
+                        <p>Roughly speaking there are 1,700 passengers delayed either here or at
+                                <placeName ref="https://www.wikidata.org/wiki/Q134514"
+                                >Suez</placeName>, and at tie lowest computation some 231,000 tons
+                            of cargo and one of the large British <placeName
+                                ref="https://www.wikidata.org/wiki/Q668">India</placeName> turret
+                            ships having 12,500 tons of cargo on board, is expected to-day. A fair
+                            estimate of probable arrivals between now and Sunday will be five ships
+                            at each end per day, say at least 25 mail vessels by Sunday morning,
+                            which will bring up the number of waiting ships to about a hundred and
+                            five. In <placeName ref="https://www.wikidata.org/wiki/Q134509">Port
+                                Said</placeName> harbour practically every possible good berth is
+                            occupied and in many oases, on the main buoys, there are two ships
+                            lying. The Dutch Basin which so far has been used solely for men-of-war
+                            has five ships in it The berth "No. 6 Black" has five ships at anchor
+                            where one usually lies. The Yam and Oxus lie side by side, as do also
+                            the Melenaus and hector; in fact, ships are everywhere, and I think I
+                            may safely say, never before has <placeName
+                                ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>
+                            seen such a sight</p>
                     </div>
                     <div type="article">
                         <head>CANAL TRAFFIC RESUMED.</head>
                         <byline>(By Telegraph)</byline>
-                        <p><placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>, Saturday, 6.16 a.m. The mail steamers Tourane, Nippon, Omrah, Wartenfele, Africa, Goentor, Oxus, Sachsen. Yarra, Staads-Kratka, and Persia will enter the canal at eight o'clock this morning, and will tie up north of Ras el Esh, and fifteen more will follow this afternoon. Eleven steamers have entered from <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName> and anchored at Ismailia, and fourteen more will go as far the Bitter Lakes to-day. Full traffic There are forty-six vessels here and the number at <placeName ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName>.</p>
+                        <p><placeName ref="https://www.wikidata.org/wiki/Q134509">Port
+                                Said</placeName>, Saturday, 6.16 a.m. The mail steamers Tourane,
+                            Nippon, Omrah, Wartenfele, Africa, Goentor, Oxus, Sachsen. Yarra,
+                            Staads-Kratka, and Persia will enter the canal at eight o'clock this
+                            morning, and will tie up north of Ras el Esh, and fifteen more will
+                            follow this afternoon. Eleven steamers have entered from <placeName
+                                ref="https://www.wikidata.org/wiki/Q134514">Suez</placeName> and
+                            anchored at Ismailia, and fourteen more will go as far the Bitter Lakes
+                            to-day. Full traffic There are forty-six vessels here and the number at
+                                <placeName ref="https://www.wikidata.org/wiki/Q134514"
+                                >Suez</placeName>.</p>
                     </div>
                     <div type="article">
-                        <head>AT KILOMETRE 18.4 Work goes on in the chiefs and everyone are more than hard at work, pieces of plate and frame are coutinually being found and recovered and several have been broken up by small mines under the supervision of the engineers’ staff assistants advised by Mr. Harris. Bands of Arabs busy collecting and transporting the smaller pieces in lighters to <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName> while the dredgers are cutting out the main channel in the wake of crane". M. Schmitt has been down to the spot examining the bank and channel, which, I believe, will have a temporary width of 30 yards and a depth of 27 feet</head>
+                        <head>AT KILOMETRE 18.4 Work goes on in the chiefs and everyone are more
+                            than hard at work, pieces of plate and frame are coutinually being found
+                            and recovered and several have been broken up by small mines under the
+                            supervision of the engineers’ staff assistants advised by Mr. Harris.
+                            Bands of Arabs busy collecting and transporting the smaller pieces in
+                            lighters to <placeName ref="https://www.wikidata.org/wiki/Q134509">Port
+                                Said</placeName> while the dredgers are cutting out the main channel
+                            in the wake of crane". M. Schmitt has been down to the spot examining
+                            the bank and channel, which, I believe, will have a temporary width of
+                            30 yards and a depth of 27 feet</head>
                     </div>
                     <div type="article">
                         <head>DEPARTURE OP M. COULLANT.</head>
-                        <p>M. Conllant, the Canal Company's chief agent at <placeName ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>, (who by the way succeeds M. Tillier as chef de service in the coming year) left last night for France in the M.M. Senegal. M- Coallant arrived hare by the Brindisi mail in company with Mr. Harris and bis two assistants in order to form the commission which eventually decided the fate of the unfortunate Chatham.</p>
+                        <p>M. Conllant, the Canal Company's chief agent at <placeName
+                                ref="https://www.wikidata.org/wiki/Q134509">Port Said</placeName>,
+                            (who by the way succeeds M. Tillier as chef de service in the coming
+                            year) left last night for France in the M.M. Senegal. M- Coallant
+                            arrived hare by the Brindisi mail in company with Mr. Harris and bis two
+                            assistants in order to form the commission which eventually decided the
+                            fate of the unfortunate Chatham.</p>
                     </div>
                 </div>
-                <div type="article"><!-- TODO Replace with ad boilerplate -->
+                <div type="article">
+                    <!-- TODO Replace with ad boilerplate -->
                     <head>BECK &amp; GO'S PILSENER BEER</head>
-                    <p><unclear>OMalaakla frum *r*nr R*M*itatl* fIra</unclear> In <placeName ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> , <placeName ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>, &amp; the Sudan. Otherwise apply too <unclear>. j ntwnn. r. wcauii</unclear></p>
+                    <p><unclear>OMalaakla frum *r*nr R*M*itatl* fIra</unclear> In <placeName
+                            ref="https://www.wikidata.org/wiki/Q85">Cairo</placeName> , <placeName
+                            ref="https://www.wikidata.org/wiki/Q87">Alexandria</placeName>, &amp;
+                        the Sudan. Otherwise apply too <unclear>. j ntwnn. r. wcauii</unclear></p>
                 </div>
                 <div type="article">
                     <head>Anglo American Nile Steamers &amp; hotel company.</head>
@@ -1905,32 +2674,87 @@
                 <div type="article">
                     <head>CURONIQUE FINANCIERE</head>
                     <dateline>Vendredi <date value="1905-10-06">6 Octobre</date>.</dateline>
-                    <p>Il y a Peru de choses à ajouter à ce que none avons dit dans notre dernière chronique concernant la pénurie de numéaire, l'élévation du taux d’escompte, les veraement à opérer t' es liquidations de fin du mois, sinou que l'effet déprimant de ces divers facteurs semble dev i subsister quelques jours encore sur notre marché.</p>
-                    <p>Durant la semaine qui vient de s'écouler la cots a subi une baisse presque générale, bien qu'une certaine animation n'ait cassé de prévaloir. Dés lundi las cours fléchissent et aprés un semblant de reprise mercredi la réaction ne fait que s'accentuer jusqu'à la clôture d'ajour-d'hui.</p>
-                    <p>Quant aux transactions, alias n'ont au de réelle importance qu'en National Bank, au Agricole et en Nungovich.</p>
-                    <p>Le Consiel d’Administration de la D ïra Sa nieh s'est réuni jeudi à la National Bank et a décidé le paiement à la date du 16 courant de £10 par action et de £78 par part de fondateur. Quelques jours aprés, le 30 courant, auront lieu les plaidoireries de l'affaire, des princes de la famille Khédiviale. Bn attendant le cours de la Dura perd 1/8 comme résumé de la semaine et clôture à 28.</p>
-                    <p>Le capital de £500.000 de 1’Anglo-Egyptian Land Allotment Co., (dont Sir W. Wilcocks est le président) a été plus que couvert. Un tiers des actions sera néanmoins offert en souscription publique afin d'obtenir la cotation officielle. Les promoteurs de l’affaire n'ayont pas touché da rénumération pécuniaire, il a été créé poor let dédommagsr, an certain, nombre de ports de fondateurs. Les actions auront droit à un dividende cumulatif de 4 % et le surplus des bénéfices sera divité entre les parts de fondateurs 30 pour cent et les actions 70 pour cent.</p>
-                    <p>Aux Sucreries la situation ne s’est pas améliorée: le cours a meme fléchi d'une façon sensible mais purs reprendre en clôture à 43. Le rapport des experts qui a paru le 4 courant n'est pas pour rassurer let actionnaires: on y voit, en effet, que les exercise éjaulés ce soldent tous par das pertes croisssantes variant de 2000 à 120000 Livres; ces pertes étaient combléas par an compte annuel d'arbitrages envoyé de <placeName ref="https://www.wikidata.org/wiki/Q90">Paris</placeName> par Crouier et dounant un bénéfice suffisant pour distribuer un dividende et laisser un reliquat.</p>
-                    <p>Le prolongement à bréva échéance du Nubarieh dont on a beaucoup parlé deraiérement vient d’etre officiallement démenti, Ce travail a été renvoyé à une date indéterminée et le Gouvernement a suspendu la vents de ses terrains dans la région intéressée attendant d'étre fixé sur ce point</p>
-                    <p>Une nouvelle banque va incessamment etre laucée ici sous le nom de Egyptian Bank of Commerce. Son capital est firé à £500000 et conseil d'administration figurent les noms de plusieurs grands financiers <placeName ref="https://www.wikidata.org/wiki/Q84">London</placeName>ians.</p>
+                    <p>Il y a Peru de choses à ajouter à ce que none avons dit dans notre dernière
+                        chronique concernant la pénurie de numéaire, l'élévation du taux d’escompte,
+                        les veraement à opérer t' es liquidations de fin du mois, sinou que l'effet
+                        déprimant de ces divers facteurs semble dev i subsister quelques jours
+                        encore sur notre marché.</p>
+                    <p>Durant la semaine qui vient de s'écouler la cots a subi une baisse presque
+                        générale, bien qu'une certaine animation n'ait cassé de prévaloir. Dés lundi
+                        las cours fléchissent et aprés un semblant de reprise mercredi la réaction
+                        ne fait que s'accentuer jusqu'à la clôture d'ajour-d'hui.</p>
+                    <p>Quant aux transactions, alias n'ont au de réelle importance qu'en National
+                        Bank, au Agricole et en Nungovich.</p>
+                    <p>Le Consiel d’Administration de la D ïra Sa nieh s'est réuni jeudi à la
+                        National Bank et a décidé le paiement à la date du 16 courant de £10 par
+                        action et de £78 par part de fondateur. Quelques jours aprés, le 30 courant,
+                        auront lieu les plaidoireries de l'affaire, des princes de la famille
+                        Khédiviale. Bn attendant le cours de la Dura perd 1/8 comme résumé de la
+                        semaine et clôture à 28.</p>
+                    <p>Le capital de £500.000 de 1’Anglo-Egyptian Land Allotment Co., (dont Sir W.
+                        Wilcocks est le président) a été plus que couvert. Un tiers des actions sera
+                        néanmoins offert en souscription publique afin d'obtenir la cotation
+                        officielle. Les promoteurs de l’affaire n'ayont pas touché da rénumération
+                        pécuniaire, il a été créé poor let dédommagsr, an certain, nombre de ports
+                        de fondateurs. Les actions auront droit à un dividende cumulatif de 4 % et
+                        le surplus des bénéfices sera divité entre les parts de fondateurs 30 pour
+                        cent et les actions 70 pour cent.</p>
+                    <p>Aux Sucreries la situation ne s’est pas améliorée: le cours a meme fléchi
+                        d'une façon sensible mais purs reprendre en clôture à 43. Le rapport des
+                        experts qui a paru le 4 courant n'est pas pour rassurer let actionnaires: on
+                        y voit, en effet, que les exercise éjaulés ce soldent tous par das pertes
+                        croisssantes variant de 2000 à 120000 Livres; ces pertes étaient combléas
+                        par an compte annuel d'arbitrages envoyé de <placeName
+                            ref="https://www.wikidata.org/wiki/Q90">Paris</placeName> par Crouier et
+                        dounant un bénéfice suffisant pour distribuer un dividende et laisser un
+                        reliquat.</p>
+                    <p>Le prolongement à bréva échéance du Nubarieh dont on a beaucoup parlé
+                        deraiérement vient d’etre officiallement démenti, Ce travail a été renvoyé à
+                        une date indéterminée et le Gouvernement a suspendu la vents de ses terrains
+                        dans la région intéressée attendant d'étre fixé sur ce point</p>
+                    <p>Une nouvelle banque va incessamment etre laucée ici sous le nom de Egyptian
+                        Bank of Commerce. Son capital est firé à £500000 et conseil d'administration
+                        figurent les noms de plusieurs grands financiers <placeName
+                            ref="https://www.wikidata.org/wiki/Q84">London</placeName>ians.</p>
                     <p>Asset mouvementés au début, les Estates</p>
-                    <p>terminent avec une reaction totals de 1/32 à 1 7/32 acheteurs. Cette valeur sera désormais inscrite au Stock Exchange de Londres,</p>
-                    <p>L’Agrioole qui a été en grande faveur durant toute la semaine finit à 9 5/8, en gain de 3/16 sur le cours de vendredi dernier.</p>
-                    <p>Toot aussi animée, quo que en snes contraire, 1a National Bank clôture à 27 3/16, en parts de 5/16.</p>
-                    <p>C'est la Nungovich qui a eu les honneurs de la semaine et le record de la bausse ces joursci; elle monte de 10 3/8 à 10 15/16. Le prix de 11 a meme été pratiqué pour le 15 courant.</p>
-                    <p>Ea hausse également les Tramways d'Alexandrie de 159 à 169 la Privilégiée et de 320 à 328 la Dividende, les Eaux du Caire de 1155 à 1160, la Béhéra de 42 1/2 à 43, la Land Bank de 9 3/4 à 9 7/8, les Markets de 23 à 25/ 3, et la Banque d'Athènes de 188 8/4 à 135.</p>
+                    <p>terminent avec une reaction totals de 1/32 à 1 7/32 acheteurs. Cette valeur
+                        sera désormais inscrite au Stock Exchange de Londres,</p>
+                    <p>L’Agrioole qui a été en grande faveur durant toute la semaine finit à 9 5/8,
+                        en gain de 3/16 sur le cours de vendredi dernier.</p>
+                    <p>Toot aussi animée, quo que en snes contraire, 1a National Bank clôture à 27
+                        3/16, en parts de 5/16.</p>
+                    <p>C'est la Nungovich qui a eu les honneurs de la semaine et le record de la
+                        bausse ces joursci; elle monte de 10 3/8 à 10 15/16. Le prix de 11 a meme
+                        été pratiqué pour le 15 courant.</p>
+                    <p>Ea hausse également les Tramways d'Alexandrie de 159 à 169 la Privilégiée et
+                        de 320 à 328 la Dividende, les Eaux du Caire de 1155 à 1160, la Béhéra de 42
+                        1/2 à 43, la Land Bank de 9 3/4 à 9 7/8, les Markets de 23 à 25/ 3, et la
+                        Banque d'Athènes de 188 8/4 à 135.</p>
                     <p>La Delta Light fléchit de 18 1/4 à 13 1/16, sans beaucoup d_ff ires.</p>
                     <p>Contraiment aux Tramways, la Ramleh Railway tombe de 7 5/16 à 7 1/8.</p>
-                    <p>La Crown Brewery accuse une baisse de 5 francs sur la Privilégiés à 202 et de 11 francs la Dividende à 1_0. Quant à la Brasserie des Pyramides, elle perd 1 frano sur la Dividende et gagne 50 centimes sur la Privilégiée au cours respectifs de 62 et 125.</p>
-                    <p>Les Cotton Mills fléchissant de 6 à 5/9 et la Salt &amp; Soda de 33/9 à 33/6.</p>
-                    <p>De 5 5/8 l'Anglo-American Nile recule à 5 9/16, la Delta Land de 2 9/16 à 2 1/2, le Treat de 1 5/16 à 1 9/32 et l'Urbaine de 5 1/2 à 5 3/8.</p>
+                    <p>La Crown Brewery accuse une baisse de 5 francs sur la Privilégiés à 202 et de
+                        11 francs la Dividende à 1_0. Quant à la Brasserie des Pyramides, elle perd
+                        1 frano sur la Dividende et gagne 50 centimes sur la Privilégiée au cours
+                        respectifs de 62 et 125.</p>
+                    <p>Les Cotton Mills fléchissant de 6 à 5/9 et la Salt &amp; Soda de 33/9 à
+                        33/6.</p>
+                    <p>De 5 5/8 l'Anglo-American Nile recule à 5 9/16, la Delta Land de 2 9/16 à 2
+                        1/2, le Treat de 1 5/16 à 1 9/32 et l'Urbaine de 5 1/2 à 5 3/8.</p>
                     <p>(Aujourd'hui à midi et demis)</p>
-                    <p>Comme d’ordinaire le samedi, notre marché a éte à peu prés nul ce matin, soit comme variations dans la cote, soit comme transactions. Cependant, on constate une inclinasion vers la baisse, ce qui est du en partie aux motifs déjà exposes dans notre chronique, en partie à 1a fermeture de la corbeille lundi prochain, à l'occasion du Grand Jeûne Israélite.</p>
-                    <p>La National Bank est offerte au prix de 27 3/16, tandis que l'Agricole est demandés à 9 11/16.</p>
-                    <p>De 2 9/16 la Delta Land fléchit à 2 1/2 acheteurs et Daïra Sanieh de 28 à 27 15/16 vendeurs. La Part de Fondateurs Daïra tombe également de 180 à 178.</p>
+                    <p>Comme d’ordinaire le samedi, notre marché a éte à peu prés nul ce matin, soit
+                        comme variations dans la cote, soit comme transactions. Cependant, on
+                        constate une inclinasion vers la baisse, ce qui est du en partie aux motifs
+                        déjà exposes dans notre chronique, en partie à 1a fermeture de la corbeille
+                        lundi prochain, à l'occasion du Grand Jeûne Israélite.</p>
+                    <p>La National Bank est offerte au prix de 27 3/16, tandis que l'Agricole est
+                        demandés à 9 11/16.</p>
+                    <p>De 2 9/16 la Delta Land fléchit à 2 1/2 acheteurs et Daïra Sanieh de 28 à 27
+                        15/16 vendeurs. La Part de Fondateurs Daïra tombe également de 180 à
+                        178.</p>
                     <p>Par conre, la Filature estun pen plus ferms</p>
                     <p>Les Estates se font remarquer par leur formeté</p>
-                    <p>Tandis que la Privilégiée Tramways d'Alexandrie est offerts à 162, la Dividende est demandée à 332, au hausse de 4 francs sur le cours d'hier.</p>
+                    <p>Tandis que la Privilégiée Tramways d'Alexandrie est offerts à 162, la
+                        Dividende est demandée à 332, au hausse de 4 francs sur le cours d'hier.</p>
                     <p><unclear/>gouverment a une reprise vere le<unclear/></p>
                 </div>
             </div>


### PR DESCRIPTION
Updates formatting so that all lines wrap at length 1000, makes
document much easier to manipulate structurally.

Fixes all errors identified in Oxygen so the documents comply
fully with the schema for the project, enabling editing using
Oxygen's author mode.